### PR TITLE
Fix scenarioParallelism=0 ("auto") being silently sequential outside ZIOBDDFramework

### DIFF
--- a/core/src/main/scala/zio/bdd/ZIOBDDFramework.scala
+++ b/core/src/main/scala/zio/bdd/ZIOBDDFramework.scala
@@ -187,7 +187,7 @@ class ZIOBDDTask(
       .run(
         updateFeatures,
         featureParallelism = config.featureParallelism,
-        scenarioParallelism = resolveParallelism(config.scenarioParallelism),
+        scenarioParallelism = config.scenarioParallelism,
         dryRun = config.dryRun
       )
       .tap(reporter.report)
@@ -371,18 +371,6 @@ class ZIOBDDTask(
         case Array("--scenario-parallelism", n)      => n.toIntOption.getOrElse(0)
       }
       .getOrElse(0)
-
-  /**
-   * Resolves the auto sentinel (0) to the actual number of available
-   * processors, falling back to 2 if the JVM reports an unreasonable value.
-   */
-  private def resolveParallelism(n: Int): Int =
-    if (n > 0) n
-    else
-      (java.lang.Runtime.getRuntime.availableProcessors() match {
-        case p if p > 0 => p
-        case _          => 2
-      })
 
   private def resolveFeatureFiles(config: BDDTestConfig, className: String, loggers: Array[Logger]): List[String] = {
     val paths =

--- a/core/src/main/scala/zio/bdd/core/FeatureExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/FeatureExecutor.scala
@@ -10,6 +10,21 @@ object FeatureExecutor {
   // Wall-clock duration measurement — independent of the ZIO Clock (and TestClock).
   private val nowNanos: UIO[Long] = ZIO.succeed(java.lang.System.nanoTime())
 
+  /**
+   * Resolves the `scenarioParallelism` auto sentinel (0) to the actual number
+   * of available processors, falling back to 2 if the JVM reports an
+   * unreasonable value. `Suite.scenarioParallelism()` documents `0` as "auto",
+   * and this is the single place that contract is honored, regardless of entry
+   * point (sbt test framework, CLI, or direct API use).
+   */
+  private def resolveParallelism(n: Int): Int =
+    if (n > 0) n
+    else
+      java.lang.Runtime.getRuntime.availableProcessors() match {
+        case p if p > 0 => p
+        case _          => 2
+      }
+
   def executeFeature[R: Tag, S: Tag: Default](
     feature: Feature,
     steps: List[StepDef[R, S]],
@@ -88,10 +103,11 @@ object FeatureExecutor {
           .provideSomeLayer[R & StepRegistry[R, S]](layer.orDie)
       }
 
-    if (scenarioParallelism <= 1)
+    val resolved = resolveParallelism(scenarioParallelism)
+    if (resolved <= 1)
       ZIO.foreach(expanded) { case (sc, flags) => runOne(sc, flags) }
     else
-      ZIO.foreachExec(expanded)(ExecutionStrategy.ParallelN(scenarioParallelism.max(1))) { case (sc, flags) =>
+      ZIO.foreachExec(expanded)(ExecutionStrategy.ParallelN(resolved)) { case (sc, flags) =>
         runOne(sc, flags)
       }
   }

--- a/core/src/test/scala/zio/bdd/core/ConcurrencySpec.scala
+++ b/core/src/test/scala/zio/bdd/core/ConcurrencySpec.scala
@@ -171,6 +171,39 @@ object ConcurrencySpec extends ZIOSpecDefault {
     } @@ TestAspect.withLiveClock
   )
 
+  private val autoParallelismSuite = suite("scenarioParallelism=0 auto-resolution")(
+    test("scenarioParallelism=0 runs scenarios concurrently, not sequentially") {
+      val inFlight    = new AtomicInteger(0)
+      val maxInFlight = new AtomicInteger(0)
+
+      class ConcurrentSteps extends ZIOSteps[Any, CountState] {
+        Given("state is set to " / int) { (n: Int) =>
+          for {
+            current <- ZIO.succeed(inFlight.incrementAndGet())
+            _       <- ZIO.succeed(maxInFlight.updateAndGet(_.max(current)))
+            _       <- ZIO.sleep(20.millis)
+            _       <- ScenarioContext.update(_ => CountState(n))
+            _       <- ZIO.succeed(inFlight.decrementAndGet())
+          } yield ()
+        }
+        Then("state should be " / int) { (expected: Int) =>
+          ScenarioContext.get.flatMap(s => Assertions.assertEquals(s.value, expected))
+        }
+      }
+
+      val steps = new ConcurrentSteps {}
+      for {
+        feature <- GherkinParser.parseFeature(makeFeature("AutoParallel", 8), F)
+        results <- FeatureExecutor.executeFeatures[Any, CountState](
+                     List(feature),
+                     steps.getSteps,
+                     steps,
+                     scenarioParallelism = 0 // documented as "auto" — must not be silently sequential
+                   )
+      } yield assertTrue(results.head.isPassed, maxInFlight.get() > 1)
+    } @@ TestAspect.withLiveClock
+  )
+
   private val noStateBleedSuite = suite("no State bleed across feature runs")(
     test("FeatureContext is reset between features under parallel execution") {
       // Each feature sets a feature-context Int value, then reads it back.
@@ -219,6 +252,7 @@ object ConcurrencySpec extends ZIOSpecDefault {
     isolationSuite,
     scenarioLayerCountSuite,
     backgroundParallelSuite,
+    autoParallelismSuite,
     noStateBleedSuite
   )
 }

--- a/docs/running.md
+++ b/docs/running.md
@@ -257,17 +257,28 @@ sbt "testOnly com.example.MySuite -- --parallelism 4"
 @Suite(parallelism = 4)
 ```
 
-### Scenario-level parallelism (`--scenario-parallelism`)
+### Scenario-level parallelism (`--scenario-parallelism` / `scenarioParallelism`)
 
-Controls how many scenarios within a single feature run concurrently. The default is `1`
-(sequential). Scenario-level parallelism requires that scenarios within a feature are
-independent and do not share mutable state.
+Controls how many scenarios within a single feature run concurrently. Scenario-level
+parallelism requires that scenarios within a feature are independent and do not share
+mutable state.
 
 ```sh
 sbt "testOnly com.example.MySuite -- --scenario-parallelism 2"
 ```
 
-There is no annotation field for `--scenario-parallelism`; it is CLI-only.
+```scala
+@Suite(scenarioParallelism = 2)
+```
+
+The default is `0`, meaning **auto**: the number of available processors (falling back to
+`2` if that can't be determined), so parallel scenario execution is on by default. Pass `1`
+explicitly to force fully sequential execution, or `auto`/`0` to make the auto behavior
+explicit:
+
+```sh
+sbt "testOnly com.example.MySuite -- --scenario-parallelism auto"
+```
 
 ### Combining both
 


### PR DESCRIPTION
## Summary

- `Suite.java` documents `scenarioParallelism = 0` as `"auto (use available processors)"`, but that resolution only ever happened inside `ZIOBDDFramework.run`, via a private `resolveParallelism` helper applied right before calling into `FeatureExecutor`.
- `FeatureExecutor.runScenarios` — the place that actually decides sequential vs. parallel (`scenarioParallelism <= 1` → sequential) — had no knowledge of the sentinel. Any direct caller of `FeatureExecutor.executeFeature` / `executeFeatures` with `scenarioParallelism = 0` got fully sequential execution instead of the documented auto behavior.
- Moved the resolution into `FeatureExecutor.runScenarios` so the "0 = auto" contract holds regardless of entry point (sbt test framework, CLI, or direct API use). `ZIOBDDFramework` now passes the raw config value through and no longer duplicates the resolution logic.
- Updated `docs/running.md`, which previously claimed the scenario-parallelism default was `1` (sequential) and that there was no `@Suite` annotation field for it — both inaccurate (the documented default is `0`/auto, and `Suite.java` has had `scenarioParallelism()` since its introduction).

Fixes #89

## Test plan

- [x] Added a regression test in `ConcurrencySpec` (`scenarioParallelism=0 auto-resolution`) that asserts scenarios run with `maxInFlight > 1` when `scenarioParallelism = 0` is passed directly to `FeatureExecutor.executeFeatures` — this fails on the pre-fix code (silently sequential, `maxInFlight == 1`).
- [x] `sbt compile`
- [x] `sbt scalafmtCheckAll`
- [x] `sbt test` — 434 tests passed, 0 failed