### PR TITLE
Bump checkout/setup-java actions off deprecated Node.js 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 11


### PR DESCRIPTION
The CI run surfaced a deprecation warning: `actions/checkout@v4` and `actions/setup-java@v4` run on Node.js 20, which GitHub is phasing out (forced to Node.js 24 from June 16 2026; Node.js 20 removed Sept 16 2026).

Bumps both to the current Node.js 24 majors — `actions/checkout@v6`, `actions/setup-java@v5` — in **both** `ci.yml` and `release.yml` (same deprecated actions). `sbt/setup-sbt@v1` was not flagged and is left as-is.