### PR TITLE
1.0.0 readiness: hook-error semantics, MiMa baseline, CHANGELOG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,4 @@ jobs:
           java-version: 11
           cache: sbt
       - uses: sbt/setup-sbt@v1
-      - run: sbt scalafmtCheckAll test
+      - run: sbt scalafmtCheckAll mimaReportBinaryIssues test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to zio-bdd are documented here.
 
-## [Unreleased / v1.0.0]
+## [1.0.0] — 2026-06-16
 
 ### Added
 
@@ -23,6 +23,10 @@ All notable changes to zio-bdd are documented here.
   validating the emitted XML by parsing it back.
 - **ZIOBDDFrameworkSpec** unit-testing the sbt fingerprint, filterFeatures tag inheritance,
   scenarioNameFilter glob, and CompositeReporter delegation.
+- **Binary-compatibility checking** via sbt-mima-plugin, with the baseline established at
+  1.0.0 (1.0.x / 1.1 are verified against 1.0.0; runs in CI).
+- **Strict/lint parser mode** (`parseFeature(..., strict = true)`): flags an unrecognized line
+  appearing after a scenario's steps begin as a likely misspelled step keyword.
 
 ### Fixed
 
@@ -37,12 +41,14 @@ All notable changes to zio-bdd are documented here.
 ### Changed
 
 - `featureDir` (singular) is deprecated; use `featureDirs` (array) in `@Suite`.
+- **before/afterStep hook failures now fail the step** (fail-loud) instead of aborting the
+  entire feature run. A hook that fails or dies marks that step (and scenario) failed with the
+  hook's cause, and the run continues; a hook that handles its own errors leaves the step Passed.
 
 ### Future Work
 
 - `@retry(n)` annotation: planned for post-v1 to avoid breaking changes.
 - Multi-language Gherkin keyword support.
-- Binary-compatibility baseline via sbt-mima-plugin (post-v1).
 
 ---
 

--- a/build.sbt
+++ b/build.sbt
@@ -35,12 +35,26 @@ lazy val commonDependencies = Seq(
   "dev.zio" %% "zio-test-sbt"          % "2.1.17" % Test
 )
 
+// Binary-compatibility checking. The baseline is established at 1.0.0: until a 1.x is published,
+// `previousStableVersion` is a 0.x tag and is filtered out (MiMa is a no-op), so the 1.0.0 release
+// itself is not checked against 0.1.0. From 1.0.0 onward, 1.0.x / 1.1 are verified against the
+// latest stable 1.x release.
+lazy val mimaSettings = Seq(
+  mimaPreviousArtifacts := previousStableVersion.value
+    // Only check against a final 1.x release — skip 0.x and pre-releases (RC/M/SNAPSHOT, which
+    // contain a '-'), so the 1.0.0 release itself is not checked against 0.1.0 or 1.0.0-RCx.
+    .filter(v => v.startsWith("1.") && !v.contains("-"))
+    .map(organization.value %% moduleName.value % _)
+    .toSet
+)
+
 lazy val root = (project in file("."))
   .aggregate(core, gherkin)
   .settings(
-    name           := "zio-bdd-root",
-    description    := "A ZIO-based BDD testing framework for Scala 3",
-    publish / skip := true
+    name                  := "zio-bdd-root",
+    description           := "A ZIO-based BDD testing framework for Scala 3",
+    publish / skip        := true,
+    mimaPreviousArtifacts := Set.empty // not published — MiMa is a no-op here
   )
   .dependsOn(core, gherkin)
 
@@ -56,13 +70,15 @@ lazy val core = (project in file("core"))
       "dev.zio"                %% "izumi-reflect"  % "3.0.2"
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
-    stepMethodGeneratorSettings
+    stepMethodGeneratorSettings,
+    mimaSettings
   )
 
 lazy val gherkin = (project in file("gherkin"))
   .settings(
     name := "zio-bdd-gherkin",
-    libraryDependencies ++= commonDependencies
+    libraryDependencies ++= commonDependencies,
+    mimaSettings
   )
 
 lazy val example = (project in file("example"))
@@ -72,5 +88,6 @@ lazy val example = (project in file("example"))
     libraryDependencies ++= commonDependencies,
     Test / testFrameworks    := Seq(new TestFramework("zio.bdd.ZIOBDDFramework")),
     Test / resourceDirectory := baseDirectory.value / "src" / "test" / "resources" / "features",
-    publish / skip           := true
+    publish / skip           := true,
+    mimaPreviousArtifacts    := Set.empty // not published — MiMa is a no-op here
   )

--- a/core/src/main/scala/zio/bdd/core/ScenarioExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/ScenarioExecutor.scala
@@ -93,30 +93,47 @@ object ScenarioExecutor {
       val input    = StepInput(step.pattern, step.dataTable, step.docString)
       val stepMeta = StepMetadata(step.pattern, effectiveType, step.file, step.line)
       val findStep = ZIO.serviceWithZIO[StepRegistry[R, S]](_.findStep(effectiveType, input))
+      // Hook failures/defects are folded into the step result rather than aborting the whole
+      // feature run: a failing before/afterStep hook fails the step (fail-loud), the run continues.
       for {
-        startNanos <- nowNanos
-        _          <- suite.beforeStepHook(stepMeta)
-        _          <- Stage.currentStepLabel.set(step.pattern)
-        result <- findStep.foldZIO(
-                    lookupErr => ZIO.succeed(StepResult(step, Left(Cause.fail(lookupErr.toException)))),
-                    effect =>
-                      if (dryRun) ZIO.succeed(StepResult(step, Right(())))
-                      else {
-                        val timedEffect = stepTimeout match {
-                          case Some(duration) =>
-                            effect
-                              .timeout(duration)
-                              .someOrFail(new StepTimeoutException(step.pattern, duration))
-                          case None =>
-                            effect
-                        }
-                        timedEffect.foldCauseZIO(
-                          cause => ZIO.succeed(StepResult(step, Left(cause))),
-                          _ => ZIO.succeed(StepResult(step, Right(())))
-                        )
+        startNanos  <- nowNanos
+        beforeCause <- suite.beforeStepHook(stepMeta).foldCause[Option[Cause[Throwable]]](c => Some(c), _ => None)
+        result <- beforeCause match {
+                    case Some(cause) =>
+                      // A failing beforeStep hook fails the step; the step body is not run.
+                      ZIO.succeed(StepResult(step, Left(cause)))
+                    case None =>
+                      for {
+                        _ <- Stage.currentStepLabel.set(step.pattern)
+                        stepRes <- findStep.foldZIO(
+                                     lookupErr =>
+                                       ZIO.succeed(StepResult(step, Left(Cause.fail(lookupErr.toException)))),
+                                     effect =>
+                                       if (dryRun) ZIO.succeed(StepResult(step, Right(())))
+                                       else {
+                                         val timedEffect = stepTimeout match {
+                                           case Some(duration) =>
+                                             effect
+                                               .timeout(duration)
+                                               .someOrFail(new StepTimeoutException(step.pattern, duration))
+                                           case None =>
+                                             effect
+                                         }
+                                         timedEffect.foldCauseZIO(
+                                           cause => ZIO.succeed(StepResult(step, Left(cause))),
+                                           _ => ZIO.succeed(StepResult(step, Right(())))
+                                         )
+                                       }
+                                   )
+                        afterCause <-
+                          suite.afterStepHook(stepMeta).foldCause[Option[Cause[Throwable]]](c => Some(c), _ => None)
+                      } yield afterCause match {
+                        // A failing afterStep hook fails an otherwise-passed step; a step that has
+                        // already failed keeps its original cause.
+                        case Some(cause) if stepRes.outcome.isRight => StepResult(step, Left(cause))
+                        case _                                      => stepRes
                       }
-                  )
-        _        <- suite.afterStepHook(stepMeta)
+                  }
         endNanos <- nowNanos
         duration  = (endNanos - startNanos) / 1_000_000L
       } yield result.copy(duration = duration)

--- a/core/src/test/scala/zio/bdd/core/CauseFidelitySpec.scala
+++ b/core/src/test/scala/zio/bdd/core/CauseFidelitySpec.scala
@@ -14,7 +14,8 @@ import zio.schema.{DeriveSchema, Schema}
  *   - ZIO.fail → StepStatus.Failed with failureOption present
  *   - Interruption → non-Passed result
  *   - Cause.Both → both failure leaves visible
- *   - die inside afterStep does not corrupt the preceding passed step's status
+ *   - a failing afterStep hook fails the step (fail-loud) without aborting the
+ *     run
  */
 object CauseFidelitySpec extends ZIOSpecDefault {
 
@@ -116,10 +117,36 @@ object CauseFidelitySpec extends ZIOSpecDefault {
     }
   )
 
-  // NOTE: a test asserting that an ignored `afterStep` die leaves a passed step Passed was
-  // dropped here pending a framework decision: ScenarioExecutor runs `afterStepHook` after the
-  // step result is computed (ScenarioExecutor.scala:119) and does not isolate defects, so a dying
-  // afterStep hook corrupts the step. See the PR description for the open question.
+  private val afterStepHookSpec = suite("a failing afterStep hook fails the step without aborting the run")(
+    test("a dying afterStep hook fails the otherwise-passed step but the feature run completes") {
+      val steps = new ZIOSteps[Any, S] {
+        afterStep(_ => ZIO.die(new RuntimeException("afterStep boom")))
+        Given("a passing step")(ZIO.unit)
+      }
+      for {
+        results   <- runFeature("Feature: F\n  Scenario: s\n    Given a passing step\n", steps)
+        stepResult = results.head.scenarioResults.head.stepResults.head
+        cause = stepResult.status match
+                  case StepStatus.Failed(c) => Some(c)
+                  case _                    => None
+      } yield assertTrue(
+        // Run completed normally (not aborted) and the hook failure is surfaced on the step.
+        stepResult.status.isInstanceOf[StepStatus.Failed],
+        cause.exists(_.dieOption.exists(_.getMessage == "afterStep boom"))
+      )
+    },
+    test("an afterStep hook that handles its own defect leaves the step Passed") {
+      val steps = new ZIOSteps[Any, S] {
+        // catchAllCause (unlike .ignore) actually swallows defects, so the hook succeeds.
+        afterStep(_ => ZIO.die(new RuntimeException("handled")).catchAllCause(_ => ZIO.unit))
+        Given("a passing step")(ZIO.unit)
+      }
+      for {
+        results   <- runFeature("Feature: F\n  Scenario: s\n    Given a passing step\n", steps)
+        stepResult = results.head.scenarioResults.head.stepResults.head
+      } yield assertTrue(stepResult.isPassed)
+    }
+  )
 
   private val skippedAfterFailureSpec = suite("steps after failure are Skipped")(
     test("3 steps: first fails, 2nd and 3rd are Skipped (not Failed)") {
@@ -147,6 +174,7 @@ object CauseFidelitySpec extends ZIOSpecDefault {
     dieSpec,
     failSpec,
     causeTreeSpec,
+    afterStepHookSpec,
     skippedAfterFailureSpec
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
-addSbtPlugin("org.scalameta"  % "sbt-scalafmt"   % "2.5.4")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.2")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"    % "2.5.4")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release"  % "1.9.2")
+addSbtPlugin("com.typesafe"   % "sbt-mima-plugin" % "1.1.6")


### PR DESCRIPTION
Closes the remaining 1.0.0-readiness items identified in review. Full suite green (**gherkin 117 + core 433 = 550**), scalafmt clean, MiMa runs (no-op pre-1.0).

## 1. before/afterStep hook errors are now fail-loud and run-safe

Previously a failing/dying `beforeStep`/`afterStep` hook **aborted the entire feature run** (the feature effect died, no results). Now `ScenarioExecutor` folds hook causes into the step result:
- a hook that fails/dies marks that **step (and scenario) Failed** with the hook's cause, and the run **continues**;
- a hook that handles its own errors leaves the step **Passed**.

This matches Cucumber's "hook failure fails the scenario" and never silently swallows hook errors. New `CauseFidelitySpec` tests cover both paths.

> Note: this corrects an earlier assumption — the test dropped in #83 relied on `ZIO.die(...).ignore` swallowing a defect, but ZIO's `.ignore` only catches *typed failures*, not defects. So there was no pre-existing framework bug; the real gap was the full-run abort, fixed here.

## 2. Binary-compatibility checking (sbt-mima-plugin)

Adds `sbt-mima-plugin` and a baseline that activates **at 1.0.0**: `mimaPreviousArtifacts` is derived from `previousStableVersion`, filtered to final `1.x` tags (skips `0.x` and pre-releases like `1.0.0-RCx`). So the 1.0.0 release itself isn't checked against `0.1.0`/RCs; from 1.0.0 on, `1.0.x`/`1.1` are verified against `1.0.0`. Wired into CI (`mimaReportBinaryIssues`), a no-op until a final 1.x is published.

## 3. CHANGELOG finalized for 1.0.0

Dated the `1.0.0` entry; documented the hook-behavior change, MiMa, and strict/lint parser mode.

---

### Also reviewed: PR #35 (classpath feature resolution) — recommend **closing as superseded**
Its feature already exists in `master` (commit `70f6040`): the `FeatureFiles` class with `classpath:` support and the `FeatureFilesSpec` tests are present and equivalent. Merging #35 would conflict and add nothing. Suggest closing with credit to the contributor.