### PR TITLE
Add CI workflow running scalafmtCheckAll and tests on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [master]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+      - run: sbt scalafmtCheckAll test


### PR DESCRIPTION
The only existing workflow (`release.yml`) triggers on tags, so pull requests and pushes to `master` had **no automated verification** — formatting and test regressions could merge unnoticed (as happened with the unformatted `TagRetentionSpec`, fixed in #79).

Adds `.github/workflows/ci.yml` running `sbt scalafmtCheckAll test` on every pull request and on pushes to `master`, mirroring the JDK/sbt setup in `release.yml`.

Once merged, the `build` check will be made a required status check for merging into `master`.