### PR TITLE
Add Used by section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ transitively and are needed to derive `Schema[S]` for your state type.
 | [docs/running-tests.md](docs/running-tests.md) | CLI flags, reporters, parallelism |
 | [docs/examples.md](docs/examples.md) | Annotated end-to-end examples |
 
+## Used by
+
+- [zio-openfeature](https://github.com/EtaCassiopeia/zio-openfeature) — ZIO bindings for the OpenFeature spec, using zio-bdd for conformance testing
+
 ## License
 
 Apache 2.0 — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- Adds a "Used by" section to README.md listing zio-openfeature as a known consumer, since GitHub's automatic "Used by" widget doesn't detect sbt dependencies.

## Test plan
- Docs-only change, no build/test impact.