### PR TITLE
Inherit feature-level tags for scenario filtering (+ fix scenario-name glob)

### DIFF
--- a/core/src/main/scala/zio/bdd/ZIOBDDFramework.scala
+++ b/core/src/main/scala/zio/bdd/ZIOBDDFramework.scala
@@ -141,35 +141,8 @@ class ZIOBDDTask(
 
   override def taskDef(): TaskDef = taskDefinition
 
-  private def filterFeatures(features: List[Feature], config: BDDTestConfig): List[Feature] = {
-    val includeTags = config.includeTags
-    val excludeTags = config.excludeTags
-
-    def shouldIgnoreFeature(tags: List[String]): Boolean =
-      tags.exists(excludeTags.contains)
-
-    def shouldIgnoreScenario(tags: List[String], name: String): Boolean = {
-      val hasExcludeTag     = tags.exists(excludeTags.contains)
-      val missingIncludeTag = includeTags.nonEmpty && !tags.exists(includeTags.contains)
-      // Scenario-name filter: treat as glob where * = any sequence of chars
-      val nameFiltered = config.scenarioNameFilter.exists { pattern =>
-        val regex = ("(?i)" + java.util.regex.Pattern.quote(pattern).replace("\\*", ".*")).r
-        !regex.matches(name)
-      }
-      hasExcludeTag || missingIncludeTag || nameFiltered
-    }
-
-    features.map { feature =>
-      val featureTags = if (shouldIgnoreFeature(feature.tags)) feature.tags :+ "ignore" else feature.tags
-      val updatedScenarios = feature.scenarios.map { scenario =>
-        val scenarioTags =
-          if (shouldIgnoreScenario(scenario.tags, scenario.name)) scenario.tags :+ "ignore"
-          else scenario.tags
-        scenario.copy(tags = scenarioTags)
-      }
-      feature.copy(tags = featureTags, scenarios = updatedScenarios)
-    }
-  }
+  private[bdd] def filterFeatures(features: List[Feature], config: BDDTestConfig): List[Feature] =
+    ZIOBDDTask.filterFeatures(features, config)
 
   override def execute(eventHandler: EventHandler, loggers: Array[Logger]): Array[Task] = {
     val className = taskDef.fullyQualifiedName()
@@ -490,6 +463,53 @@ class ZIOBDDTask(
         }
         eventHandler.handle(event)
       }
+    }
+  }
+}
+
+object ZIOBDDTask {
+
+  /**
+   * Apply include/exclude tag filters and the scenario-name filter to a list of
+   * features.
+   *
+   * Per the Gherkin spec, feature-level tags are inherited by all of a
+   * feature's scenarios for the purpose of filtering: a feature tagged `@smoke`
+   * makes every scenario match `--include-tags smoke`, even when the scenario
+   * carries no tags of its own. Scenarios that do not survive the filter are
+   * marked `@ignore`; a feature whose scenarios are all ignored is itself
+   * marked `@ignore`.
+   */
+  def filterFeatures(features: List[Feature], config: BDDTestConfig): List[Feature] = {
+    val includeTags = config.includeTags
+    val excludeTags = config.excludeTags
+
+    def shouldIgnoreScenario(featureTags: List[String], scenarioTags: List[String], name: String): Boolean = {
+      // Feature tags are inherited by the scenario for filtering.
+      val effectiveTags     = (featureTags ++ scenarioTags).distinct
+      val hasExcludeTag     = effectiveTags.exists(excludeTags.contains)
+      val missingIncludeTag = includeTags.nonEmpty && !effectiveTags.exists(includeTags.contains)
+      // Scenario-name filter: glob where '*' = any sequence of chars, rest matched
+      // literally and case-insensitively. Split on '*' and quote each literal segment so
+      // regex metacharacters in the name (and the pattern) are not interpreted.
+      val nameFiltered = config.scenarioNameFilter.exists { pattern =>
+        val regex = ("(?i)" + pattern.split("\\*", -1).map(java.util.regex.Pattern.quote).mkString(".*")).r
+        !regex.matches(name)
+      }
+      hasExcludeTag || missingIncludeTag || nameFiltered
+    }
+
+    features.map { feature =>
+      val updatedScenarios = feature.scenarios.map { scenario =>
+        val scenarioTags =
+          if (shouldIgnoreScenario(feature.tags, scenario.tags, scenario.name)) scenario.tags :+ "ignore"
+          else scenario.tags
+        scenario.copy(tags = scenarioTags)
+      }
+      // Mark the feature itself as ignored when all of its scenarios are ignored.
+      val allScenariosIgnored = updatedScenarios.nonEmpty && updatedScenarios.forall(_.isIgnored)
+      val featureTags         = if (allScenariosIgnored) feature.tags :+ "ignore" else feature.tags
+      feature.copy(tags = featureTags, scenarios = updatedScenarios)
     }
   }
 }

--- a/core/src/test/scala/zio/bdd/TagFilteringSpec.scala
+++ b/core/src/test/scala/zio/bdd/TagFilteringSpec.scala
@@ -1,0 +1,205 @@
+package zio.bdd
+
+import zio.test.*
+import zio.test.Assertion.*
+import zio.bdd.gherkin.{Feature, Scenario, Step, StepType}
+
+/**
+ * Unit tests for ZIOBDDTask.filterFeatures tag filtering behaviour.
+ *
+ * Key invariants exercised:
+ *   - Scenario-level include/exclude tags work as before
+ *   - Feature-level tags are inherited by scenarios for filtering
+ *   - Exclude takes precedence over include
+ *   - When all scenarios in a feature are ignored the feature itself is ignored
+ *   - Empty include/exclude sets leave everything intact
+ *   - scenarioNameFilter is independent of tag inheritance
+ */
+object TagFilteringSpec extends ZIOSpecDefault {
+
+  private def mkScenario(name: String, tags: String*): Scenario =
+    Scenario(name, tags.toList, List(Step(StepType.GivenStep, "a step")), Some("test.feature"), Some(1))
+
+  private def mkFeature(name: String, featureTags: List[String], scenarios: Scenario*): Feature =
+    Feature(name, featureTags, scenarios.toList, Some("test.feature"), Some(1))
+
+  private def filter(config: BDDTestConfig)(features: Feature*): List[Feature] =
+    ZIOBDDTask.filterFeatures(features.toList, config)
+
+  private def withInclude(tags: String*): BDDTestConfig =
+    BDDTestConfig(includeTags = tags.toSet)
+
+  private def withExclude(tags: String*): BDDTestConfig =
+    BDDTestConfig(excludeTags = tags.toSet)
+
+  // ── No-op baseline ─────────────────────────────────────────────────────────
+
+  private val noopSuite = suite("no-op when no filters are set")(
+    test("scenarios without any tags pass through unchanged") {
+      val features = filter(BDDTestConfig())(
+        mkFeature("F", Nil, mkScenario("s1"), mkScenario("s2"))
+      )
+      assertTrue(features.head.scenarios.forall(!_.isIgnored))
+    },
+    test("scenarios with tags pass through when no filter is configured") {
+      val features = filter(BDDTestConfig())(
+        mkFeature("F", List("smoke"), mkScenario("s1", "smoke"), mkScenario("s2"))
+      )
+      assertTrue(features.head.scenarios.forall(!_.isIgnored))
+    }
+  )
+
+  // ── Include-tag filtering ──────────────────────────────────────────────────
+
+  private val includeSuite = suite("include-tag filtering")(
+    test("scenario with matching tag is kept") {
+      val features = filter(withInclude("smoke"))(
+        mkFeature("F", Nil, mkScenario("s1", "smoke"), mkScenario("s2"))
+      )
+      val results = features.head.scenarios
+      assertTrue(!results(0).isIgnored, results(1).isIgnored)
+    },
+    test("feature-level tag is inherited: scenario runs when feature carries the include tag") {
+      val features = filter(withInclude("smoke"))(
+        mkFeature("F", List("smoke"), mkScenario("s1"), mkScenario("s2"))
+      )
+      assertTrue(features.head.scenarios.forall(!_.isIgnored))
+    },
+    test("feature-level tag inheritance: scenario tag also satisfies include") {
+      val features = filter(withInclude("smoke"))(
+        mkFeature("F", List("billing"), mkScenario("tagged", "smoke"), mkScenario("untagged"))
+      )
+      val results = features.head.scenarios
+      assertTrue(!results(0).isIgnored, results(1).isIgnored)
+    },
+    test("scenario without any matching tag (scenario or feature) is ignored") {
+      val features = filter(withInclude("smoke"))(
+        mkFeature("F", List("billing"), mkScenario("s1"), mkScenario("s2", "regression"))
+      )
+      assertTrue(features.head.scenarios.forall(_.isIgnored))
+    },
+    test("when all scenarios are ignored the feature itself is marked ignored") {
+      val features = filter(withInclude("smoke"))(
+        mkFeature("F", Nil, mkScenario("s1"), mkScenario("s2"))
+      )
+      assertTrue(features.head.isIgnored)
+    },
+    test("feature is NOT marked ignored when at least one scenario survives") {
+      val features = filter(withInclude("smoke"))(
+        mkFeature("F", Nil, mkScenario("s1", "smoke"), mkScenario("s2"))
+      )
+      assertTrue(!features.head.isIgnored)
+    }
+  )
+
+  // ── Exclude-tag filtering ──────────────────────────────────────────────────
+
+  private val excludeSuite = suite("exclude-tag filtering")(
+    test("scenario with excluded tag is ignored") {
+      val features = filter(withExclude("slow"))(
+        mkFeature("F", Nil, mkScenario("fast"), mkScenario("slow-test", "slow"))
+      )
+      val results = features.head.scenarios
+      assertTrue(!results(0).isIgnored, results(1).isIgnored)
+    },
+    test("feature-level exclude tag ignores all scenarios") {
+      val features = filter(withExclude("slow"))(
+        mkFeature("F", List("slow"), mkScenario("s1"), mkScenario("s2"))
+      )
+      assertTrue(features.head.scenarios.forall(_.isIgnored))
+    },
+    test("feature-level exclude tag causes feature itself to be ignored") {
+      val features = filter(withExclude("slow"))(
+        mkFeature("F", List("slow"), mkScenario("s1"), mkScenario("s2"))
+      )
+      assertTrue(features.head.isIgnored)
+    },
+    test("scenario-level exclude tag ignores only that scenario") {
+      val features = filter(withExclude("slow"))(
+        mkFeature("F", Nil, mkScenario("fast"), mkScenario("slow-one", "slow"))
+      )
+      val results = features.head.scenarios
+      assertTrue(!results(0).isIgnored, results(1).isIgnored)
+    }
+  )
+
+  // ── Exclude takes precedence over include ──────────────────────────────────
+
+  private val precedenceSuite = suite("exclude takes precedence over include")(
+    test("excluded scenario is ignored even when it carries an include tag") {
+      val config = BDDTestConfig(includeTags = Set("smoke"), excludeTags = Set("slow"))
+      val features = filter(config)(
+        mkFeature("F", Nil, mkScenario("both", "smoke", "slow"))
+      )
+      assertTrue(features.head.scenarios.head.isIgnored)
+    },
+    test("feature-level exclude overrides feature-level include") {
+      val config = BDDTestConfig(includeTags = Set("smoke"), excludeTags = Set("slow"))
+      val features = filter(config)(
+        mkFeature("F", List("smoke", "slow"), mkScenario("s1"), mkScenario("s2"))
+      )
+      assertTrue(features.head.scenarios.forall(_.isIgnored))
+    }
+  )
+
+  // ── Scenario-name filter ───────────────────────────────────────────────────
+
+  private val nameSuite = suite("scenario-name filter")(
+    test("exact name match keeps scenario") {
+      val config = BDDTestConfig(scenarioNameFilter = Some("Login"))
+      val features = filter(config)(
+        mkFeature("F", Nil, mkScenario("Login"), mkScenario("Register"))
+      )
+      val results = features.head.scenarios
+      assertTrue(!results(0).isIgnored, results(1).isIgnored)
+    },
+    test("glob wildcard filter works case-insensitively") {
+      val config = BDDTestConfig(scenarioNameFilter = Some("Log*"))
+      val features = filter(config)(
+        mkFeature("F", Nil, mkScenario("Logout"), mkScenario("login flow"), mkScenario("Register"))
+      )
+      val results = features.head.scenarios
+      assertTrue(!results(0).isIgnored, !results(1).isIgnored, results(2).isIgnored)
+    },
+    test("name filter is independent of tag inheritance") {
+      val config = BDDTestConfig(includeTags = Set("smoke"), scenarioNameFilter = Some("Pay*"))
+      val features = filter(config)(
+        mkFeature("F", List("smoke"), mkScenario("Payment"), mkScenario("Refund"))
+      )
+      val results = features.head.scenarios
+      // "Payment" matches name and inherits smoke tag → not ignored
+      // "Refund" fails name filter → ignored even though it inherits smoke
+      assertTrue(!results(0).isIgnored, results(1).isIgnored)
+    }
+  )
+
+  // ── Multiple features ──────────────────────────────────────────────────────
+
+  private val multiFeatureSuite = suite("multiple features")(
+    test("each feature is filtered independently") {
+      val config = BDDTestConfig(includeTags = Set("smoke"))
+      val features = filter(config)(
+        mkFeature("F1", List("smoke"), mkScenario("s1")),
+        mkFeature("F2", Nil, mkScenario("s2"))
+      )
+      assertTrue(!features(0).scenarios.head.isIgnored, features(1).scenarios.head.isIgnored)
+    },
+    test("feature without matching scenarios is marked ignored, others are not") {
+      val config = BDDTestConfig(includeTags = Set("smoke"))
+      val features = filter(config)(
+        mkFeature("F1", List("smoke"), mkScenario("s1")),
+        mkFeature("F2", Nil, mkScenario("s2"))
+      )
+      assertTrue(!features(0).isIgnored, features(1).isIgnored)
+    }
+  )
+
+  def spec: Spec[Any, Nothing] = suite("TagFiltering")(
+    noopSuite,
+    includeSuite,
+    excludeSuite,
+    precedenceSuite,
+    nameSuite,
+    multiFeatureSuite
+  )
+}


### PR DESCRIPTION
## Problem
`ZIOBDDTask.filterFeatures` evaluated include/exclude tag rules against **`scenario.tags` only**, ignoring feature-level tags. Per the Gherkin spec, a feature's tags are inherited by all its scenarios for filtering — so a feature tagged `@smoke` should make every scenario match `--include-tags smoke`, but they were all filtered out.

Two related defects in the same method:
- a feature whose scenarios were all filtered out was never itself marked `@ignore`;
- the scenario-name glob filter was effectively broken — `Pattern.quote(pattern).replace("\\*", ".*")` never substitutes, because `quote` wraps the pattern in `\Q…\E`, so `--scenario-name 'Login*'` matched the literal string `Login*` rather than acting as a wildcard. (Surfaced by the new tests.)

## Changes
- Tags are now resolved as `(featureTags ++ scenarioTags).distinct` for include/exclude checks — feature tags are inherited.
- A feature with all scenarios ignored is now marked `@ignore` itself.
- Scenario-name glob fixed: split on `*`, quote each literal segment, join with `.*` (case-insensitive). Literal and wildcard patterns both work; regex metacharacters in names are no longer interpreted.
- `filterFeatures` extracted to a pure `ZIOBDDTask` companion method for unit testing.

## Tests
New `core/src/test/scala/zio/bdd/TagFilteringSpec.scala` (19 cases): scenario/feature include & exclude, feature-tag inheritance, exclude-over-include precedence, feature-marked-ignored, scenario-name exact + glob, and multi-feature independence. Full suite green (`core` 320, `gherkin` 85, `example` ✓).

## Relationship to #77
Complementary, independent layer. #77 (`fix/scenario-tag-stripping`) fixes a **parser** bug where `parseScenario`'s examples loop consumed the next scenario's tag line, leaving `scenario.tags` partial. This PR fixes the **filtering** layer. Both are needed for full end-to-end correctness; this PR's unit tests build `Feature`/`Scenario` values directly, so they're valid regardless of #77.