### PR TITLE
Fix documentation drift accumulated since v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to zio-bdd are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **`scenarioParallelism = 0` ("auto") silently ran sequentially outside `ZIOBDDFramework`** —
+  callers that constructed the executor directly (rather than going through the sbt test
+  framework entry point) did not get the intended auto-detected parallelism and fell back to
+  running scenarios one at a time.
+- **A blank line in a `Feature:` description silently dropped the feature** — the Gherkin parser
+  treated a blank line inside the description block as the end of the feature, discarding any
+  content (including scenarios) that followed.
+
 ## [1.0.0] — 2026-06-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ object AccountSpec extends ZIOSteps[Any, AccountState]:
 
 ```scala
 // build.sbt
-libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "0.1.0" % Test
+libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.0.0" % Test
 
 Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
 ```
@@ -74,11 +74,8 @@ transitively and are needed to derive `Schema[S]` for your state type.
 |---|---|
 | [docs/quickstart.md](docs/quickstart.md) | Zero to running test in 5 minutes |
 | [docs/concepts.md](docs/concepts.md) | Mental model: how the framework works |
-| [docs/step-definitions.md](docs/step-definitions.md) | Step DSL, extractors, and patterns |
-| [docs/gherkin-reference.md](docs/gherkin-reference.md) | Supported Gherkin syntax |
-| [docs/advanced-features.md](docs/advanced-features.md) | Flags, TypeMap, HasLens, HasService |
-| [docs/running-tests.md](docs/running-tests.md) | CLI flags, reporters, parallelism |
-| [docs/examples.md](docs/examples.md) | Annotated end-to-end examples |
+| [docs/step-dsl.md](docs/step-dsl.md) | Step DSL, extractors, and patterns |
+| [docs/index.md](docs/index.md) | Full documentation index — Gherkin syntax, state, layers, hooks, reporters, feature flags, cookbook, migrating from Cucumber, troubleshooting |
 
 ## Used by
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,7 +9,7 @@ as a concrete example throughout.
 In `build.sbt`:
 
 ```scala
-libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "0.1.0" % Test
+libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.0.0" % Test
 
 Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
 ```

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -127,14 +127,14 @@ for {
 
 ### junitxml
 
-`JUnitXMLReporter` writes one XML file per feature into `target/test-results/`. File names
+`JUnitXMLReporter` writes one XML file per feature into `target/test-reports/`. File names
 are derived from the feature name with non-alphanumeric characters replaced by `_`.
 
 **Configuration:**
 
 ```scala
 JUnitReporterConfig(
-  outputDir = "target/test-results",   // default
+  outputDir = "target/test-reports",   // default
   format    = JUnitXMLFormatter.Format.JUnit5  // default
 )
 ```
@@ -145,7 +145,7 @@ To override, instantiate the reporter directly in a custom `BDDTestConfig`.
 **File location:**
 
 ```
-target/test-results/
+target/test-reports/
   User_registration.xml
   Shopping_cart.xml
   ...
@@ -294,12 +294,14 @@ Step bodies and reporters interact with the following result types.
 enum StepStatus:
   case Passed
   case Failed(cause: Cause[Throwable])
+  case TimedOut(timeout: Duration, cause: Cause[Throwable])
   case Skipped
   case Pending(reason: String)
 ```
 
 A step is `Skipped` when a prior step in the same scenario failed and it was never attempted.
 A step is `Pending` when its body called `pending("reason")`.
+A step is `TimedOut` when it exceeded the configured step timeout (see `docs/running.md`).
 
 ### ScenarioResult
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -353,7 +353,7 @@ For suite-wide shared state (e.g. a shared HTTP client), put it in `R` via `glob
 ### Q: Can I use zio-test assertions inside step bodies?
 
 zio-bdd provides its own assertion helpers in `zio.bdd.core.Assertions`:
-`assertTrue`, `assertEquals`, `assertSome`, `assertNone`, `assertFails`, `collectAll`.
+`assertTrue`, `assertEquals`, `assertSome`, `assertNone`, `assertThrows`, `collectAll`.
 
 These are plain ZIO effects that throw `AssertionError` on failure — compatible with the
 zio-bdd step execution model.  Do not use `zio-test`'s `assertTrue` / `assert` macros

--- a/example/README.md
+++ b/example/README.md
@@ -8,7 +8,7 @@ This README provides instructions to run the tests for the `zio-bdd` example loc
 - **SBT**: Use SBT 1.9.x or later.
 - **Dependencies**: Add the following to your `build.sbt`:
   ```scala
-  libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "0.1.0" % Test
+  libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.0.0" % Test
   libraryDependencies += "dev.zio" %% "zio" % "2.1.17"
   Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
   ```
@@ -19,8 +19,8 @@ The example includes a feature file with tagged scenarios:
 - Feature: `Simple Greeting` (`@core @greeting`)
 - Scenarios:
     - `Greet a user` (`@positive @smoke`)
-    - `Greet an empty user` (`@negative @ignore`)
-    - `Greet a different user` (`@positive @flaky @retry(2)`)
+    - `Greet an empty user` (`@ignore`)
+    - `Greet a different user` (`@negative`)
 
 ## Running Tests
 
@@ -32,29 +32,40 @@ sbt "example/test"
 ```
 - Runs all scenarios filtered by `@Suite(includeTags = Array("positive"))`, executing only `@positive` scenarios by default.
 
+> `testOnly` must be scoped to the `example` project (`example/testOnly ...`) — the root
+> project only aggregates `core` and `gherkin`, so an unscoped `testOnly` from the repo root
+> finds no tests at all.
+
 ### 2. Filter by Including Tags
 ```bash
-sbt "testOnly zio.bdd.example.SimpleSpec -- --include-tags smoke"
+sbt "example/testOnly zio.bdd.example.SimpleSpec -- --include-tags smoke"
 ```
-- Runs only scenarios with `@smoke` (e.g., `Greet a user`).
+- Runs only scenarios with `@smoke` (`Greet a user`). `--include-tags` fully replaces the
+  `@Suite`'s `includeTags = Array("positive")` for this run.
 
 ### 3. Filter by Excluding Tags
 ```bash
-sbt "testOnly zio.bdd.example.SimpleSpec -- --exclude-tags ignore"
+sbt "example/testOnly zio.bdd.example.SimpleSpec -- --exclude-tags ignore"
 ```
-- Runs scenarios without `@ignore` (e.g., `Greet a user` and `Greet a different user`).
+- `--include-tags` and `--exclude-tags` are resolved independently: since this command doesn't
+  set `--include-tags`, the `@Suite`'s `includeTags = Array("positive")` is still in effect.
+  Only `Greet a user` runs; `Greet a different user` (`@negative`) stays excluded.
 
 ### 4. Combine Include and Exclude Filters
 ```bash
-sbt "testOnly zio.bdd.example.SimpleSpec -- --include-tags positive --exclude-tags flaky"
+sbt "example/testOnly zio.bdd.example.SimpleSpec -- --include-tags positive --exclude-tags flaky"
 ```
-- Runs `@positive` scenarios excluding `@flaky` (e.g., `Greet a user`).
+- Runs `@positive` scenarios excluding `@flaky` (`Greet a user` — none of the scenarios carry
+  `@flaky` here, so this behaves the same as `--include-tags positive` alone).
 
 ### 5. Test Feature-Level Tags
 ```bash
-sbt "testOnly zio.bdd.example.SimpleSpec -- --include-tags core"
+sbt "example/testOnly zio.bdd.example.SimpleSpec -- --include-tags core"
 ```
-- Runs all scenarios because the feature has `@core`.
+- The `@core` tag on the `Feature:` line is inherited by every scenario, so this matches
+  `Greet a user` and `Greet a different user`. `Greet an empty user` still shows as `IGNORED` —
+  `@ignore` is a built-in status tag handled separately from `--include-tags`/`--exclude-tags`
+  filtering, so it's never run regardless of which tags are included.
 
 ### 6. Debug Mode (Verbose Output)
 ```bash
@@ -64,4 +75,8 @@ sbt --debug "example/test"
 
 ## Notes
 - Ensure the feature file is at `example/src/test/resources/features/simple.feature`.
-- Tag filters override the `@Suite` configuration when specified via the command line.
+- `--include-tags`/`--exclude-tags` on the command line each independently replace the
+  corresponding `@Suite` annotation field *only if supplied*; an omitted CLI flag falls back to
+  the `@Suite` value for that field. They do not merge with or fully override the annotation as
+  a pair.
+- `@ignore` always marks a scenario `IGNORED`, independent of `--include-tags`/`--exclude-tags`.


### PR DESCRIPTION
## Summary
- `README.md` linked to 5 `docs/*.md` files that no longer exist (renamed/merged in a prior pass: `step-definitions.md`→`step-dsl.md`, `gherkin-reference.md`→`gherkin.md`, `running-tests.md`→`running.md`, `advanced-features.md`/`examples.md` split across other docs). Replaced with working links, anchored to `docs/index.md` as the canonical index so the list can't drift out of sync again.
- Three install snippets (`README.md`, `docs/quickstart.md`, `example/README.md`) still pinned `% "0.1.0"`; the repo is at `v1.0.0`. Bumped all three.
- `example/README.md` described `Greet an empty user` as `@negative @ignore` and `Greet a different user` as `@positive @flaky @retry(2)` — neither matches `simple.feature` (`@ignore` and `@negative` respectively). Fixed, and corrected the tag-filter walkthrough: CLI `--include-tags`/`--exclude-tags` are merged independently per field against the `@Suite` annotation (confirmed against `ZIOBDDFramework.scala`'s merge logic and by actually running each documented command), not overridden as a pair as the doc claimed. Also fixed unscoped `testOnly` examples, which silently match nothing since the root sbt project only aggregates `core`/`gherkin`, not `example`.
- `docs/reporters.md`: added the missing `TimedOut` `StepStatus` case and fixed the default JUnit XML output directory (`target/test-reports`, not `target/test-results`).
- `docs/troubleshooting.md`: removed a reference to a non-existent `assertFails` helper, replaced with the real `assertThrows`.
- `CHANGELOG.md`: added an `[Unreleased]` section for two fixes already merged to `master` since the `v1.0.0` tag (`scenarioParallelism=0` auto-resolution, blank-line-in-Feature-description parsing bug) that hadn't been changelogged.

No functional/runtime code changes — this is a documentation-accuracy pass. Remaining `docs/*.md` files (concepts, cookbook, migrating, state, layers, hooks, step-dsl, gherkin, running, testing-flags) were audited against current source and found accurate; no changes needed there.

## Test plan
- [x] `sbt clean compile Test/compile` across `gherkin`/`core`/`example` — compiles clean, same pre-existing warnings as baseline (none new).
- [x] `sbt example/test` — still 1 passed / 2 ignored, matching pre-change baseline.
- [x] Manually re-ran each tag-filter command now documented in `example/README.md` (`--include-tags smoke`, `--exclude-tags ignore`, `--include-tags positive --exclude-tags flaky`, `--include-tags core`) and confirmed actual output matches the corrected doc text.
- [x] Confirmed every `docs/*.md` link in `README.md` resolves on disk; confirmed no `0.1.0` version strings remain in docs.