### PR TITLE
Format TagRetentionSpec to satisfy scalafmtCheckAll

### DIFF
--- a/gherkin/src/test/scala/zio/bdd/gherkin/TagRetentionSpec.scala
+++ b/gherkin/src/test/scala/zio/bdd/gherkin/TagRetentionSpec.scala
@@ -2,10 +2,13 @@ package zio.bdd.gherkin
 
 import zio.test.*
 
-/** Regression: a scenario's own tag line must not be swallowed by the preceding scenario's Examples-collection loop.
-  * Before the fix, `parseScenario` greedily consumed the next scenario's tags while looking for an Examples block and
-  * discarded them when none followed, so every scenario lost its tags to its predecessor.
-  */
+/**
+ * Regression: a scenario's own tag line must not be swallowed by the preceding
+ * scenario's Examples-collection loop. Before the fix, `parseScenario` greedily
+ * consumed the next scenario's tags while looking for an Examples block and
+ * discarded them when none followed, so every scenario lost its tags to its
+ * predecessor.
+ */
 object TagRetentionSpec extends ZIOSpecDefault:
   private val feature =
     """Feature: F
@@ -36,8 +39,12 @@ object TagRetentionSpec extends ZIOSpecDefault:
       for f <- GherkinParser.parseFeature(feature, "repro.feature")
       yield assertTrue(
         f.scenarios.find(_.name == "First").exists(_.tags.contains("first-tag")),
-        f.scenarios.find(_.name == "Second").exists(s => s.tags.contains("second-tag") && s.tags.contains("spec-1.2.3")),
-        f.scenarios.exists(s => s.name.startsWith("Third") && s.tags.contains("outline-tag") && s.tags.contains("ex-tag"))
+        f.scenarios
+          .find(_.name == "Second")
+          .exists(s => s.tags.contains("second-tag") && s.tags.contains("spec-1.2.3")),
+        f.scenarios.exists(s =>
+          s.name.startsWith("Third") && s.tags.contains("outline-tag") && s.tags.contains("ex-tag")
+        )
       )
     }
   )


### PR DESCRIPTION
`TagRetentionSpec.scala` (added in #77) was merged unformatted and fails `sbt scalafmtCheckAll`. This applies scalafmt to it — formatting-only, no behavioral change. Needed for a clean v1.0.0-RC2 release.