### PR TITLE
Fix parseScenario stripping the next scenario's tags (breaks tag filtering)

### DIFF
--- a/gherkin/src/main/scala/zio/bdd/gherkin/GherkinParser.scala
+++ b/gherkin/src/main/scala/zio/bdd/gherkin/GherkinParser.scala
@@ -376,6 +376,7 @@ object GherkinParser {
     def isEOF: Boolean                    = pos >= tokens.length
     def advance(): Unit                   = pos += 1
     def position: Int                     = pos
+    def reset(p: Int): Unit               = pos = p
 
     /** Skip empty lines and comments. */
     def skipBlanks(): Unit =
@@ -567,13 +568,18 @@ object GherkinParser {
         var cont     = true
         while (cont) {
           cursor.skipBlanks()
-          // Tags may appear before an Examples block
+          // Tags may appear before an Examples block. Tentatively consume them, but if no Examples block follows
+          // they belong to the NEXT scenario — restore the cursor so they aren't silently swallowed (which would
+          // strip that scenario's tags). See parseScenario tag-stripping regression.
+          val mark   = cursor.position
           val exTags = cursor.consume { case TagsLine(ts, _) => ts }.getOrElse(Nil)
           cursor.skipBlanks()
           cursor.peek match {
             case Some(ExamplesLine(_, _, _)) =>
               examples += parseExamplesBlock(cursor, exTags, file)
-            case _ => cont = false
+            case _ =>
+              cursor.reset(mark)
+              cont = false
           }
         }
         RawScenario(name, tags, steps, examples.result(), isOutline, lineNo)

--- a/gherkin/src/test/scala/zio/bdd/gherkin/TagRetentionSpec.scala
+++ b/gherkin/src/test/scala/zio/bdd/gherkin/TagRetentionSpec.scala
@@ -1,0 +1,43 @@
+package zio.bdd.gherkin
+
+import zio.test.*
+
+/** Regression: a scenario's own tag line must not be swallowed by the preceding scenario's Examples-collection loop.
+  * Before the fix, `parseScenario` greedily consumed the next scenario's tags while looking for an Examples block and
+  * discarded them when none followed, so every scenario lost its tags to its predecessor.
+  */
+object TagRetentionSpec extends ZIOSpecDefault:
+  private val feature =
+    """Feature: F
+      |  Background:
+      |    Given setup
+      |
+      |  @first-tag
+      |  Scenario: First
+      |    Given setup
+      |
+      |  # a comment line
+      |  # another comment
+      |  @second-tag @spec-1.2.3
+      |  Scenario: Second
+      |    Given setup
+      |
+      |  @outline-tag
+      |  Scenario Outline: Third
+      |    Given a <x> thing
+      |    @ex-tag
+      |    Examples:
+      |      | x   |
+      |      | foo |
+      |""".stripMargin
+
+  def spec = suite("TagRetentionSpec")(
+    test("each scenario keeps its own tags (incl. after comments and before Examples blocks)") {
+      for f <- GherkinParser.parseFeature(feature, "repro.feature")
+      yield assertTrue(
+        f.scenarios.find(_.name == "First").exists(_.tags.contains("first-tag")),
+        f.scenarios.find(_.name == "Second").exists(s => s.tags.contains("second-tag") && s.tags.contains("spec-1.2.3")),
+        f.scenarios.exists(s => s.name.startsWith("Third") && s.tags.contains("outline-tag") && s.tags.contains("ex-tag"))
+      )
+    }
+  )


### PR DESCRIPTION
## Problem

`includeTags`/`excludeTags` filtering silently did nothing for most scenarios. Root cause is in the parser, not the filter: `parseScenario`'s Examples-collection loop does `consume { case TagsLine }` to grab tags before an `Examples:` block, but when a scenario has no (more) Examples it consumes the **next scenario's** tag line, finds a `Scenario`/`Scenario Outline` keyword instead of `Examples`, and **discards** those tags.

Net effect: every scenario loses its own tags to its predecessor's parse, so `scenario.tags` is empty/partial and `filterFeatures` never marks them `ignore`.

## Repro (added as `TagRetentionSpec`)

```gherkin
@first-tag
Scenario: First            # -> tags: [first-tag]  (ok: preceded by Background)
  Given setup

@second-tag @spec-1.2.3
Scenario: Second           # -> tags: []           (BUG: eaten by First's Examples loop)
  Given setup

@outline-tag
Scenario Outline: Third    # -> tags: [ex-tag] only (BUG: @outline-tag lost)
  Given a <x> thing
  @ex-tag
  Examples:
    | x   |
    | foo |
```

## Fix

Mark the cursor before tentatively consuming Examples tags; if no `Examples:` block follows, `reset` the cursor so the tags flow back to the next scenario. Adds `TokenCursor.reset` and a regression test. All existing gherkin (85) and core (301) tests still pass.

Found while running the OpenFeature spec's gherkin conformance suite against zio-bdd — with this fix, `excludeTags` correctly skips tagged scenarios (110 passed / 9 ignored instead of 110 / 9 failed).