### PR TITLE
Add property-based testing via Gherkin (Mode P)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 test-output/
+.zio-bdd/
 .sbtopts
 .bsp
 project/.sbt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to zio-bdd are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Property-based testing (Mode P)** — `@property(samples=N, seed=S, shrink=true, ...)` on a
+  header-only `Examples:` block runs the scenario against N generated samples instead of literal
+  rows. The `HasGen[T]` typeclass resolves a `zio.test.Gen` per column (built-ins for
+  `Int`/`Long`/`Double`/`Boolean`/`String`/`UUID`), named overrides via `HasGen.named(name)(gen)`
+  and the `| column: generatorName |` header syntax, and `ZIOSteps#columnGenLookup` for
+  suite-level column-to-generator routing. Falsifying samples are persisted to
+  `.zio-bdd/failures/` and replayed first on the next run; `pretty` and `junitxml` reporters both
+  render the counterexample.
+
 ### Fixed
 
 - **`scenarioParallelism = 0` ("auto") silently ran sequentially outside `ZIOBDDFramework`** —

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ object AccountSpec extends ZIOSteps[Any, AccountState]:
 - **Three-tier environment** — `globalLayer` (once per JVM), `featureLayer` (once per feature), `scenarioLayer(meta)` (once per scenario) for fine-grained resource sharing
 - **Lifecycle hooks** — `beforeAll`, `afterAll`, `beforeFeature`, `afterFeature`, `beforeScenario`, `afterScenario`, `beforeStep`, `afterStep`
 - **Full Gherkin support** — Background, Scenario Outline (Examples tables), data tables, doc strings, tags
+- **Property-based testing** — `@property(samples=N, seed=S)` on a header-only `Examples:` block runs the scenario N times with ZIO Test `Gen`-sampled values; `HasGen[T]` typeclass wires domain generators; named column overrides (`| amount: smallAmounts |`); automatic failure replay via `.zio-bdd/failures/`
 - **Flag matrix** — `@flags(key=value)` tags expand a scenario into N runs with different environment values
 - **Tag filtering** — `includeTags` / `excludeTags` in `@Suite` or via `--include-tags` / `--exclude-tags` CLI
 - **Parallel execution** — feature-level via `@Suite(parallelism = N)`, scenario-level via `--scenario-parallelism N`
@@ -75,6 +76,7 @@ transitively and are needed to derive `Schema[S]` for your state type.
 | [docs/quickstart.md](docs/quickstart.md) | Zero to running test in 5 minutes |
 | [docs/concepts.md](docs/concepts.md) | Mental model: how the framework works |
 | [docs/step-dsl.md](docs/step-dsl.md) | Step DSL, extractors, and patterns |
+| [docs/property-testing.md](docs/property-testing.md) | `@property(...)` tag, `HasGen[T]` registry, named generator overrides, failure replay, JUnit XML output |
 | [docs/index.md](docs/index.md) | Full documentation index — Gherkin syntax, state, layers, hooks, reporters, feature flags, cookbook, migrating from Cucumber, troubleshooting |
 
 ## Used by

--- a/build.sbt
+++ b/build.sbt
@@ -47,11 +47,34 @@ lazy val mimaSettings = Seq(
     .filter(v => v.startsWith("1.") && !v.contains("-"))
     .map(organization.value %% moduleName.value % _)
     .toSet,
-  // #96 added a `Tag[A]` member to `TypedExtractor[A]` (a prerequisite for type-based
-  // HasGen discovery in property testing, #99) so `table`/`tableWithMapping` gained a
-  // `Tag[T]` context bound and `TableExtractor` gained a `Tag[List[T]]` constructor param.
-  // Source-compatible, not binary-compatible against 1.0.0.
+  // Property-based testing (#91) added new defaulted fields to `Scenario` / the internal
+  // `RawExamplesBlock`, a new defaulted `genLookup` parameter on `FeatureExecutor`, and
+  // replaced several `PrettyReporter.Color` case objects with `val` aliases of the same type.
+  // All of these are source-compatible but not binary-compatible against 1.0.0 — expected for
+  // a minor feature release; filtered rather than worked around.
   mimaBinaryIssueFilters ++= Seq(
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.gherkin.GherkinParser#RawExamplesBlock.apply"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.gherkin.GherkinParser#RawExamplesBlock.this"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.gherkin.GherkinParser#RawExamplesBlock.copy"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.gherkin.Scenario.apply"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.gherkin.Scenario.this"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.gherkin.Scenario.copy"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.FeatureExecutor.executeFeature"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.FeatureExecutor.executeFeatures"),
+    ProblemFilters.exclude[MissingFieldProblem]("zio.bdd.core.report.Color.Yellow"),
+    ProblemFilters.exclude[MissingFieldProblem]("zio.bdd.core.report.Color.PaleGreen"),
+    ProblemFilters.exclude[MissingFieldProblem]("zio.bdd.core.report.Color.PaleCyan"),
+    ProblemFilters.exclude[MissingFieldProblem]("zio.bdd.core.report.Color.PaleYellow"),
+    ProblemFilters.exclude[MissingFieldProblem]("zio.bdd.core.report.Color.PaleRed"),
+    ProblemFilters.exclude[MissingClassProblem]("zio.bdd.core.report.Color$PaleCyan$"),
+    ProblemFilters.exclude[MissingClassProblem]("zio.bdd.core.report.Color$PaleGreen$"),
+    ProblemFilters.exclude[MissingClassProblem]("zio.bdd.core.report.Color$PaleRed$"),
+    ProblemFilters.exclude[MissingClassProblem]("zio.bdd.core.report.Color$PaleYellow$"),
+    ProblemFilters.exclude[MissingClassProblem]("zio.bdd.core.report.Color$Yellow$"),
+    // #96 added a `Tag[A]` member to `TypedExtractor[A]` (a prerequisite for type-based
+    // HasGen discovery in property testing, #99) so `table`/`tableWithMapping` gained a
+    // `Tag[T]` context bound and `TableExtractor` gained a `Tag[List[T]]` constructor param.
+    // Source-compatible, not binary-compatible against 1.0.0.
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.step.DefaultTypedExtractor.table"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.step.DefaultTypedExtractor.tableWithMapping"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.step.TableExtractor.this"),

--- a/core/src/main/scala/zio/bdd/core/FeatureExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/FeatureExecutor.scala
@@ -101,8 +101,10 @@ object FeatureExecutor {
             // Property scenario — dispatch to PropertyExecutor. `flags` (if any @flags(...)
             // tag is present) is forwarded so each sample uses suite.flagLayer like the
             // literal path does; expandFlagScenarios already multiplied one full sample
-            // batch per @flags(...) combination upstream.
-            PropertyExecutor.run[R, S](scenario, suite, genLookup, flags)
+            // batch per @flags(...) combination upstream. `dryRun` is forwarded too, so
+            // --dry-run validates step matching with one sample instead of running the full
+            // configured sample count for real.
+            PropertyExecutor.run[R, S](scenario, suite, genLookup, flags, dryRun)
           case None =>
             val meta = ScenarioMetadata.from(scenario, flags)
             val layer =

--- a/core/src/main/scala/zio/bdd/core/FeatureExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/FeatureExecutor.scala
@@ -75,20 +75,15 @@ object FeatureExecutor {
    */
   private def expandFlagScenarios(scenarios: List[Scenario]): List[(Scenario, Map[String, String])] =
     scenarios.flatMap { scenario =>
-      // Property scenarios are dispatched to PropertyExecutor, which has no notion of flag
-      // values — never multiply them per @flags(...) combination, or they'd run the full
-      // sample batch once per combination with the (ignored) flag value never applied.
-      if (scenario.propertyConfig.isDefined) List((scenario, Map.empty))
+      val flagMaps = FlagsTag.extractAll(scenario.tags)
+      if (flagMaps.isEmpty)
+        List((scenario, Map.empty))
       else
-        val flagMaps = FlagsTag.extractAll(scenario.tags)
-        if (flagMaps.isEmpty)
-          List((scenario, Map.empty))
-        else
-          flagMaps.map { flags =>
-            val label   = flags.toList.sortBy(_._1).map { case (k, v) => s"$k=$v" }.mkString(", ")
-            val renamed = scenario.copy(name = s"${scenario.name} [$label]")
-            (renamed, flags)
-          }
+        flagMaps.map { flags =>
+          val label   = flags.toList.sortBy(_._1).map { case (k, v) => s"$k=$v" }.mkString(", ")
+          val renamed = scenario.copy(name = s"${scenario.name} [$label]")
+          (renamed, flags)
+        }
     }
 
   private def runScenarios[R: Tag, S: Tag: Default](
@@ -103,8 +98,11 @@ object FeatureExecutor {
       ZIO.logAnnotate("scenarioId", scenario.id.toString) {
         scenario.propertyConfig match
           case Some(_) =>
-            // Property scenario — dispatch to PropertyExecutor, bypass flag expansion
-            PropertyExecutor.run[R, S](scenario, suite, genLookup)
+            // Property scenario — dispatch to PropertyExecutor. `flags` (if any @flags(...)
+            // tag is present) is forwarded so each sample uses suite.flagLayer like the
+            // literal path does; expandFlagScenarios already multiplied one full sample
+            // batch per @flags(...) combination upstream.
+            PropertyExecutor.run[R, S](scenario, suite, genLookup, flags)
           case None =>
             val meta = ScenarioMetadata.from(scenario, flags)
             val layer =

--- a/core/src/main/scala/zio/bdd/core/FeatureExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/FeatureExecutor.scala
@@ -2,6 +2,7 @@ package zio.bdd.core
 
 import izumi.reflect.Tag
 import zio.*
+import zio.bdd.core.property.{ColumnGenLookup, PropertyExecutor}
 import zio.bdd.core.step.{StepDef, StepRegistry, ZIOSteps}
 import zio.bdd.gherkin.{Feature, FlagsTag, Scenario, ScenarioMetadata}
 
@@ -30,7 +31,8 @@ object FeatureExecutor {
     steps: List[StepDef[R, S]],
     suite: ZIOSteps[R, S],
     scenarioParallelism: Int = 1,
-    dryRun: Boolean = false
+    dryRun: Boolean = false,
+    genLookup: ColumnGenLookup = ColumnGenLookup.empty
   ): ZIO[R, Nothing, FeatureResult] =
     if (feature.isIgnored) {
       val ignoredScenarios = feature.scenarios.map { scenario =>
@@ -47,7 +49,7 @@ object FeatureExecutor {
             featureResult <- (for {
                                _       <- suite.beforeFeatureHook
                                expanded = expandFlagScenarios(feature.scenarios)
-                               results <- runScenarios(expanded, steps, suite, scenarioParallelism, dryRun)
+                               results <- runScenarios(expanded, steps, suite, scenarioParallelism, dryRun, genLookup)
                              } yield FeatureResult(feature, results))
                                // afterFeature teardown always runs, even on failure or interruption.
                                .ensuring(suite.afterFeatureHook)
@@ -89,18 +91,23 @@ object FeatureExecutor {
     steps: List[StepDef[R, S]],
     suite: ZIOSteps[R, S],
     scenarioParallelism: Int,
-    dryRun: Boolean
+    dryRun: Boolean,
+    genLookup: ColumnGenLookup
   ): ZIO[R & StepRegistry[R, S], Nothing, List[ScenarioResult]] = {
     def runOne(scenario: Scenario, flags: Map[String, String]): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
       ZIO.logAnnotate("scenarioId", scenario.id.toString) {
-        val meta = ScenarioMetadata.from(scenario, flags)
-        // Use flagLayer when flags are present, scenarioLayer otherwise (backward-compatible)
-        val layer =
-          if (flags.isEmpty) suite.scenarioLayer(meta)
-          else suite.flagLayer(meta, flags)
-        ScenarioExecutor
-          .executeScenario[R, S](scenario, suite, dryRun, flags, suite.stepTimeout)
-          .provideSomeLayer[R & StepRegistry[R, S]](layer.orDie)
+        scenario.propertyConfig match
+          case Some(_) =>
+            // Property scenario — dispatch to PropertyExecutor, bypass flag expansion
+            PropertyExecutor.run[R, S](scenario, suite, genLookup)
+          case None =>
+            val meta = ScenarioMetadata.from(scenario, flags)
+            val layer =
+              if (flags.isEmpty) suite.scenarioLayer(meta)
+              else suite.flagLayer(meta, flags)
+            ScenarioExecutor
+              .executeScenario[R, S](scenario, suite, dryRun, flags, suite.stepTimeout)
+              .provideSomeLayer[R & StepRegistry[R, S]](layer.orDie)
       }
 
     val resolved = resolveParallelism(scenarioParallelism)
@@ -118,15 +125,16 @@ object FeatureExecutor {
     suite: ZIOSteps[R, S],
     featureParallelism: Int = 1,
     scenarioParallelism: Int = 1,
-    dryRun: Boolean = false
+    dryRun: Boolean = false,
+    genLookup: ColumnGenLookup = ColumnGenLookup.empty
   ): ZIO[R, Nothing, List[FeatureResult]] =
     for {
       _ <- suite.beforeAllHook
       results <- if (featureParallelism <= 1)
-                   ZIO.foreach(features)(executeFeature(_, steps, suite, scenarioParallelism, dryRun))
+                   ZIO.foreach(features)(executeFeature(_, steps, suite, scenarioParallelism, dryRun, genLookup))
                  else
                    ZIO.foreachExec(features)(ExecutionStrategy.ParallelN(featureParallelism.max(1)))(
-                     executeFeature(_, steps, suite, scenarioParallelism, dryRun)
+                     executeFeature(_, steps, suite, scenarioParallelism, dryRun, genLookup)
                    )
       _ <- suite.afterAllHook
     } yield results

--- a/core/src/main/scala/zio/bdd/core/FeatureExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/FeatureExecutor.scala
@@ -75,15 +75,20 @@ object FeatureExecutor {
    */
   private def expandFlagScenarios(scenarios: List[Scenario]): List[(Scenario, Map[String, String])] =
     scenarios.flatMap { scenario =>
-      val flagMaps = FlagsTag.extractAll(scenario.tags)
-      if (flagMaps.isEmpty)
-        List((scenario, Map.empty))
+      // Property scenarios are dispatched to PropertyExecutor, which has no notion of flag
+      // values — never multiply them per @flags(...) combination, or they'd run the full
+      // sample batch once per combination with the (ignored) flag value never applied.
+      if (scenario.propertyConfig.isDefined) List((scenario, Map.empty))
       else
-        flagMaps.map { flags =>
-          val label   = flags.toList.sortBy(_._1).map { case (k, v) => s"$k=$v" }.mkString(", ")
-          val renamed = scenario.copy(name = s"${scenario.name} [$label]")
-          (renamed, flags)
-        }
+        val flagMaps = FlagsTag.extractAll(scenario.tags)
+        if (flagMaps.isEmpty)
+          List((scenario, Map.empty))
+        else
+          flagMaps.map { flags =>
+            val label   = flags.toList.sortBy(_._1).map { case (k, v) => s"$k=$v" }.mkString(", ")
+            val renamed = scenario.copy(name = s"${scenario.name} [$label]")
+            (renamed, flags)
+          }
     }
 
   private def runScenarios[R: Tag, S: Tag: Default](

--- a/core/src/main/scala/zio/bdd/core/LogCollector.scala
+++ b/core/src/main/scala/zio/bdd/core/LogCollector.scala
@@ -1,6 +1,6 @@
 package zio.bdd.core
 
-import zio.{Runtime, ZLogger, *}
+import zio.{ZLogger, *}
 import zio.logging.LogFormat
 
 import java.time.Instant
@@ -117,8 +117,9 @@ object LogCollector {
    * write with no ZIO runtime re-entry. Eliminates the `Unsafe.unsafe` bridge
    * and the associated interpreter overhead on every log call.
    *
-   * The runtime default logger is AUGMENTED (not replaced) so that step-level
-   * ZIO.log* calls also appear on the console.
+   * The runtime default logger is REPLACED (not augmented) so that ZIO.log*
+   * calls inside step bodies are captured by the collector only and not also
+   * echoed to stdout by the default logger.
    */
   private def customLogger(collector: LogCollectorImpl): ZLogger[String, Unit] = {
     val formatLogger = LogFormat.default.toLogger
@@ -152,7 +153,7 @@ object LogCollector {
     ZLayer.scoped {
       val collector = new LogCollectorImpl(config)
       FiberRef.currentLoggers
-        .locallyScoped(Runtime.defaultLoggers + customLogger(collector))
+        .locallyScoped(Set(customLogger(collector)))
         .as(collector)
     }
 

--- a/core/src/main/scala/zio/bdd/core/property/HasGen.scala
+++ b/core/src/main/scala/zio/bdd/core/property/HasGen.scala
@@ -8,11 +8,16 @@ import scala.collection.concurrent.TrieMap
 /**
  * Typeclass that provides a ZIO Test `Gen[Any, A]` for a given type `A`.
  *
- * ==Default resolution==
- * Step parameters of type `T` that also have a `HasGen[T]` implicit in scope
- * are automatically sampled during `@property` scenario execution. Built-in
- * instances are provided for primitive types matching the existing
- * `TypedExtractor` built-ins.
+ * ==Resolution is by column name, not by type==
+ * A `@property` column is just a string name parsed from the Gherkin header —
+ * there is no automatic inference from a step's `TypedExtractor[T]` to a
+ * `HasGen[T]`. Every property column, including ones using a built-in type
+ * below, must be routed explicitly via `ZIOSteps#columnGenLookup` (see
+ * `zio.bdd.core.property.ColumnGenLookup`) or a named override (see below).
+ * Built-in instances exist for `Int`/`Long`/`Double`/`Boolean`/ `String`/`UUID`
+ * so you don't need to write `Gen.int` etc. yourself, but you still need to
+ * route the column name to `HasGen[Int]` (or whichever applies) in
+ * `columnGenLookup`.
  *
  * ==Named generator overrides==
  * Register a non-default generator for a column via
@@ -23,7 +28,8 @@ import scala.collection.concurrent.TrieMap
  * Example:
  * {{{
  * object MySteps extends ZIOSteps[MyEnv, Unit]:
- *   given HasGen[Money] = Gen.double(0, 10_000).map(Money.apply)
+ *   given HasGen[Money] with
+ *     def gen = Gen.double(0, 10_000).map(Money.apply)
  *   HasGen.named("smallAmounts")(Gen.double(0.01, 10.0).map(Money.apply))
  * }}}
  */

--- a/core/src/main/scala/zio/bdd/core/property/HasGen.scala
+++ b/core/src/main/scala/zio/bdd/core/property/HasGen.scala
@@ -1,0 +1,81 @@
+package zio.bdd.core.property
+
+import zio.test.Gen
+
+import java.util.UUID
+import scala.collection.concurrent.TrieMap
+
+/**
+ * Typeclass that provides a ZIO Test `Gen[Any, A]` for a given type `A`.
+ *
+ * ==Default resolution==
+ * Step parameters of type `T` that also have a `HasGen[T]` implicit in scope
+ * are automatically sampled during `@property` scenario execution. Built-in
+ * instances are provided for primitive types matching the existing
+ * `TypedExtractor` built-ins.
+ *
+ * ==Named generator overrides==
+ * Register a non-default generator for a column via
+ * `HasGen.named[A](name)(gen)` and reference it in the Gherkin header: `|
+ * amount: smallAmounts |`. The `:smallAmounts` suffix is resolved against the
+ * named registry at runtime.
+ *
+ * Example:
+ * {{{
+ * object MySteps extends ZIOSteps[MyEnv, Unit]:
+ *   given HasGen[Money] = Gen.double(0, 10_000).map(Money.apply)
+ *   HasGen.named("smallAmounts")(Gen.double(0.01, 10.0).map(Money.apply))
+ * }}}
+ */
+trait HasGen[A]:
+  def gen: Gen[Any, A]
+  // Human-readable label surfaced in failure output, e.g. "HasGen[Int]".
+  def label: String = s"HasGen[${gen.getClass.getSimpleName}]"
+
+object HasGen:
+  // ── Built-in defaults ────────────────────────────────────────────────────
+
+  given HasGen[Int] with
+    def gen            = Gen.int
+    override def label = "HasGen[Int]"
+
+  given HasGen[Long] with
+    def gen            = Gen.long
+    override def label = "HasGen[Long]"
+
+  given HasGen[Double] with
+    def gen            = Gen.double
+    override def label = "HasGen[Double]"
+
+  given HasGen[Boolean] with
+    def gen            = Gen.boolean
+    override def label = "HasGen[Boolean]"
+
+  given HasGen[String] with
+    def gen            = Gen.alphaNumericString
+    override def label = "HasGen[String]"
+
+  given HasGen[UUID] with
+    def gen            = Gen.uuid
+    override def label = "HasGen[UUID]"
+
+  // ── Named generator registry ─────────────────────────────────────────────
+
+  private val namedRegistry: TrieMap[String, HasGen[?]] = TrieMap.empty
+
+  /**
+   * Register a named generator override. Call this in your `ZIOSteps` companion
+   * object or object initialiser:
+   *
+   * {{{
+   * HasGen.named("smallAmounts")(Gen.double(0.01, 10.0).map(Money.apply))
+   * }}}
+   */
+  def named[A](name: String)(g: Gen[Any, A]): Unit =
+    namedRegistry.put(name, new HasGen[A] { def gen = g; override def label = name })
+
+  /** Summon a HasGen[A] from implicit scope. */
+  def apply[A](using hg: HasGen[A]): HasGen[A] = hg
+
+  /** Look up a named generator. Returns `None` if not registered. */
+  def resolve(name: String): Option[HasGen[?]] = namedRegistry.get(name)

--- a/core/src/main/scala/zio/bdd/core/property/HasGen.scala
+++ b/core/src/main/scala/zio/bdd/core/property/HasGen.scala
@@ -9,24 +9,18 @@ import scala.collection.concurrent.TrieMap
 /**
  * Typeclass that provides a ZIO Test `Gen[Any, A]` for a given type `A`.
  *
- * ==Resolution is by column name, not by type (for now)==
- * A `@property` column is just a string name parsed from the Gherkin header —
- * there is no automatic inference from a step's `TypedExtractor[T]` to a
- * `HasGen[T]`. Every property column, including ones using a built-in type
- * below, must be routed explicitly via `ZIOSteps#columnGenLookup` (see
- * `zio.bdd.core.property.ColumnGenLookup`) or a named override (see below).
- * Built-in instances exist for `Int`/`Long`/`Double`/`Boolean`/ `String`/`UUID`
- * so you don't need to write `Gen.int` etc. yourself, but you still need to
- * route the column name to `HasGen[Int]` (or whichever applies) in
- * `columnGenLookup`.
- *
- * The type-keyed registry below (`registerType`/`resolveByTag`) is the piece
- * that makes automatic by-type resolution possible — see
- * `StepRegistry.resolveTemplateColumns`, which finds the `Tag[_]` a column's
- * extractor produces. Wiring that into column resolution so `columnGenLookup`
- * becomes optional rather than mandatory is tracked separately; until then,
- * this paragraph's "must be routed explicitly" still describes the current
- * runtime behavior.
+ * ==Resolution order==
+ * A `@property` column resolves in this order: (1) a named header override (`|
+ * col: genName |`, see below), (2) the suite's `ZIOSteps#columnGenLookup` (see
+ * `zio.bdd.core.property.ColumnGenLookup`), (3) automatic type-based lookup —
+ * `PropertyExecutor` finds the `Tag[_]` the column's step extractor produces
+ * (via `StepRegistry.resolveTemplateColumns`) and resolves it through this
+ * object's type-keyed registry (`registerType`/`resolveByTag` below). The six
+ * built-in types (`Int`/`Long`/`Double`/`Boolean`/`String`/ `UUID`) are
+ * pre-registered, so columns of those types need no `columnGenLookup` entry at
+ * all. Domain types need one `registerType` call per *type* to get the same
+ * automatic resolution — `columnGenLookup` is then the override path, for when
+ * the automatic choice isn't the one you want.
  *
  * ==Named generator overrides==
  * Register a non-default generator for a column via
@@ -126,18 +120,26 @@ object HasGen:
     typeRegistry.put(summon[Tag[A]].tag, instance)
 
   /**
-   * Look up a registered `HasGen` by runtime type tag. `tag` is taken as a
-   * plain value (not a context bound) so this also accepts an existential
-   * `Tag[_]` — e.g. one of the `Tag[_]`s `StepRegistry.resolveTemplateColumns`
-   * returns, where the underlying type isn't statically known at the call site.
-   * Returns `None` if `A` is neither a built-in nor was registered via
+   * Look up a registered `HasGen` by runtime type tag.
+   *
+   * Takes an existential `Tag[_]` — e.g. one of the `Tag[_]`s
+   * `StepRegistry.resolveTemplateColumns` returns, where the underlying type
+   * isn't statically known at the call site — rather than a statically-typed
+   * `Tag[A]`. (`izumi.reflect.Tag[T <: AnyKind]`'s kind bound means a `Tag[?]`
+   * value doesn't actually unify with a `Tag[A]` parameter at a generic call
+   * site, since `A` there defaults to the narrower proper-type kind `*` — so
+   * the existential form is the one callers can actually use.) The returned
+   * `HasGen[?]` is erased the same way; callers that need it for sampling only
+   * use `.gen`/`.label`, neither of which needs the concrete type back.
+   *
+   * Returns `None` if the type is neither a built-in nor was registered via
    * `registerType`.
    */
-  def resolveByTag[A](tag: Tag[A]): Option[HasGen[A]] =
-    typeRegistry.get(tag.tag).asInstanceOf[Option[HasGen[A]]]
+  def resolveByTag(tag: Tag[?]): Option[HasGen[?]] =
+    typeRegistry.get(tag.tag)
 
   // Built-ins are usable by type with zero setup — pre-populate eagerly so
-  // resolveByTag[Int] etc. works without any suite ever calling registerType.
+  // resolveByTag(Tag[Int]) etc. works without any suite ever calling registerType.
   registerType(HasGen[Int])
   registerType(HasGen[Long])
   registerType(HasGen[Double])

--- a/core/src/main/scala/zio/bdd/core/property/HasGen.scala
+++ b/core/src/main/scala/zio/bdd/core/property/HasGen.scala
@@ -1,5 +1,6 @@
 package zio.bdd.core.property
 
+import izumi.reflect.Tag
 import zio.test.Gen
 
 import java.util.UUID
@@ -8,7 +9,7 @@ import scala.collection.concurrent.TrieMap
 /**
  * Typeclass that provides a ZIO Test `Gen[Any, A]` for a given type `A`.
  *
- * ==Resolution is by column name, not by type==
+ * ==Resolution is by column name, not by type (for now)==
  * A `@property` column is just a string name parsed from the Gherkin header —
  * there is no automatic inference from a step's `TypedExtractor[T]` to a
  * `HasGen[T]`. Every property column, including ones using a built-in type
@@ -18,6 +19,14 @@ import scala.collection.concurrent.TrieMap
  * so you don't need to write `Gen.int` etc. yourself, but you still need to
  * route the column name to `HasGen[Int]` (or whichever applies) in
  * `columnGenLookup`.
+ *
+ * The type-keyed registry below (`registerType`/`resolveByTag`) is the piece
+ * that makes automatic by-type resolution possible — see
+ * `StepRegistry.resolveTemplateColumns`, which finds the `Tag[_]` a column's
+ * extractor produces. Wiring that into column resolution so `columnGenLookup`
+ * becomes optional rather than mandatory is tracked separately; until then,
+ * this paragraph's "must be routed explicitly" still describes the current
+ * runtime behavior.
  *
  * ==Named generator overrides==
  * Register a non-default generator for a column via
@@ -85,3 +94,53 @@ object HasGen:
 
   /** Look up a named generator. Returns `None` if not registered. */
   def resolve(name: String): Option[HasGen[?]] = namedRegistry.get(name)
+
+  // ── Type-keyed registry ──────────────────────────────────────────────────
+  //
+  // Mirrors zio.bdd.core.step.TypeMap: keyed by the same `Tag[A].tag` (the
+  // underlying LightTypeTag) izumi-reflect uses for its own equality/hashing,
+  // so two `Tag[A]` instances for the same `A` — summoned independently, e.g.
+  // one here and one from StepRegistry.resolveTemplateColumns — look up the
+  // same entry. TrieMap gives lock-free concurrent reads and writes, matching
+  // `namedRegistry` above; registration normally happens once at startup
+  // (object init for built-ins, a suite's object initializer for custom
+  // types), but nothing here assumes that — concurrent registerType/resolveByTag
+  // calls from parallel scenario fibers are safe.
+
+  private val typeRegistry: TrieMap[Any, HasGen[?]] = TrieMap.empty
+
+  /**
+   * Register a `HasGen[A]` so it can be looked up later by its runtime `Tag[A]`
+   * — once per ''type'', not per column name. Scala cannot enumerate arbitrary
+   * `given HasGen[_]` instances at runtime, so types beyond the six built-ins
+   * below need this one-time call (e.g. in a suite's companion object or object
+   * initializer):
+   *
+   * {{{
+   * given HasGen[Money] with
+   *   def gen = Gen.double(0, 10_000).map(Money.apply)
+   * HasGen.registerType(HasGen[Money])
+   * }}}
+   */
+  def registerType[A: Tag](instance: HasGen[A]): Unit =
+    typeRegistry.put(summon[Tag[A]].tag, instance)
+
+  /**
+   * Look up a registered `HasGen` by runtime type tag. `tag` is taken as a
+   * plain value (not a context bound) so this also accepts an existential
+   * `Tag[_]` — e.g. one of the `Tag[_]`s `StepRegistry.resolveTemplateColumns`
+   * returns, where the underlying type isn't statically known at the call site.
+   * Returns `None` if `A` is neither a built-in nor was registered via
+   * `registerType`.
+   */
+  def resolveByTag[A](tag: Tag[A]): Option[HasGen[A]] =
+    typeRegistry.get(tag.tag).asInstanceOf[Option[HasGen[A]]]
+
+  // Built-ins are usable by type with zero setup — pre-populate eagerly so
+  // resolveByTag[Int] etc. works without any suite ever calling registerType.
+  registerType(HasGen[Int])
+  registerType(HasGen[Long])
+  registerType(HasGen[Double])
+  registerType(HasGen[Boolean])
+  registerType(HasGen[String])
+  registerType(HasGen[UUID])

--- a/core/src/main/scala/zio/bdd/core/property/PropertyExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/property/PropertyExecutor.scala
@@ -28,11 +28,22 @@ object PropertyExecutor:
 
   case class ColumnGen(name: String, gen: Gen[Any, Any], label: String)
 
+  /**
+   * Separator between `col=val (gen)` entries in a `[counterexample]` step
+   * pattern. A plain comma would be ambiguous — a domain type's default
+   * `toString` (e.g. a case class) commonly contains one (`Address(Main
+   * St,London)`) — so this uses a token vanishingly unlikely to appear in
+   * generated text instead of escaping (and thus visually mangling) the values.
+   * `PrettyReporter.counterexampleTable` splits on this same separator.
+   */
+  val counterexampleEntrySep = " ‖ "
+
   def run[R: Tag, S: Tag: Default](
     scenario: Scenario,
     suite: ZIOSteps[R, S],
     genLookup: ColumnGenLookup,
-    flags: Map[String, String] = Map.empty
+    flags: Map[String, String] = Map.empty,
+    dryRun: Boolean = false
   ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
     scenario.propertyConfig match
       case None =>
@@ -50,26 +61,63 @@ object PropertyExecutor:
           )
         )
       case Some(config) =>
-        runProperty(scenario, config, suite, genLookup, flags)
+        runProperty(scenario, config, suite, genLookup, flags, dryRun)
 
   private def runProperty[R: Tag, S: Tag: Default](
     scenario: Scenario,
     config: PropertyTag.PropertyConfig,
     suite: ZIOSteps[R, S],
     lookup: ColumnGenLookup,
-    flags: Map[String, String]
+    flags: Map[String, String],
+    dryRun: Boolean
   ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
     resolveColumnGens(scenario, lookup).flatMap {
       case Left(err) =>
         ZIO.succeed(ScenarioResult(scenario, Nil, setupError = Some(Cause.fail(new RuntimeException(err)))))
       case Right(colGens) =>
-        for {
-          seed      <- config.seed.map(ZIO.succeed).getOrElse(Random.nextLong)
-          replayRec <- if (config.replay) PropertyFailureStore.read(scenario) else ZIO.none
-          result <- replayRec match
-                      case Some(rec) => handleReplay(scenario, config, suite, colGens, rec, seed, flags)
-                      case None      => runFreshSamples(scenario, config, suite, colGens, seed, flags)
-        } yield result
+        if (dryRun)
+          // --dry-run validates step matching without executing step bodies. Sampling the
+          // configured `samples` count for real would defeat that — instead, validate column
+          // resolution (already done above) and run exactly one dry-run sample to confirm
+          // every step pattern matches, without looping or touching the failure store.
+          runDryRunSample(scenario, suite, colGens, flags)
+        else
+          for {
+            seed      <- config.seed.map(ZIO.succeed).getOrElse(Random.nextLong)
+            replayRec <- if (config.replay) PropertyFailureStore.read(scenario) else ZIO.none
+            result <- replayRec match
+                        case Some(rec) => handleReplay(scenario, config, suite, colGens, rec, seed, flags)
+                        case None      => runFreshSamples(scenario, config, suite, colGens, seed, flags)
+          } yield result
+    }
+
+  private def runDryRunSample[R: Tag, S: Tag: Default](
+    scenario: Scenario,
+    suite: ZIOSteps[R, S],
+    colGens: List[ColumnGen],
+    flags: Map[String, String]
+  ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
+    sampleColumnValues(colGens, seed = 0L, sampleIdx = 0).flatMap { colValues =>
+      val substituted = substituteSteps(scenario, colValues.toMap)
+      val meta        = zio.bdd.gherkin.ScenarioMetadata.from(substituted, flags)
+      val layer       = if (flags.isEmpty) suite.scenarioLayer(meta) else suite.flagLayer(meta, flags)
+      ScenarioExecutor
+        .executeScenario[R, S](substituted, suite, dryRun = true, flagValues = flags)
+        .provideSomeLayer[R & StepRegistry[R, S]](layer.orDie)
+        .map { result =>
+          val genSummary = colGens.map(cg => s"${cg.name} (${cg.label})").mkString(", ")
+          val summaryStep = Step(
+            stepType = StepType.GivenStep,
+            pattern = s"[property] dry-run: step patterns validated — generators: $genSummary"
+          )
+          result.copy(
+            // stableId preserves the pre-rename id so logs collected during this run (tagged
+            // with the original scenario id by FeatureExecutor's logAnnotate, before this
+            // rename happens) are still found by reporters looking up by `scenario.id`.
+            scenario = scenario.copy(name = s"${scenario.name} [dry-run]", stableId = Some(scenario.id)),
+            stepResults = StepResult(summaryStep, Right(())) +: result.stepResults
+          )
+        }
     }
 
   private def handleReplay[R: Tag, S: Tag: Default](
@@ -173,7 +221,8 @@ object PropertyExecutor:
       pattern = s"[property] $label — generators: $genSummary"
     )
     ScenarioResult(
-      scenario = scenario.copy(name = s"${scenario.name} [$label]"),
+      // stableId: see the matching comment in runDryRunSample.
+      scenario = scenario.copy(name = s"${scenario.name} [$label]", stableId = Some(scenario.id)),
       stepResults = List(StepResult(summaryStep, Right(())))
     )
 
@@ -205,10 +254,16 @@ object PropertyExecutor:
     val replayNote = if (isReplay) " [replayed from failure store]" else ""
     val summary    = s"Falsified after ${sampleIndex + 1} samples (seed=$seed)$replayNote"
 
+    // Column values are arbitrary user-generated strings — a domain type's default toString
+    // (e.g. a case class: `Address(Main St,London)`) commonly contains a literal comma, which
+    // would make a plain ", "-joined list ambiguous to split back into entries. `entrySep` is
+    // a token vanishingly unlikely to appear in generated text, so entries split unambiguously
+    // without needing to escape (and thus visually mangle) the values themselves; kept in sync
+    // with PrettyReporter.counterexampleTable, which parses this exact format.
     val counterexampleLabel = shrunkValues.toList
       .sortBy(_._1)
       .map { case (col, v) => s"$col=$v (${generatorLabels.getOrElse(col, "?")})" }
-      .mkString(", ")
+      .mkString(PropertyExecutor.counterexampleEntrySep)
     val counterexampleStep = Step(
       stepType = StepType.GivenStep,
       pattern = s"[counterexample] $counterexampleLabel"
@@ -225,7 +280,8 @@ object PropertyExecutor:
     )
 
     originalResult.copy(
-      scenario = scenario.copy(name = s"${scenario.name} [seed=$seed]"),
+      // stableId: see the matching comment in runDryRunSample.
+      scenario = scenario.copy(name = s"${scenario.name} [seed=$seed]", stableId = Some(scenario.id)),
       stepResults = counterexampleResult +: originalResult.stepResults,
       // Error is now carried by the first StepResult, not setupError.
       // ScenarioResult.error already walks stepResults first, so this is consistent.
@@ -263,18 +319,28 @@ object PropertyExecutor:
 
   /**
    * Sample one string value per column using the column's `Gen`, seeded
-   * deterministically using `seed XOR sampleIndex` so each sample in a run is
-   * distinct while remaining reproducible.
+   * deterministically from `(seed, sampleIndex, columnIndex)` so each sample in
+   * a run is distinct, each column within a sample is independent — even when
+   * two columns share the exact same `Gen` (e.g. two `HasGen[Int]` columns must
+   * not always be equal) — while the whole run remains reproducible from `seed`
+   * alone.
    */
   private def sampleColumnValues(
     colGens: List[ColumnGen],
     seed: Long,
     sampleIdx: Int
   ): UIO[List[(String, String)]] =
-    ZIO.foreach(colGens) { cg =>
-      val itemSeed = seed ^ (sampleIdx.toLong * 6364136223846793005L + 1442695040888963407L)
-      sampleGenToString(cg.gen, itemSeed).map(v => cg.name -> v)
+    ZIO.foreach(colGens.zipWithIndex) { case (cg, colIdx) =>
+      sampleGenToString(cg.gen, mixSeed(seed, sampleIdx, colIdx)).map(v => cg.name -> v)
     }
+
+  /**
+   * Mix the property seed with the sample and column index into one
+   * well-distributed seed.
+   */
+  private def mixSeed(seed: Long, sampleIdx: Int, colIdx: Int): Long =
+    val bySample = seed ^ (sampleIdx.toLong * 6364136223846793005L + 1442695040888963407L)
+    bySample ^ (colIdx.toLong * 2685821657736338717L + 1L)
 
   private def sampleGenToString(gen: Gen[Any, Any], seed: Long): UIO[String] =
     (for {

--- a/core/src/main/scala/zio/bdd/core/property/PropertyExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/property/PropertyExecutor.scala
@@ -31,7 +31,8 @@ object PropertyExecutor:
   def run[R: Tag, S: Tag: Default](
     scenario: Scenario,
     suite: ZIOSteps[R, S],
-    genLookup: ColumnGenLookup
+    genLookup: ColumnGenLookup,
+    flags: Map[String, String] = Map.empty
   ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
     scenario.propertyConfig match
       case None =>
@@ -49,13 +50,14 @@ object PropertyExecutor:
           )
         )
       case Some(config) =>
-        runProperty(scenario, config, suite, genLookup)
+        runProperty(scenario, config, suite, genLookup, flags)
 
   private def runProperty[R: Tag, S: Tag: Default](
     scenario: Scenario,
     config: PropertyTag.PropertyConfig,
     suite: ZIOSteps[R, S],
-    lookup: ColumnGenLookup
+    lookup: ColumnGenLookup,
+    flags: Map[String, String]
   ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
     resolveColumnGens(scenario, lookup).flatMap {
       case Left(err) =>
@@ -65,8 +67,8 @@ object PropertyExecutor:
           seed      <- config.seed.map(ZIO.succeed).getOrElse(Random.nextLong)
           replayRec <- if (config.replay) PropertyFailureStore.read(scenario) else ZIO.none
           result <- replayRec match
-                      case Some(rec) => handleReplay(scenario, config, suite, colGens, rec, seed)
-                      case None      => runFreshSamples(scenario, config, suite, colGens, seed)
+                      case Some(rec) => handleReplay(scenario, config, suite, colGens, rec, seed, flags)
+                      case None      => runFreshSamples(scenario, config, suite, colGens, seed, flags)
         } yield result
     }
 
@@ -76,15 +78,16 @@ object PropertyExecutor:
     suite: ZIOSteps[R, S],
     colGens: List[ColumnGen],
     rec: PropertyFailureStore.FailureRecord,
-    freshSeed: Long
+    freshSeed: Long,
+    flags: Map[String, String]
   ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
     val replayValues = colGens.map(cg => cg.name -> rec.shrunkValues.getOrElse(cg.name, ""))
-    runOneSample(scenario, suite, replayValues).flatMap {
+    runOneSample(scenario, suite, replayValues, flags).flatMap {
       case None =>
         // The previously-falsifying sample now passes — the bug is fixed. Clear the stale
         // failure record and proceed with a full fresh batch of samples instead of just
         // reporting the one-sample replay as the whole scenario result.
-        PropertyFailureStore.clear(scenario) *> runFreshSamples(scenario, config, suite, colGens, freshSeed)
+        PropertyFailureStore.clear(scenario) *> runFreshSamples(scenario, config, suite, colGens, freshSeed, flags)
       case Some(failResult) =>
         // Still failing
         ZIO.succeed(
@@ -105,7 +108,8 @@ object PropertyExecutor:
     config: PropertyTag.PropertyConfig,
     suite: ZIOSteps[R, S],
     colGens: List[ColumnGen],
-    seed: Long
+    seed: Long,
+    flags: Map[String, String]
   ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
     ZIO.logAnnotate("propertyScenario", scenario.name) {
       // Run up to `config.samples` iterations. Short-circuit on first failure.
@@ -114,7 +118,7 @@ object PropertyExecutor:
         .iterate((0, Option.empty[ScenarioResult]))(s => s._2.isEmpty && s._1 < config.samples) { s =>
           val idx = s._1
           sampleColumnValues(colGens, seed, idx).flatMap { colValues =>
-            runOneSample(scenario, suite, colValues).flatMap {
+            runOneSample(scenario, suite, colValues, flags).flatMap {
               case None =>
                 ZIO.succeed((idx + 1, None))
               case Some(failResult) =>
@@ -234,13 +238,15 @@ object PropertyExecutor:
   private def runOneSample[R: Tag, S: Tag: Default](
     scenario: Scenario,
     suite: ZIOSteps[R, S],
-    colValues: List[(String, String)]
+    colValues: List[(String, String)],
+    flags: Map[String, String]
   ): ZIO[R & StepRegistry[R, S], Nothing, Option[ScenarioResult]] =
     val substituted = substituteSteps(scenario, colValues.toMap)
-    val meta        = zio.bdd.gherkin.ScenarioMetadata.from(substituted)
+    val meta        = zio.bdd.gherkin.ScenarioMetadata.from(substituted, flags)
+    val layer       = if (flags.isEmpty) suite.scenarioLayer(meta) else suite.flagLayer(meta, flags)
     ScenarioExecutor
-      .executeScenario[R, S](substituted, suite)
-      .provideSomeLayer[R & StepRegistry[R, S]](suite.scenarioLayer(meta).orDie)
+      .executeScenario[R, S](substituted, suite, flagValues = flags)
+      .provideSomeLayer[R & StepRegistry[R, S]](layer.orDie)
       .map(result => if (result.isPassed) None else Some(result))
 
   /** Substitute `<placeholder>` in step patterns with sampled string values. */

--- a/core/src/main/scala/zio/bdd/core/property/PropertyExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/property/PropertyExecutor.scala
@@ -414,11 +414,13 @@ object PropertyExecutor:
    * Tag-keyed registry. Only the steps mentioning one of `columns` are
    * structurally matched.
    */
+  private def mentionsColumn(step: Step, col: String): Boolean = step.pattern.contains(s"<$col>")
+
   private def resolveByType[R: Tag, S: Tag](
     scenario: Scenario,
     columns: Set[String]
   ): URIO[StepRegistry[R, S], Map[String, Either[String, HasGen[?]]]] = {
-    val relevantSteps = scenario.steps.filter(step => columns.exists(col => step.pattern.contains(s"<$col>")))
+    val relevantSteps = scenario.steps.filter(step => columns.exists(mentionsColumn(step, _)))
     ZIO
       .foreach(relevantSteps) { step =>
         StepRegistry.resolveTemplateColumns[R, S](step.stepType, step.pattern).either.map(step -> _)
@@ -432,10 +434,13 @@ object PropertyExecutor:
     col: String,
     perStep: List[(Step, Either[TemplateLookupError, List[(String, Tag[?])]])]
   ): Either[String, HasGen[?]] = {
-    val mentions = perStep.filter { case (step, _) => step.pattern.contains(s"<$col>") }
+    val mentions = perStep.filter { case (step, _) => mentionsColumn(step, col) }
+    // Distinct: the same step can legitimately mention `col` more than once (the same
+    // sampled value substitutes into every occurrence), which would otherwise duplicate
+    // entries here without indicating any real conflict.
     val seen: List[(Tag[?], String)] = mentions.collect { case (step, Right(cols)) =>
       cols.collect { case (name, tag) if name == col => tag -> step.pattern }
-    }.flatten
+    }.flatten.distinct
     val distinctTags = seen.map(_._1).distinct
 
     distinctTags match {
@@ -468,9 +473,11 @@ object PropertyExecutor:
 
   /**
    * Render a Tag's underlying type name for error messages, e.g. `Tag[Money]`
-   * -> `"Money"`.
+   * -> `"Money"`. `tag.tag` is the underlying `LightTypeTag`, whose own
+   * `toString` already renders just the type name — more robust than parsing
+   * `Tag.toString`'s `"Tag[...]"` wrapper.
    */
-  private def typeName(tag: Tag[?]): String = tag.toString.stripPrefix("Tag[").stripSuffix("]")
+  private def typeName(tag: Tag[?]): String = tag.tag.toString
 
 /**
  * Thrown when a property scenario is falsified. Message contains the

--- a/core/src/main/scala/zio/bdd/core/property/PropertyExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/property/PropertyExecutor.scala
@@ -65,10 +65,8 @@ object PropertyExecutor:
           seed      <- config.seed.map(ZIO.succeed).getOrElse(Random.nextLong)
           replayRec <- if (config.replay) PropertyFailureStore.read(scenario) else ZIO.none
           result <- replayRec match
-                      case Some(rec) if rec.bodyHash == PropertyFailureStore.bodyHash(scenario) =>
-                        handleReplay(scenario, config, suite, colGens, rec, seed)
-                      case _ =>
-                        runFreshSamples(scenario, config, suite, colGens, seed)
+                      case Some(rec) => handleReplay(scenario, config, suite, colGens, rec, seed)
+                      case None      => runFreshSamples(scenario, config, suite, colGens, seed)
         } yield result
     }
 
@@ -81,19 +79,24 @@ object PropertyExecutor:
     freshSeed: Long
   ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
     val replayValues = colGens.map(cg => cg.name -> rec.shrunkValues.getOrElse(cg.name, ""))
-    runOneSample(scenario, suite, replayValues).map {
+    runOneSample(scenario, suite, replayValues).flatMap {
       case None =>
-        buildPassResult(scenario, rec.seed, sampleCount = 0, colGens, replayPassed = true)
+        // The previously-falsifying sample now passes — the bug is fixed. Clear the stale
+        // failure record and proceed with a full fresh batch of samples instead of just
+        // reporting the one-sample replay as the whole scenario result.
+        PropertyFailureStore.clear(scenario) *> runFreshSamples(scenario, config, suite, colGens, freshSeed)
       case Some(failResult) =>
         // Still failing
-        buildFailureResult(
-          scenario = scenario,
-          seed = rec.seed,
-          sampleIndex = rec.sampleIndex,
-          shrunkValues = rec.shrunkValues,
-          generatorLabels = colGens.map(cg => cg.name -> cg.label).toMap,
-          originalResult = failResult,
-          isReplay = true
+        ZIO.succeed(
+          buildFailureResult(
+            scenario = scenario,
+            seed = rec.seed,
+            sampleIndex = rec.sampleIndex,
+            shrunkValues = rec.shrunkValues,
+            generatorLabels = colGens.map(cg => cg.name -> cg.label).toMap,
+            originalResult = failResult,
+            isReplay = true
+          )
         )
     }
 
@@ -157,13 +160,10 @@ object PropertyExecutor:
     scenario: Scenario,
     seed: Long,
     sampleCount: Int,
-    colGens: List[ColumnGen],
-    replayPassed: Boolean = false
+    colGens: List[ColumnGen]
   ): ScenarioResult =
     val genSummary = colGens.map(cg => s"${cg.name} (${cg.label})").mkString(", ")
-    val label =
-      if (replayPassed) s"replay passed (seed=$seed)"
-      else s"$sampleCount samples passed, seed=$seed"
+    val label      = s"$sampleCount samples passed, seed=$seed"
     val summaryStep = Step(
       stepType = StepType.GivenStep,
       pattern = s"[property] $label — generators: $genSummary"

--- a/core/src/main/scala/zio/bdd/core/property/PropertyExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/property/PropertyExecutor.scala
@@ -29,6 +29,30 @@ object PropertyExecutor:
   case class ColumnGen(name: String, gen: Gen[Any, Any], label: String)
 
   /**
+   * What running one sample produced — distinguishes a genuine property
+   * falsification from an infrastructure problem (a failing `beforeScenario`
+   * hook, an unimplemented/`@pending` step) that happened to occur while
+   * running a sample.
+   *
+   * This distinction matters because `Errored` results must NOT be persisted to
+   * `PropertyFailureStore` or rendered as a `[counterexample]` — doing so would
+   * misreport "the environment is broken" or "this step isn't implemented yet"
+   * as "this property is falsified by these generated values", which is a
+   * different (and misleading) claim. See the regression tests in
+   * `PropertyExecutorSpec` for both failure modes.
+   */
+  private enum SampleOutcome:
+    case Passed
+    case Falsified(result: ScenarioResult)
+    case Errored(result: ScenarioResult)
+
+  private object SampleOutcome:
+    def from(result: ScenarioResult): SampleOutcome =
+      if (result.isPassed) Passed
+      else if (result.setupError.isDefined || result.hasPending) Errored(result)
+      else Falsified(result)
+
+  /**
    * Separator between `col=val (gen)` entries in a `[counterexample]` step
    * pattern. A plain comma would be ambiguous — a domain type's default
    * `toString` (e.g. a case class) commonly contains one (`Address(Main
@@ -131,13 +155,13 @@ object PropertyExecutor:
   ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
     val replayValues = colGens.map(cg => cg.name -> rec.shrunkValues.getOrElse(cg.name, ""))
     runOneSample(scenario, suite, replayValues, flags).flatMap {
-      case None =>
+      case SampleOutcome.Passed =>
         // The previously-falsifying sample now passes — the bug is fixed. Clear the stale
         // failure record and proceed with a full fresh batch of samples instead of just
         // reporting the one-sample replay as the whole scenario result.
         PropertyFailureStore.clear(scenario) *> runFreshSamples(scenario, config, suite, colGens, freshSeed, flags)
-      case Some(failResult) =>
-        // Still failing
+      case SampleOutcome.Falsified(failResult) =>
+        // Still failing the same way.
         ZIO.succeed(
           buildFailureResult(
             scenario = scenario,
@@ -149,6 +173,12 @@ object PropertyExecutor:
             isReplay = true
           )
         )
+      case SampleOutcome.Errored(result) =>
+        // The replay run hit a setup error or a pending step, not the original falsification —
+        // that's an infra/environment problem, not evidence the bug still reproduces (or
+        // doesn't). Surface it as-is and leave the failure record untouched so a later run can
+        // still attempt the real replay once the environment/step is fixed.
+        ZIO.succeed(result)
     }
 
   private def runFreshSamples[R: Tag, S: Tag: Default](
@@ -160,16 +190,20 @@ object PropertyExecutor:
     flags: Map[String, String]
   ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
     ZIO.logAnnotate("propertyScenario", scenario.name) {
-      // Run up to `config.samples` iterations. Short-circuit on first failure.
-      // State is (sampleIndex, Option[failResult]); we stop when failResult is Some.
+      // Run up to `config.samples` iterations. Short-circuit on the first non-Passed
+      // outcome. State is (sampleIndex, Option[terminal result]); we stop once that's Some —
+      // for either a genuine falsification (persisted to the failure store, wrapped as a
+      // [counterexample]) or an infra error (surfaced as-is, NOT persisted — see SampleOutcome).
       ZIO
         .iterate((0, Option.empty[ScenarioResult]))(s => s._2.isEmpty && s._1 < config.samples) { s =>
           val idx = s._1
           sampleColumnValues(colGens, seed, idx).flatMap { colValues =>
             runOneSample(scenario, suite, colValues, flags).flatMap {
-              case None =>
+              case SampleOutcome.Passed =>
                 ZIO.succeed((idx + 1, None))
-              case Some(failResult) =>
+              case SampleOutcome.Errored(result) =>
+                ZIO.succeed((idx + 1, Some(result)))
+              case SampleOutcome.Falsified(failResult) =>
                 val shrunkValues    = colValues.toMap
                 val generatorLabels = colGens.map(cg => cg.name -> cg.label).toMap
                 PropertyFailureStore
@@ -195,8 +229,8 @@ object PropertyExecutor:
         }
         .map { s =>
           s._2 match {
-            case Some(failResult) => failResult
-            case None             => buildPassResult(scenario, seed, s._1, colGens)
+            case Some(terminalResult) => terminalResult
+            case None                 => buildPassResult(scenario, seed, s._1, colGens)
           }
         }
     }
@@ -296,14 +330,14 @@ object PropertyExecutor:
     suite: ZIOSteps[R, S],
     colValues: List[(String, String)],
     flags: Map[String, String]
-  ): ZIO[R & StepRegistry[R, S], Nothing, Option[ScenarioResult]] =
+  ): ZIO[R & StepRegistry[R, S], Nothing, SampleOutcome] =
     val substituted = substituteSteps(scenario, colValues.toMap)
     val meta        = zio.bdd.gherkin.ScenarioMetadata.from(substituted, flags)
     val layer       = if (flags.isEmpty) suite.scenarioLayer(meta) else suite.flagLayer(meta, flags)
     ScenarioExecutor
       .executeScenario[R, S](substituted, suite, flagValues = flags)
       .provideSomeLayer[R & StepRegistry[R, S]](layer.orDie)
-      .map(result => if (result.isPassed) None else Some(result))
+      .map(SampleOutcome.from)
 
   /** Substitute `<placeholder>` in step patterns with sampled string values. */
   private def substituteSteps(scenario: Scenario, values: Map[String, String]): Scenario =
@@ -375,19 +409,40 @@ object PropertyExecutor:
       placeholderRe.findAllMatchIn(step.pattern).map(_.group(1)).toList
     }.distinct
 
-    def explicit(col: String): Option[HasGen[?]] =
-      scenario.columnGens.get(col).flatMap(HasGen.resolve).orElse(lookup.byColumn(col))
+    // A named header override (`| col: genName |`) that doesn't resolve against HasGen's
+    // named registry is a setup error, not a silent fall-through to tiers 2-3 — falling
+    // through would let a typo'd generator name go unnoticed and quietly resolve to a
+    // *different* generator (columnGenLookup's, or the automatic by-type one) instead of
+    // erroring, which defeats the point of naming an override at all.
+    def explicit(col: String): Either[String, Option[HasGen[?]]] =
+      scenario.columnGens.get(col) match
+        case Some(genName) =>
+          HasGen
+            .resolve(genName)
+            .map(hg => Some(hg))
+            .toRight(
+              s"Column '$col' specifies generator '$genName' via header override " +
+                s"(`| $col: $genName |`), but no generator is registered under that name. " +
+                s"""Register it with `HasGen.named("$genName")(...)`."""
+            )
+        case None => Right(lookup.byColumn(col))
+
+    val explicitOutcomes: Map[String, Either[String, Option[HasGen[?]]]] =
+      allPlaceholders.map(col => col -> explicit(col)).toMap
+
+    val namedOverrideErrors: List[String] = explicitOutcomes.values.collect { case Left(e) => e }.toList
+    val erroredCols: Set[String]          = explicitOutcomes.collect { case (col, Left(_)) => col }.toSet
 
     val explicitResolved: Map[String, HasGen[?]] =
-      allPlaceholders.flatMap(col => explicit(col).map(col -> _)).toMap
-    val unresolved = allPlaceholders.filterNot(explicitResolved.contains)
+      explicitOutcomes.collect { case (col, Right(Some(hg))) => col -> hg }
+    val unresolved = allPlaceholders.filterNot(col => explicitResolved.contains(col) || erroredCols.contains(col))
 
     val byType: URIO[StepRegistry[R, S], Map[String, Either[String, HasGen[?]]]] =
       if (unresolved.isEmpty) ZIO.succeed(Map.empty)
       else resolveByType[R, S](scenario, unresolved.toSet)
 
     byType.map { byTypeResolved =>
-      val resolved = allPlaceholders.map { col =>
+      val resolved = allPlaceholders.filterNot(erroredCols.contains).map { col =>
         explicitResolved
           .get(col)
           .map(Right(_))
@@ -399,7 +454,8 @@ object PropertyExecutor:
           )
           .map(hg => col -> hg)
       }
-      val errors = resolved.collect { case Left(e) => e }
+      val tierErrors = resolved.collect { case Left(e) => e }
+      val errors     = namedOverrideErrors ++ tierErrors
       if (errors.nonEmpty) Left(errors.mkString("; "))
       else
         Right(resolved.collect { case Right((col, hg)) =>

--- a/core/src/main/scala/zio/bdd/core/property/PropertyExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/property/PropertyExecutor.scala
@@ -2,7 +2,7 @@ package zio.bdd.core.property
 
 import izumi.reflect.Tag
 import zio.*
-import zio.bdd.core.step.{StepRegistry, ZIOSteps}
+import zio.bdd.core.step.{StepRegistry, TemplateLookupError, ZIOSteps}
 import zio.bdd.core.{Default, ScenarioExecutor, ScenarioResult, StepResult}
 import zio.bdd.gherkin.{PropertyTag, Scenario, Step, StepType}
 import zio.test.{Gen, Sized, TestRandom}
@@ -71,7 +71,7 @@ object PropertyExecutor:
     flags: Map[String, String],
     dryRun: Boolean
   ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
-    resolveColumnGens(scenario, lookup).flatMap {
+    resolveColumnGens[R, S](scenario, lookup).flatMap {
       case Left(err) =>
         ZIO.succeed(ScenarioResult(scenario, Nil, setupError = Some(Cause.fail(new RuntimeException(err)))))
       case Right(colGens) =>
@@ -350,27 +350,127 @@ object PropertyExecutor:
       .provideLayer(Sized.default ++ TestRandom.deterministic)
 
   // ── Column generator resolution ──────────────────────────────────────────
+  //
+  // Resolution order for each `<col>` placeholder:
+  //   1. Named override from the column header (`| col: genName |`)
+  //   2. The suite's explicit `columnGenLookup`
+  //   3. Automatic type-based lookup: find the Tag[_] the column's extractor
+  //      produces (StepRegistry.resolveTemplateColumns, #97) and resolve it via
+  //      HasGen.resolveByTag (#98)
+  //   4. Setup error
+  //
+  // Tiers 1-2 are pure (no StepRegistry needed). Tier 3 only runs for columns
+  // still unresolved after 1-2, and only queries StepRegistry for steps that
+  // actually mention one of those columns — a suite that already wires every
+  // column explicitly (tiers 1-2 resolve everything) never touches tier 3 at
+  // all, so existing fully-explicit suites see zero behavior or performance
+  // change.
 
-  private def resolveColumnGens(
+  private def resolveColumnGens[R: Tag, S: Tag](
     scenario: Scenario,
     lookup: ColumnGenLookup
-  ): UIO[Either[String, List[ColumnGen]]] =
-    ZIO.succeed {
-      val placeholderRe = "<([^>]+)>".r
-      val allPlaceholders = scenario.steps.flatMap { step =>
-        placeholderRe.findAllMatchIn(step.pattern).map(_.group(1)).toList
-      }.distinct
+  ): URIO[StepRegistry[R, S], Either[String, List[ColumnGen]]] = {
+    val placeholderRe = "<([^>]+)>".r
+    val allPlaceholders = scenario.steps.flatMap { step =>
+      placeholderRe.findAllMatchIn(step.pattern).map(_.group(1)).toList
+    }.distinct
 
+    def explicit(col: String): Option[HasGen[?]] =
+      scenario.columnGens.get(col).flatMap(HasGen.resolve).orElse(lookup.byColumn(col))
+
+    val explicitResolved: Map[String, HasGen[?]] =
+      allPlaceholders.flatMap(col => explicit(col).map(col -> _)).toMap
+    val unresolved = allPlaceholders.filterNot(explicitResolved.contains)
+
+    val byType: URIO[StepRegistry[R, S], Map[String, Either[String, HasGen[?]]]] =
+      if (unresolved.isEmpty) ZIO.succeed(Map.empty)
+      else resolveByType[R, S](scenario, unresolved.toSet)
+
+    byType.map { byTypeResolved =>
       val resolved = allPlaceholders.map { col =>
-        val namedGen = scenario.columnGens.get(col).flatMap(HasGen.resolve)
-        namedGen.orElse(lookup.byColumn(col)) match
-          case Some(hg) => Right(ColumnGen(col, hg.gen.asInstanceOf[Gen[Any, Any]], hg.label))
-          case None     => Left(s"No HasGen registered for column '$col'. Register `given HasGen[T]` for its type.")
+        explicitResolved
+          .get(col)
+          .map(Right(_))
+          .getOrElse(
+            byTypeResolved.getOrElse(
+              col,
+              Left(s"No HasGen registered for column '$col'. Register `given HasGen[T]` for its type.")
+            )
+          )
+          .map(hg => col -> hg)
       }
       val errors = resolved.collect { case Left(e) => e }
       if (errors.nonEmpty) Left(errors.mkString("; "))
-      else Right(resolved.collect { case Right(cg) => cg })
+      else
+        Right(resolved.collect { case Right((col, hg)) =>
+          ColumnGen(col, hg.gen.asInstanceOf[Gen[Any, Any]], hg.label)
+        })
     }
+  }
+
+  /**
+   * Tier 3: resolve `columns` by inferring each one's type from the step
+   * extractor that governs it, then looking that type up in `HasGen`'s
+   * Tag-keyed registry. Only the steps mentioning one of `columns` are
+   * structurally matched.
+   */
+  private def resolveByType[R: Tag, S: Tag](
+    scenario: Scenario,
+    columns: Set[String]
+  ): URIO[StepRegistry[R, S], Map[String, Either[String, HasGen[?]]]] = {
+    val relevantSteps = scenario.steps.filter(step => columns.exists(col => step.pattern.contains(s"<$col>")))
+    ZIO
+      .foreach(relevantSteps) { step =>
+        StepRegistry.resolveTemplateColumns[R, S](step.stepType, step.pattern).either.map(step -> _)
+      }
+      .map { perStep =>
+        columns.toList.map(col => col -> resolveOneColumnByType(col, perStep)).toMap
+      }
+  }
+
+  private def resolveOneColumnByType(
+    col: String,
+    perStep: List[(Step, Either[TemplateLookupError, List[(String, Tag[?])]])]
+  ): Either[String, HasGen[?]] = {
+    val mentions = perStep.filter { case (step, _) => step.pattern.contains(s"<$col>") }
+    val seen: List[(Tag[?], String)] = mentions.collect { case (step, Right(cols)) =>
+      cols.collect { case (name, tag) if name == col => tag -> step.pattern }
+    }.flatten
+    val distinctTags = seen.map(_._1).distinct
+
+    distinctTags match {
+      case Nil =>
+        // No step told us this column's type — surface why, preferring the most direct cause.
+        val message = mentions.collectFirst { case (step, Left(err)) =>
+          s"Column '$col': could not determine its type from step \"${step.pattern}\" (${err.toException.getMessage})."
+        }
+          .getOrElse(s"No HasGen registered for column '$col'. Register `given HasGen[T]` for its type.")
+        Left(message)
+      case tag :: Nil =>
+        HasGen.resolveByTag(tag) match {
+          case Some(hg) => Right(hg)
+          case None =>
+            val name = typeName(tag)
+            Left(
+              s"Column '$col' was inferred as $name (from its step's extractor) but no HasGen is " +
+                s"registered for that type. Register one via `given HasGen[$name] with ...` then " +
+                s"`HasGen.registerType(HasGen[$name])`, or add an explicit `columnGenLookup` entry for '$col'."
+            )
+        }
+      case _ =>
+        val detail = seen.map { case (tag, pattern) => s"${typeName(tag)} (from \"$pattern\")" }.mkString(", ")
+        Left(
+          s"Column '$col' has conflicting inferred types across steps: $detail. " +
+            "Use `columnGenLookup` to disambiguate."
+        )
+    }
+  }
+
+  /**
+   * Render a Tag's underlying type name for error messages, e.g. `Tag[Money]`
+   * -> `"Money"`.
+   */
+  private def typeName(tag: Tag[?]): String = tag.toString.stripPrefix("Tag[").stripSuffix("]")
 
 /**
  * Thrown when a property scenario is falsified. Message contains the
@@ -379,9 +479,12 @@ object PropertyExecutor:
 class PropertyFalsifiedException(message: String) extends RuntimeException(message)
 
 /**
- * Resolves a column name to a `HasGen` instance. Suites provide this by mapping
- * placeholder names to the `HasGen` for the corresponding `TypedExtractor`
- * type.
+ * Resolves a column name to a `HasGen` instance. This is the *override* path —
+ * most columns resolve automatically (named header override, then automatic
+ * type-based lookup via `HasGen.resolveByTag`; see `resolveColumnGens` above).
+ * Provide an entry here when you want a different generator than the automatic
+ * choice, or to disambiguate a column whose inferred type conflicts across
+ * steps.
  */
 trait ColumnGenLookup:
   def byColumn(columnName: String): Option[HasGen[?]]

--- a/core/src/main/scala/zio/bdd/core/property/PropertyExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/property/PropertyExecutor.scala
@@ -1,0 +1,318 @@
+package zio.bdd.core.property
+
+import izumi.reflect.Tag
+import zio.*
+import zio.bdd.core.step.{StepRegistry, ZIOSteps}
+import zio.bdd.core.{Default, ScenarioExecutor, ScenarioResult, StepResult}
+import zio.bdd.gherkin.{PropertyTag, Scenario, Step, StepType}
+import zio.test.{Gen, Sized, TestRandom}
+
+/**
+ * Executes `@property` scenarios by sampling values from the `HasGen[T]`
+ * registry and running the scenario body for each sample.
+ *
+ * Does NOT reuse `zio.test.check` — zio-bdd steps fail with `Throwable` while
+ * `check` expects a `TestResult`/`BoolAlgebra` return.
+ *
+ * v1 algorithm:
+ *   1. Resolve each column → `HasGen` instance. 2. If a replay record exists
+ *      for this scenario, run the stored counterexample first. 3. Loop
+ *      `samples` times, substituting sampled values into step placeholders. 4.
+ *      On failure: persist the failing seed + values, annotate the result. 5.
+ *      Emit one `ScenarioResult` for the whole property run.
+ *
+ * Full shrink-tree walking is deferred to v2. v1 records the seed that
+ * triggered the failure so developers can replay it exactly.
+ */
+object PropertyExecutor:
+
+  case class ColumnGen(name: String, gen: Gen[Any, Any], label: String)
+
+  def run[R: Tag, S: Tag: Default](
+    scenario: Scenario,
+    suite: ZIOSteps[R, S],
+    genLookup: ColumnGenLookup
+  ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
+    scenario.propertyConfig match
+      case None =>
+        ZIO.succeed(
+          ScenarioResult(
+            scenario,
+            Nil,
+            setupError = Some(
+              Cause.fail(
+                new IllegalStateException(
+                  s"PropertyExecutor called on scenario without @property config: ${scenario.name}"
+                )
+              )
+            )
+          )
+        )
+      case Some(config) =>
+        runProperty(scenario, config, suite, genLookup)
+
+  private def runProperty[R: Tag, S: Tag: Default](
+    scenario: Scenario,
+    config: PropertyTag.PropertyConfig,
+    suite: ZIOSteps[R, S],
+    lookup: ColumnGenLookup
+  ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
+    resolveColumnGens(scenario, lookup).flatMap {
+      case Left(err) =>
+        ZIO.succeed(ScenarioResult(scenario, Nil, setupError = Some(Cause.fail(new RuntimeException(err)))))
+      case Right(colGens) =>
+        for {
+          seed      <- config.seed.map(ZIO.succeed).getOrElse(Random.nextLong)
+          replayRec <- if (config.replay) PropertyFailureStore.read(scenario) else ZIO.none
+          result <- replayRec match
+                      case Some(rec) if rec.bodyHash == PropertyFailureStore.bodyHash(scenario) =>
+                        handleReplay(scenario, config, suite, colGens, rec, seed)
+                      case _ =>
+                        runFreshSamples(scenario, config, suite, colGens, seed)
+        } yield result
+    }
+
+  private def handleReplay[R: Tag, S: Tag: Default](
+    scenario: Scenario,
+    config: PropertyTag.PropertyConfig,
+    suite: ZIOSteps[R, S],
+    colGens: List[ColumnGen],
+    rec: PropertyFailureStore.FailureRecord,
+    freshSeed: Long
+  ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
+    val replayValues = colGens.map(cg => cg.name -> rec.shrunkValues.getOrElse(cg.name, ""))
+    runOneSample(scenario, suite, replayValues).map {
+      case None =>
+        buildPassResult(scenario, rec.seed, sampleCount = 0, colGens, replayPassed = true)
+      case Some(failResult) =>
+        // Still failing
+        buildFailureResult(
+          scenario = scenario,
+          seed = rec.seed,
+          sampleIndex = rec.sampleIndex,
+          shrunkValues = rec.shrunkValues,
+          generatorLabels = colGens.map(cg => cg.name -> cg.label).toMap,
+          originalResult = failResult,
+          isReplay = true
+        )
+    }
+
+  private def runFreshSamples[R: Tag, S: Tag: Default](
+    scenario: Scenario,
+    config: PropertyTag.PropertyConfig,
+    suite: ZIOSteps[R, S],
+    colGens: List[ColumnGen],
+    seed: Long
+  ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
+    ZIO.logAnnotate("propertyScenario", scenario.name) {
+      // Run up to `config.samples` iterations. Short-circuit on first failure.
+      // State is (sampleIndex, Option[failResult]); we stop when failResult is Some.
+      ZIO
+        .iterate((0, Option.empty[ScenarioResult]))(s => s._2.isEmpty && s._1 < config.samples) { s =>
+          val idx = s._1
+          sampleColumnValues(colGens, seed, idx).flatMap { colValues =>
+            runOneSample(scenario, suite, colValues).flatMap {
+              case None =>
+                ZIO.succeed((idx + 1, None))
+              case Some(failResult) =>
+                val shrunkValues    = colValues.toMap
+                val generatorLabels = colGens.map(cg => cg.name -> cg.label).toMap
+                PropertyFailureStore
+                  .write(scenario, seed, idx, shrunkValues, generatorLabels)
+                  .as(
+                    (
+                      idx + 1,
+                      Some(
+                        buildFailureResult(
+                          scenario,
+                          seed,
+                          idx,
+                          shrunkValues,
+                          generatorLabels,
+                          failResult,
+                          isReplay = false
+                        )
+                      )
+                    )
+                  )
+            }
+          }
+        }
+        .map { s =>
+          s._2 match {
+            case Some(failResult) => failResult
+            case None             => buildPassResult(scenario, seed, s._1, colGens)
+          }
+        }
+    }
+
+  // ── Result builders ──────────────────────────────────────────────────────
+
+  /**
+   * Pass result: one synthetic "summary" step surfaces the generator labels and
+   * sample count in the `<steps>` block so CI dashboards and the Cucumber
+   * Reports plugin show something informative instead of an empty step list.
+   */
+  private def buildPassResult(
+    scenario: Scenario,
+    seed: Long,
+    sampleCount: Int,
+    colGens: List[ColumnGen],
+    replayPassed: Boolean = false
+  ): ScenarioResult =
+    val genSummary = colGens.map(cg => s"${cg.name} (${cg.label})").mkString(", ")
+    val label =
+      if (replayPassed) s"replay passed (seed=$seed)"
+      else s"$sampleCount samples passed, seed=$seed"
+    val summaryStep = Step(
+      stepType = StepType.GivenStep,
+      pattern = s"[property] $label — generators: $genSummary"
+    )
+    ScenarioResult(
+      scenario = scenario.copy(name = s"${scenario.name} [$label]"),
+      stepResults = List(StepResult(summaryStep, Right(())))
+    )
+
+  /**
+   * Failure result: prepends a synthetic "[counterexample]" step to the real
+   * step results from the failing sample run.
+   *
+   * This means the `<steps>` block in JUnit XML shows:
+   *   1. A failed "[counterexample] col=val (gen), ..." step carrying the
+   *      summary message — visible in the Jenkins/GitHub Actions step detail.
+   *      2. The real Given/When/Then steps from the falsifying sample, with the
+   *      exact step that failed marked as "failed" and subsequent steps as
+   *      "skipped".
+   *
+   * The failure is carried by the counterexample step's outcome (not
+   * setupError), so ScenarioResult.error resolves through the normal
+   * stepResults path and the JUnit <failure message=...> attribute is populated
+   * correctly.
+   */
+  private def buildFailureResult(
+    scenario: Scenario,
+    seed: Long,
+    sampleIndex: Int,
+    shrunkValues: Map[String, String],
+    generatorLabels: Map[String, String],
+    originalResult: ScenarioResult,
+    isReplay: Boolean
+  ): ScenarioResult =
+    val replayNote = if (isReplay) " [replayed from failure store]" else ""
+    val summary    = s"Falsified after ${sampleIndex + 1} samples (seed=$seed)$replayNote"
+
+    val counterexampleLabel = shrunkValues.toList
+      .sortBy(_._1)
+      .map { case (col, v) => s"$col=$v (${generatorLabels.getOrElse(col, "?")})" }
+      .mkString(", ")
+    val counterexampleStep = Step(
+      stepType = StepType.GivenStep,
+      pattern = s"[counterexample] $counterexampleLabel"
+    )
+    val counterexampleResult = StepResult(
+      step = counterexampleStep,
+      outcome = Left(
+        Cause.fail(
+          new PropertyFalsifiedException(
+            s"$summary\nMinimal counterexample: $counterexampleLabel"
+          )
+        )
+      )
+    )
+
+    originalResult.copy(
+      scenario = scenario.copy(name = s"${scenario.name} [seed=$seed]"),
+      stepResults = counterexampleResult +: originalResult.stepResults,
+      // Error is now carried by the first StepResult, not setupError.
+      // ScenarioResult.error already walks stepResults first, so this is consistent.
+      setupError = None
+    )
+
+  /**
+   * Run the scenario once with the given column → string value substitution.
+   */
+  private def runOneSample[R: Tag, S: Tag: Default](
+    scenario: Scenario,
+    suite: ZIOSteps[R, S],
+    colValues: List[(String, String)]
+  ): ZIO[R & StepRegistry[R, S], Nothing, Option[ScenarioResult]] =
+    val substituted = substituteSteps(scenario, colValues.toMap)
+    val meta        = zio.bdd.gherkin.ScenarioMetadata.from(substituted)
+    ScenarioExecutor
+      .executeScenario[R, S](substituted, suite)
+      .provideSomeLayer[R & StepRegistry[R, S]](suite.scenarioLayer(meta).orDie)
+      .map(result => if (result.isPassed) None else Some(result))
+
+  /** Substitute `<placeholder>` in step patterns with sampled string values. */
+  private def substituteSteps(scenario: Scenario, values: Map[String, String]): Scenario =
+    val placeholderRe = "<([^>]+)>".r
+    val substitutedSteps = scenario.steps.map { step =>
+      val newPattern = placeholderRe.replaceAllIn(
+        step.pattern,
+        m => java.util.regex.Matcher.quoteReplacement(values.getOrElse(m.group(1), m.matched))
+      )
+      step.copy(pattern = newPattern)
+    }
+    scenario.copy(steps = substitutedSteps, propertyConfig = None)
+
+  /**
+   * Sample one string value per column using the column's `Gen`, seeded
+   * deterministically using `seed XOR sampleIndex` so each sample in a run is
+   * distinct while remaining reproducible.
+   */
+  private def sampleColumnValues(
+    colGens: List[ColumnGen],
+    seed: Long,
+    sampleIdx: Int
+  ): UIO[List[(String, String)]] =
+    ZIO.foreach(colGens) { cg =>
+      val itemSeed = seed ^ (sampleIdx.toLong * 6364136223846793005L + 1442695040888963407L)
+      sampleGenToString(cg.gen, itemSeed).map(v => cg.name -> v)
+    }
+
+  private def sampleGenToString(gen: Gen[Any, Any], seed: Long): UIO[String] =
+    (for {
+      _ <- TestRandom.setSeed(seed)
+      v <- gen.sample.map(_.value.toString).runHead
+    } yield v.getOrElse(""))
+      .provideLayer(Sized.default ++ TestRandom.deterministic)
+
+  // ── Column generator resolution ──────────────────────────────────────────
+
+  private def resolveColumnGens(
+    scenario: Scenario,
+    lookup: ColumnGenLookup
+  ): UIO[Either[String, List[ColumnGen]]] =
+    ZIO.succeed {
+      val placeholderRe = "<([^>]+)>".r
+      val allPlaceholders = scenario.steps.flatMap { step =>
+        placeholderRe.findAllMatchIn(step.pattern).map(_.group(1)).toList
+      }.distinct
+
+      val resolved = allPlaceholders.map { col =>
+        val namedGen = scenario.columnGens.get(col).flatMap(HasGen.resolve)
+        namedGen.orElse(lookup.byColumn(col)) match
+          case Some(hg) => Right(ColumnGen(col, hg.gen.asInstanceOf[Gen[Any, Any]], hg.label))
+          case None     => Left(s"No HasGen registered for column '$col'. Register `given HasGen[T]` for its type.")
+      }
+      val errors = resolved.collect { case Left(e) => e }
+      if (errors.nonEmpty) Left(errors.mkString("; "))
+      else Right(resolved.collect { case Right(cg) => cg })
+    }
+
+/**
+ * Thrown when a property scenario is falsified. Message contains the
+ * counterexample.
+ */
+class PropertyFalsifiedException(message: String) extends RuntimeException(message)
+
+/**
+ * Resolves a column name to a `HasGen` instance. Suites provide this by mapping
+ * placeholder names to the `HasGen` for the corresponding `TypedExtractor`
+ * type.
+ */
+trait ColumnGenLookup:
+  def byColumn(columnName: String): Option[HasGen[?]]
+
+object ColumnGenLookup:
+  val empty: ColumnGenLookup = _ => None

--- a/core/src/main/scala/zio/bdd/core/property/PropertyFailureStore.scala
+++ b/core/src/main/scala/zio/bdd/core/property/PropertyFailureStore.scala
@@ -46,7 +46,35 @@ object PropertyFailureStore:
 
   // ── Minimal JSON encode/decode (avoids adding a library dependency) ───────
   // We control the output format: keys are known identifiers, values are
-  // strings or longs — no nesting beyond one level of object.
+  // strings or longs — no nesting beyond one level of object. Sampled column values are
+  // arbitrary user-generated strings, though, so the nested-object scan below is
+  // quote-aware (tracks whether it's inside a quoted string) rather than naively
+  // stopping at the first '}' byte — a generated value containing a literal brace
+  // must not be mistaken for the end of the object.
+
+  private def jsonUnescape(s: String): String =
+    s.replace("\\\"", "\"").replace("\\\\", "\\")
+
+  /**
+   * Find the index of the `}` that closes the object opened at `openIdx` (which
+   * must point at that object's `{`), skipping over any `}` that appears inside
+   * a quoted string value. Returns -1 if unterminated.
+   */
+  private def matchingBrace(s: String, openIdx: Int): Int = {
+    var i        = openIdx + 1
+    var inString = false
+    var result   = -1
+    while (result == -1 && i < s.length) {
+      val c = s.charAt(i)
+      if (inString) {
+        if (c == '\\') i += 1 // skip the escaped character, whatever it is
+        else if (c == '"') inString = false
+      } else if (c == '"') inString = true
+      else if (c == '}') result = i
+      i += 1
+    }
+    result
+  }
 
   private def encodeJson(rec: FailureRecord): String =
     def esc(s: String)              = s.replace("\\", "\\\\").replace("\"", "\\\"")
@@ -74,7 +102,7 @@ object PropertyFailureStore:
       val sep       = "\\s*:\\s*"
       (keyPart + sep + valuePart).r
         .findFirstMatchIn(json)
-        .map(m => m.group(1).replace("\\\"", "\"").replace("\\\\", "\\"))
+        .map(m => jsonUnescape(m.group(1)))
     }
     def longVal(key: String): Option[Long] = {
       val keyPart = "\"" + key + "\""
@@ -90,18 +118,23 @@ object PropertyFailureStore:
     }
     def objVal(key: String): Map[String, String] = {
       val keyPart = "\"" + key + "\""
-      val objBody = (keyPart + "\\s*:\\s*\\{([^}]*)\\}").r
-      objBody
+      val openPat = (keyPart + "\\s*:\\s*\\{").r
+      val pairPat = "\"([^\"]+)\"\\s*:\\s*\"((?:[^\"\\\\]|\\\\.)*)\""
+      openPat
         .findFirstMatchIn(json)
-        .map { m =>
-          val body    = m.group(1)
-          val pairPat = "\"([^\"]+)\"\\s*:\\s*\"((?:[^\"\\\\]|\\\\.)*)\""
-          pairPat.r
-            .findAllMatchIn(body)
-            .map { pm =>
-              pm.group(1) -> pm.group(2).replace("\\\"", "\"").replace("\\\\", "\\")
-            }
-            .toMap
+        .flatMap { m =>
+          val openIdx  = json.indexOf('{', m.start)
+          val closeIdx = matchingBrace(json, openIdx)
+          if (closeIdx < 0) None
+          else {
+            val body = json.substring(openIdx + 1, closeIdx)
+            Some(
+              pairPat.r
+                .findAllMatchIn(body)
+                .map(pm => pm.group(1) -> jsonUnescape(pm.group(2)))
+                .toMap
+            )
+          }
         }
         .getOrElse(Map.empty)
     }
@@ -128,11 +161,11 @@ object PropertyFailureStore:
   }
 
   def read(scenario: Scenario): UIO[Option[FailureRecord]] =
-    ZIO.attempt {
+    ZIO.attemptBlocking {
       val f = file(scenario)
       if (!f.exists()) None
       else {
-        val json = scala.io.Source.fromFile(f).mkString
+        val json = scala.util.Using.resource(scala.io.Source.fromFile(f))(_.mkString)
         decodeJson(json)
       }
     }
@@ -156,7 +189,7 @@ object PropertyFailureStore:
     shrunkValues: Map[String, String],
     generatorLabels: Map[String, String]
   ): UIO[Unit] =
-    ZIO.attempt {
+    ZIO.attemptBlocking {
       Files.createDirectories(dir)
       val rec = FailureRecord(
         scenarioId = slug(scenario),
@@ -167,10 +200,8 @@ object PropertyFailureStore:
         generatorLabels = generatorLabels,
         timestamp = Instant.now().toString
       )
-      val w = new PrintWriter(file(scenario))
-      try w.write(encodeJson(rec))
-      finally w.close()
+      scala.util.Using.resource(new PrintWriter(file(scenario)))(_.write(encodeJson(rec)))
     }.orDie
 
   def clear(scenario: Scenario): UIO[Unit] =
-    ZIO.attempt { val _ = file(scenario).delete() }.orDie
+    ZIO.attemptBlocking { val _ = file(scenario).delete() }.orDie

--- a/core/src/main/scala/zio/bdd/core/property/PropertyFailureStore.scala
+++ b/core/src/main/scala/zio/bdd/core/property/PropertyFailureStore.scala
@@ -133,11 +133,21 @@ object PropertyFailureStore:
       if (!f.exists()) None
       else {
         val json = scala.io.Source.fromFile(f).mkString
-        decodeJson(json).flatMap { rec =>
-          if (rec.bodyHash == bodyHash(scenario)) Some(rec) else None
-        }
+        decodeJson(json)
       }
-    }.orElse(ZIO.none)
+    }
+      .orElse(ZIO.none)
+      .flatMap {
+        case Some(rec) if rec.bodyHash == bodyHash(scenario) => ZIO.some(rec)
+        case Some(_)                                         =>
+          // The scenario's step list changed since this failure was recorded — the stored
+          // counterexample no longer corresponds to the current scenario body. Discard it
+          // rather than replaying a test that no longer exists in this form.
+          ZIO.logWarning(
+            s"Discarding stale property-failure record for '${scenario.name}' — scenario body changed since it was recorded."
+          ) *> clear(scenario).as(None)
+        case None => ZIO.none
+      }
 
   def write(
     scenario: Scenario,

--- a/core/src/main/scala/zio/bdd/core/property/PropertyFailureStore.scala
+++ b/core/src/main/scala/zio/bdd/core/property/PropertyFailureStore.scala
@@ -1,0 +1,166 @@
+package zio.bdd.core.property
+
+import zio.*
+import zio.bdd.gherkin.Scenario
+
+import java.io.{File, PrintWriter}
+import java.nio.file.{Files, Path, Paths}
+import java.time.Instant
+
+/**
+ * Persists and replays failing property seeds across test runs.
+ *
+ * On any property failure the executor writes a JSON file to
+ * `.zio-bdd/failures/<scenario-slug>.json`. On the next run the stored failing
+ * seed is replayed FIRST so developers get immediate feedback on whether a fix
+ * worked — without burning new samples.
+ *
+ * Body-hash invalidation: if the scenario's step list changes, the stale
+ * failure is discarded with a warning.
+ */
+object PropertyFailureStore:
+
+  case class FailureRecord(
+    scenarioId: String,
+    bodyHash: String,
+    seed: Long,
+    sampleIndex: Int,
+    shrunkValues: Map[String, String],
+    generatorLabels: Map[String, String],
+    timestamp: String
+  )
+
+  private val dir: Path = Paths.get(".zio-bdd", "failures")
+
+  private[property] def slug(scenario: Scenario): String =
+    val feature = scenario.file.getOrElse("unknown").replaceAll(""".*[/\\]""", "").stripSuffix(".feature")
+    val name    = scenario.name
+    (feature + "--" + name).toLowerCase.replaceAll("[^a-z0-9]+", "-").take(120)
+
+  private[property] def bodyHash(scenario: Scenario): String =
+    val content = scenario.steps.map(s => s"${s.stepType}:${s.pattern}").mkString("|")
+    Integer.toHexString(content.hashCode)
+
+  private def file(scenario: Scenario): File =
+    dir.resolve(slug(scenario) + ".json").toFile
+
+  // ── Minimal JSON encode/decode (avoids adding a library dependency) ───────
+  // We control the output format: keys are known identifiers, values are
+  // strings or longs — no nesting beyond one level of object.
+
+  private def encodeJson(rec: FailureRecord): String =
+    def esc(s: String)              = s.replace("\\", "\\\\").replace("\"", "\\\"")
+    def str(s: String)              = "\"" + esc(s) + "\""
+    def kvStr(k: String, v: String) = str(k) + ":" + str(v)
+    def kvLong(k: String, v: Long)  = str(k) + ":" + v.toString
+    def kvInt(k: String, v: Int)    = str(k) + ":" + v.toString
+    def obj(m: Map[String, String]) =
+      "{" + m.map { case (k, v) => kvStr(k, v) }.mkString(",") + "}"
+    List(
+      kvStr("scenarioId", rec.scenarioId),
+      kvStr("bodyHash", rec.bodyHash),
+      kvLong("seed", rec.seed),
+      kvInt("sampleIndex", rec.sampleIndex),
+      "\"shrunkValues\":" + obj(rec.shrunkValues),
+      "\"generatorLabels\":" + obj(rec.generatorLabels),
+      kvStr("timestamp", rec.timestamp)
+    ).mkString("{", ",", "}")
+
+  private def decodeJson(json: String): Option[FailureRecord] = {
+    // Extract a "key":"value" pair. key is a plain identifier, value may contain \" escapes.
+    def strVal(key: String): Option[String] = {
+      val keyPart   = "\"" + key + "\""            // literal key with quotes
+      val valuePart = "\"((?:[^\"\\\\]|\\\\.)*)\"" // captured value
+      val sep       = "\\s*:\\s*"
+      (keyPart + sep + valuePart).r
+        .findFirstMatchIn(json)
+        .map(m => m.group(1).replace("\\\"", "\"").replace("\\\\", "\\"))
+    }
+    def longVal(key: String): Option[Long] = {
+      val keyPart = "\"" + key + "\""
+      (keyPart + "\\s*:\\s*(-?\\d+)").r
+        .findFirstMatchIn(json)
+        .flatMap(m => m.group(1).toLongOption)
+    }
+    def intVal(key: String): Option[Int] = {
+      val keyPart = "\"" + key + "\""
+      (keyPart + "\\s*:\\s*(-?\\d+)").r
+        .findFirstMatchIn(json)
+        .flatMap(m => m.group(1).toIntOption)
+    }
+    def objVal(key: String): Map[String, String] = {
+      val keyPart = "\"" + key + "\""
+      val objBody = (keyPart + "\\s*:\\s*\\{([^}]*)\\}").r
+      objBody
+        .findFirstMatchIn(json)
+        .map { m =>
+          val body    = m.group(1)
+          val pairPat = "\"([^\"]+)\"\\s*:\\s*\"((?:[^\"\\\\]|\\\\.)*)\""
+          pairPat.r
+            .findAllMatchIn(body)
+            .map { pm =>
+              pm.group(1) -> pm.group(2).replace("\\\"", "\"").replace("\\\\", "\\")
+            }
+            .toMap
+        }
+        .getOrElse(Map.empty)
+    }
+
+    try {
+      for {
+        scenarioId  <- strVal("scenarioId")
+        bodyHash    <- strVal("bodyHash")
+        seed        <- longVal("seed")
+        sampleIndex <- intVal("sampleIndex")
+        timestamp   <- strVal("timestamp")
+      } yield FailureRecord(
+        scenarioId = scenarioId,
+        bodyHash = bodyHash,
+        seed = seed,
+        sampleIndex = sampleIndex,
+        shrunkValues = objVal("shrunkValues"),
+        generatorLabels = objVal("generatorLabels"),
+        timestamp = timestamp
+      )
+    } catch {
+      case _: Exception => None
+    }
+  }
+
+  def read(scenario: Scenario): UIO[Option[FailureRecord]] =
+    ZIO.attempt {
+      val f = file(scenario)
+      if (!f.exists()) None
+      else {
+        val json = scala.io.Source.fromFile(f).mkString
+        decodeJson(json).flatMap { rec =>
+          if (rec.bodyHash == bodyHash(scenario)) Some(rec) else None
+        }
+      }
+    }.orElse(ZIO.none)
+
+  def write(
+    scenario: Scenario,
+    seed: Long,
+    sampleIndex: Int,
+    shrunkValues: Map[String, String],
+    generatorLabels: Map[String, String]
+  ): UIO[Unit] =
+    ZIO.attempt {
+      Files.createDirectories(dir)
+      val rec = FailureRecord(
+        scenarioId = slug(scenario),
+        bodyHash = bodyHash(scenario),
+        seed = seed,
+        sampleIndex = sampleIndex,
+        shrunkValues = shrunkValues,
+        generatorLabels = generatorLabels,
+        timestamp = Instant.now().toString
+      )
+      val w = new PrintWriter(file(scenario))
+      try w.write(encodeJson(rec))
+      finally w.close()
+    }.orDie
+
+  def clear(scenario: Scenario): UIO[Unit] =
+    ZIO.attempt { val _ = file(scenario).delete() }.orDie

--- a/core/src/main/scala/zio/bdd/core/report/JUnitXMLFormatter.scala
+++ b/core/src/main/scala/zio/bdd/core/report/JUnitXMLFormatter.scala
@@ -2,6 +2,7 @@ package zio.bdd.core.report
 
 import zio.*
 import zio.bdd.core.*
+import zio.bdd.core.property.PropertyFalsifiedException
 import zio.bdd.gherkin.{Feature, Step, StepType}
 
 import java.time.Instant
@@ -51,8 +52,8 @@ object JUnitXMLFormatter {
         val e   = cause.squash
         val msg = Option(e.getMessage).getOrElse(e.getClass.getSimpleName)
         val trace = e match
-          case _: AssertionError                                                             => None // message is self-explanatory; no trace needed
-          case _ if e.getClass.getName == "zio.bdd.core.property.PropertyFalsifiedException" => None
+          case _: AssertionError             => None // message is self-explanatory; no trace needed
+          case _: PropertyFalsifiedException => None
           case _ =>
             Option(e.getStackTrace).map { frames =>
               val userFrames = frames.filterNot { f =>

--- a/core/src/main/scala/zio/bdd/core/report/JUnitXMLFormatter.scala
+++ b/core/src/main/scala/zio/bdd/core/report/JUnitXMLFormatter.scala
@@ -48,9 +48,21 @@ object JUnitXMLFormatter {
       case StepStatus.TimedOut(d, cause) =>
         TimedOut(s"Step timed out after ${d.toSeconds}s")
       case StepStatus.Failed(cause) =>
-        val msg =
-          cause.failureOption.map(_.getMessage).orElse(cause.dieOption.map(_.getMessage)).getOrElse("Test failed")
-        val trace = Option(cause.prettyPrint)
+        val e   = cause.squash
+        val msg = Option(e.getMessage).getOrElse(e.getClass.getSimpleName)
+        val trace = e match
+          case _: AssertionError                                                             => None // message is self-explanatory; no trace needed
+          case _ if e.getClass.getName == "zio.bdd.core.property.PropertyFalsifiedException" => None
+          case _ =>
+            Option(e.getStackTrace).map { frames =>
+              val userFrames = frames.filterNot { f =>
+                val c = f.getClassName
+                c.startsWith("zio.bdd.") || c.startsWith("zio.") ||
+                c.startsWith("scala.runtime.") || c.startsWith("java.")
+              }
+                .take(10)
+              userFrames.mkString("\n\tat ", "\n\tat ", "")
+            }
         Failed(msg, trace)
 
     def xmlStatus(o: StepOutcome): String = o match

--- a/core/src/main/scala/zio/bdd/core/report/PrettyReporter.scala
+++ b/core/src/main/scala/zio/bdd/core/report/PrettyReporter.scala
@@ -349,11 +349,17 @@ object DocBuilder:
 
   /** Render a `[counterexample]` pattern as a compact table. */
   private def counterexampleTable(pattern: String): List[Doc.Leaf] =
-    // Pattern: "[counterexample] col1=val1 (gen1), col2=val2 (gen2)"
+    // Pattern: "[counterexample] col1=val1 (gen1) ‖ col2=val2 (gen2)" — entries are joined with
+    // PropertyExecutor.counterexampleEntrySep, not a plain comma, since column values are
+    // arbitrary generated text that commonly contains literal commas (e.g. a case class's
+    // default toString: `Address(Main St,London)`).
     val body = pattern.stripPrefix("[counterexample]").trim
     if (body.isEmpty) Nil
     else
-      val entries = body.split(",").map(_.trim).toList
+      val entries = body
+        .split(java.util.regex.Pattern.quote(zio.bdd.core.property.PropertyExecutor.counterexampleEntrySep))
+        .map(_.trim)
+        .toList
       val colWidth = entries.map { e =>
         e.indexOf('=') match { case -1 => 0; case i => i }
       }.maxOption.getOrElse(0)
@@ -377,7 +383,7 @@ object DocBuilder:
       case e: AssertionError =>
         // User assertion: show only the message — no stack frames needed.
         List(Doc.Leaf(e.getMessage, Style(Color.Red)))
-      case e if e.getClass.getName == "zio.bdd.core.property.PropertyFalsifiedException" =>
+      case e: zio.bdd.core.property.PropertyFalsifiedException =>
         // Property counterexample summary: show only the message, no internal frames.
         List(Doc.Leaf(e.getMessage, Style(Color.Red)))
       case e =>

--- a/core/src/main/scala/zio/bdd/core/report/PrettyReporter.scala
+++ b/core/src/main/scala/zio/bdd/core/report/PrettyReporter.scala
@@ -69,21 +69,50 @@ sealed abstract class Color(val darkCode: String, val lightCode: String):
 
 object Color:
   // ── Result / status colors ────────────────────────────────────────────────
-  case object Green  extends Color("[92m", "[32m")             // passed feature
-  case object Red    extends Color("[91m", "[31m")             // failed / error
-  case object Blue   extends Color("[94m", "[34m")             // step (passed)
-  case object Yellow extends Color("[93m", "[33m")             // scenario (passed)
-  case object Gray   extends Color("[90m", "[37m")             // ignored / skipped
-  case object Orange extends Color("[38;5;214m", "[38;5;166m") // pending
-  case object Cyan   extends Color("[96m", "[36m")             // summary / headings
+  //
+  // Each entry: (darkTerminalCode, lightTerminalCode)
+  // Light codes are chosen for legibility on white backgrounds (WCAG AA contrast).
+  //
+  //   Feature  → dark forest green  / deep green
+  //   Scenario → sky blue           / dark navy blue
+  //   Step     → soft mint          / dark teal green
+  //   Failed   → bright red         / dark crimson
+  //   Pending  → amber orange       / dark burnt orange
+  //   Skipped  → dim gray           / dark charcoal (not ANSI white which vanishes on white bg)
+  //   Headings → bright cyan        / dark teal
+  //
+  case object Green  extends Color("[38;5;35m", "[38;5;22m")   // forest green  / deep green
+  case object Blue   extends Color("[38;5;75m", "[38;5;19m")   // sky blue      / dark navy
+  case object Mint   extends Color("[38;5;121m", "[38;5;29m")  // soft mint     / dark teal
+  case object Red    extends Color("[91m", "[38;5;160m")       // bright red    / dark crimson
+  case object Gray   extends Color("[90m", "[38;5;240m")       // dim gray      / dark charcoal
+  case object Orange extends Color("[38;5;214m", "[38;5;130m") // amber orange  / dark burnt orange
+  case object Cyan   extends Color("[96m", "[38;5;30m")        // bright cyan   / dark teal
+
+  // Aliases so any code outside StatusColor that used the old names compiles.
+  val Yellow: Color = Blue
+  val Teal: Color   = Blue
 
   // ── Muted log entry palette ────────────────────────────────────────────────
-  // Dark:  pale 24-bit tints — visible without competing with tree nodes
-  // Light: normal ANSI — pale 24-bit tints are near-invisible on white
-  case object PaleGreen  extends Color("[38;2;144;238;144m", "[32m")
-  case object PaleCyan   extends Color("[38;2;173;216;230m", "[36m")
-  case object PaleYellow extends Color("[38;2;200;200;100m", "[33m")
-  case object PaleRed    extends Color("[38;2;255;182;193m", "[31m")
+  // Dark:  faded enough not to compete with tree nodes
+  // Light: darker than the tree colours so they're readable on white,
+  //        but still clearly subordinate (muted hue, not bold)
+  //
+  //   Debug   → steel gray    / dark slate gray
+  //   Info    → dusty teal    / dark slate teal
+  //   Warning → muted gold    / dark olive/brown
+  //   Error   → muted rose    / dark rose/maroon
+  //
+  case object LogDebug   extends Color("[38;5;242m", "[38;5;238m")         // steel gray    / dark slate
+  case object LogInfo    extends Color("[38;2;100;180;160m", "[38;5;66m")  // dusty teal    / dark slate teal
+  case object LogWarning extends Color("[38;2;200;170;80m", "[38;5;94m")   // muted gold    / dark olive
+  case object LogError   extends Color("[38;2;210;100;100m", "[38;5;124m") // muted rose    / dark maroon
+
+  // Keep Pale* as aliases for any code that references them directly
+  val PaleGreen: Color  = LogInfo
+  val PaleCyan: Color   = LogDebug
+  val PaleYellow: Color = LogWarning
+  val PaleRed: Color    = LogError
 
 // ── Style ─────────────────────────────────────────────────────────────────────
 
@@ -108,32 +137,32 @@ object StatusColor:
   def from[A](f: A => Style): StatusColor[A] = a => f(a)
 
   given StatusColor[StepStatus] = from {
-    case StepStatus.Passed         => Style(Color.Blue, "•")   // •
-    case StepStatus.Failed(_)      => Style(Color.Red, "✗")    // ✗
-    case StepStatus.TimedOut(_, _) => Style(Color.Red, "⏱")    // ⏱
-    case StepStatus.Skipped        => Style(Color.Gray, "○")   // ○
-    case StepStatus.Pending(_)     => Style(Color.Orange, "◌") // ◌
+    case StepStatus.Passed         => Style(Color.Mint, "•") // soft mint  — leaf-level pass
+    case StepStatus.Failed(_)      => Style(Color.Red, "✗")
+    case StepStatus.TimedOut(_, _) => Style(Color.Red, "⏱")
+    case StepStatus.Skipped        => Style(Color.Gray, "○")
+    case StepStatus.Pending(_)     => Style(Color.Orange, "◌")
   }
 
   given StatusColor[ScenarioResult] = from { sc =>
-    if (sc.isIgnored) Style(Color.Gray, "◑")                           // ◑
-    else if (sc.hasPending && !sc.hasFailure) Style(Color.Orange, "◑") // ◑
-    else if (sc.isPassed) Style(Color.Yellow, "✓")                     // ✓
-    else Style(Color.Red, "✗")                                         // ✗
+    if (sc.isIgnored) Style(Color.Gray, "◑")
+    else if (sc.hasPending && !sc.hasFailure) Style(Color.Orange, "◑")
+    else if (sc.isPassed) Style(Color.Blue, "✓") // sky blue — scenario-level pass
+    else Style(Color.Red, "✗")
   }
 
   given StatusColor[FeatureResult] = from { f =>
-    if (f.isIgnored) Style(Color.Gray, "◉")      // ◉
-    else if (f.isPassed) Style(Color.Green, "◉") // ◉
-    else Style(Color.Red, "◉")                   // ◉
+    if (f.isIgnored) Style(Color.Gray, "◉")
+    else if (f.isPassed) Style(Color.Green, "◉") // bright green — feature-level pass
+    else Style(Color.Red, "◉")
   }
 
   given StatusColor[InternalLogLevel] = from {
-    case InternalLogLevel.Debug   => Style(Color.PaleCyan, "")
-    case InternalLogLevel.Info    => Style(Color.PaleGreen, "")
-    case InternalLogLevel.Warning => Style(Color.PaleYellow, "")
-    case InternalLogLevel.Error   => Style(Color.PaleRed, "")
-    case InternalLogLevel.Fatal   => Style(Color.PaleRed, "")
+    case InternalLogLevel.Debug   => Style(Color.LogDebug, "")    // steel gray  — least noise
+    case InternalLogLevel.Info    => Style(Color.LogInfo, "")     // dusty teal  — readable, calm
+    case InternalLogLevel.Warning => Style(Color.LogWarning, "⚠") // muted gold  — caution, noticeable
+    case InternalLogLevel.Error   => Style(Color.LogError, "✖")   // muted rose  — error, softer than tree red
+    case InternalLogLevel.Fatal   => Style(Color.Red, "✖")        // full red    — fatal demands attention
   }
 
 // ── Doc tree (pure, testable) ─────────────────────────────────────────────────
@@ -202,7 +231,8 @@ final class AnsiRenderer(val theme: Theme) extends DocRenderer[UIO]:
       if (theme == Theme.Plain)
         s"$indent$prefix${leaf.style.icon} ${leaf.text}"
       else
-        s"$indent${ansi(leaf.style.color)}$prefix${leaf.style.icon} ${leaf.text}$Reset"
+        // Glyph (├─ ╰─) — no colour, matches the plain │ in the indent string
+        s"$indent$prefix${ansi(leaf.style.color)}${leaf.style.icon} ${leaf.text}$Reset"
     Console.printLine(line).orDie
 
   def render(doc: Doc, indent: String = ""): UIO[Unit] = doc match
@@ -297,20 +327,75 @@ object DocBuilder:
 
   def stepLeaf(sr: StepResult): Doc.Leaf =
     val st  = sr.status
-    val sty = summon[StatusColor[StepStatus]].style(st)
     val kw  = sr.step.stepType.toString.replace("Step", "")
     val loc = sr.step.line.map(l => s":$l").getOrElse("")
-    Doc.Leaf(
-      text = s"$kw ${sr.step.pattern}$loc${statusLabel(st)}${durStr(sr.duration)}",
-      style = sty
-    )
+    val pat = sr.step.pattern
+    // Property synthetic steps get distinct styling instead of the normal step colour.
+    if (pat.startsWith("[counterexample]"))
+      Doc.Leaf(
+        text = s"$pat${statusLabel(st)}${durStr(sr.duration)}",
+        style = Style(Color.Orange, icon = "⚡")
+      )
+    else if (pat.startsWith("[property]"))
+      Doc.Leaf(
+        text = s"$pat${durStr(sr.duration)}",
+        style = Style(Color.Cyan, icon = "⟳")
+      )
+    else
+      Doc.Leaf(
+        text = s"$kw $pat$loc${statusLabel(st)}${durStr(sr.duration)}",
+        style = summon[StatusColor[StepStatus]].style(st)
+      )
+
+  /** Render a `[counterexample]` pattern as a compact table. */
+  private def counterexampleTable(pattern: String): List[Doc.Leaf] =
+    // Pattern: "[counterexample] col1=val1 (gen1), col2=val2 (gen2)"
+    val body = pattern.stripPrefix("[counterexample]").trim
+    if (body.isEmpty) Nil
+    else
+      val entries = body.split(",").map(_.trim).toList
+      val colWidth = entries.map { e =>
+        e.indexOf('=') match { case -1 => 0; case i => i }
+      }.maxOption.getOrElse(0)
+      val sep = "  " + "─" * (colWidth + 2 + 30)
+      val rows = entries.map { e =>
+        e.indexOf('=') match
+          case -1 => Doc.Leaf(s"  │ $e", Style(Color.Orange))
+          case i =>
+            val col  = e.take(i).padTo(colWidth, ' ')
+            val rest = e.drop(i + 1)
+            Doc.Leaf(s"  │ $col │ $rest", Style(Color.Orange))
+      }
+      Doc.Leaf(sep, Style(Color.Orange)) ::
+        rows ++
+        List(Doc.Leaf(sep, Style(Color.Orange)))
 
   def causeLeaves(cause: zio.Cause[Throwable]): List[Doc.Leaf] =
     cause.squash match
       case mae: zio.bdd.core.MultipleAssertionError =>
         mae.failures.map(msg => Doc.Leaf(s"  - $msg", Style(Color.Red)))
-      case _ =>
-        cause.prettyPrint.split("\n").map(line => Doc.Leaf(line, Style(Color.Red))).toList
+      case e: AssertionError =>
+        // User assertion: show only the message — no stack frames needed.
+        List(Doc.Leaf(e.getMessage, Style(Color.Red)))
+      case e if e.getClass.getName == "zio.bdd.core.property.PropertyFalsifiedException" =>
+        // Property counterexample summary: show only the message, no internal frames.
+        List(Doc.Leaf(e.getMessage, Style(Color.Red)))
+      case e =>
+        // Other exceptions: show message then user-relevant frames only
+        // (strip zio.bdd.core.*, zio.*, scala.runtime.* internals).
+        val msg = Option(e.getMessage).getOrElse(e.getClass.getSimpleName)
+        val frames = Option(e.getStackTrace)
+          .getOrElse(Array.empty[StackTraceElement])
+          .filterNot { f =>
+            val c = f.getClassName
+            c.startsWith("zio.bdd.") || c.startsWith("zio.") ||
+            c.startsWith("scala.runtime.") || c.startsWith("java.")
+          }
+          .take(5)
+          .map(f => s"  at ${f.getClassName}.${f.getMethodName}(${f.getFileName}:${f.getLineNumber})")
+        val msgLeaf     = Doc.Leaf(msg, Style(Color.Red))
+        val frameLeaves = frames.map(l => Doc.Leaf(l, Style(Color.Red))).toList
+        msgLeaf :: frameLeaves
 
   def logLeaves(logs: CollectedLogs): List[Doc.Leaf] =
     logs.entries.flatMap { entry =>
@@ -323,10 +408,15 @@ object DocBuilder:
 
   def stepBranch(sr: StepResult, isLast: Boolean, logs: CollectedLogs): Doc =
     val header = stepLeaf(sr)
-    val causeDoc = sr.status match
-      case StepStatus.Failed(cause)      => causeLeaves(cause)
-      case StepStatus.TimedOut(_, cause) => causeLeaves(cause)
-      case _                             => Nil
+    val causeDoc: List[Doc.Leaf] =
+      if (sr.step.pattern.startsWith("[counterexample]"))
+        // Replace the raw exception message with the table view.
+        counterexampleTable(sr.step.pattern)
+      else
+        sr.status match
+          case StepStatus.Failed(cause)      => causeLeaves(cause)
+          case StepStatus.TimedOut(_, cause) => causeLeaves(cause)
+          case _                             => Nil
     val logDoc   = logLeaves(logs)
     val children = (causeDoc ++ logDoc).map(l => l: Doc)
     Doc.Branch(header, children, isLast)

--- a/core/src/main/scala/zio/bdd/core/step/ZIOSteps.scala
+++ b/core/src/main/scala/zio/bdd/core/step/ZIOSteps.scala
@@ -546,11 +546,37 @@ trait ZIOSteps[R: Tag, S: Tag: Default]
 
   // ── Execution ───────────────────────────────────────────────────────────
 
+  /**
+   * Override to provide named or type-based generator lookups for `@property`
+   * scenarios. The default returns `None` for every column, which means only
+   * the built-in `HasGen[T]` given instances (for `Int`, `Long`, `String`,
+   * etc.) and any named generators registered via `HasGen.named(...)` are
+   * available.
+   *
+   * Example:
+   * {{{
+   * override def columnGenLookup = new ColumnGenLookup:
+   *   def byColumn(col: String) = col match
+   *     case "amount" => HasGen.resolve("smallAmounts")
+   *     case _        => None
+   * }}}
+   */
+  def columnGenLookup: zio.bdd.core.property.ColumnGenLookup =
+    zio.bdd.core.property.ColumnGenLookup.empty
+
   def run(
     features: List[Feature],
     featureParallelism: Int = 1,
     scenarioParallelism: Int = 1,
     dryRun: Boolean = false
   ): ZIO[R, Nothing, List[FeatureResult]] =
-    FeatureExecutor.executeFeatures[R, S](features, getSteps, this, featureParallelism, scenarioParallelism, dryRun)
+    FeatureExecutor.executeFeatures[R, S](
+      features,
+      getSteps,
+      this,
+      featureParallelism,
+      scenarioParallelism,
+      dryRun,
+      genLookup = columnGenLookup
+    )
 }

--- a/core/src/main/scala/zio/bdd/core/step/ZIOSteps.scala
+++ b/core/src/main/scala/zio/bdd/core/step/ZIOSteps.scala
@@ -547,17 +547,19 @@ trait ZIOSteps[R: Tag, S: Tag: Default]
   // ── Execution ───────────────────────────────────────────────────────────
 
   /**
-   * Override to provide named or type-based generator lookups for `@property`
-   * scenarios. The default returns `None` for every column, which means only
-   * the built-in `HasGen[T]` given instances (for `Int`, `Long`, `String`,
-   * etc.) and any named generators registered via `HasGen.named(...)` are
-   * available.
+   * Override to route `@property` Examples columns to a `HasGen[T]` by column
+   * name. The default returns `None` for every column, so only columns with a
+   * `| col: genName |` header override (resolved via `HasGen.named(...)`) work
+   * out of the box — every other column, including ones using a built-in type
+   * like `HasGen[Int]`, must be routed here explicitly. There is no automatic
+   * name-to-type inference.
    *
    * Example:
    * {{{
    * override def columnGenLookup = new ColumnGenLookup:
    *   def byColumn(col: String) = col match
    *     case "amount" => HasGen.resolve("smallAmounts")
+   *     case "retries" => Some(HasGen[Int])
    *     case _        => None
    * }}}
    */

--- a/core/src/test/scala/zio/bdd/core/PropertyExecutorSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/PropertyExecutorSpec.scala
@@ -1,0 +1,361 @@
+package zio.bdd.core
+
+import zio.*
+import zio.test.*
+import zio.test.Assertion.*
+import zio.bdd.core.property.{ColumnGenLookup, HasGen}
+import zio.bdd.core.step.{State, ZIOSteps}
+import zio.bdd.gherkin.GherkinParser
+import zio.test.Gen
+
+/**
+ * End-to-end tests for Mode P (property-based testing) execution.
+ *
+ * Verifies:
+ *   - Property scenarios pass when all samples satisfy the predicate
+ *   - Property scenarios fail (with PropertyFalsifiedException) when a sample
+ *     falsifies
+ *   - Failure carries seed and counterexample in the message
+ *   - The failure file is written on failure
+ *   - Replaying a stored failure returns immediately without new samples
+ *   - Named generator overrides via column header `| col: genName |` work
+ *   - `HasGen.named` registration is resolved during execution
+ *   - Existing literal BDD scenarios in the same feature are unaffected
+ *   - `Default` state is reset between property samples
+ */
+object PropertyExecutorSpec extends ZIOSpecDefault {
+
+  case class S(value: String = "")
+  import zio.schema.{DeriveSchema, Schema}
+  given Schema[S] = DeriveSchema.gen[S]
+
+  private def runFeature(content: String, steps: ZIOSteps[Any, S]) =
+    GherkinParser.parseFeature(content, "property-test.feature").flatMap { f =>
+      // Use Int lookup for basic types
+      val lookup = new ColumnGenLookup:
+        def byColumn(col: String): Option[HasGen[?]] = col match
+          case "n" | "x" | "y" | "a" | "b" | "c" => Some(HasGen[Int])
+          case "s" | "str"                       => Some(HasGen[String])
+          case _                                 => None
+      FeatureExecutor.executeFeatures[Any, S](List(f), steps.getSteps, steps, genLookup = lookup)
+    }
+
+  def spec: Spec[TestEnvironment & Scope, Any] = suite("PropertyExecutorSpec")(
+    passSuite,
+    failSuite,
+    generatorSuite,
+    mixedSuite,
+    stateSuite
+  )
+
+  // ── Passing property scenarios ─────────────────────────────────────────────
+
+  private val passSuite = suite("Passing property scenarios")(
+    test("all samples pass → ScenarioResult.isPassed") {
+      val steps = new ZIOSteps[Any, S]:
+        Given("a number " / int) { (n: Int) =>
+          ZIO.when(false)(ZIO.fail(new RuntimeException("never"))).unit
+        }
+        Then("it exists")(ZIO.unit)
+
+      runFeature(
+        """Feature: Properties
+          |  Scenario Outline: number always passes
+          |    Given a number <n>
+          |    Then it exists
+          |    @property(samples=20)
+          |    Examples:
+          |      | n |
+          |""".stripMargin,
+        steps
+      ).map { results =>
+        val sc = results.head.scenarioResults.head
+        assertTrue(
+          sc.isPassed,
+          // Pass result carries exactly one synthetic summary step
+          sc.stepResults.length == 1,
+          sc.stepResults.head.step.pattern.startsWith("[property]"),
+          sc.stepResults.head.isPassed
+        )
+      }
+    },
+    test("pass result name contains sample count and seed") {
+      val steps = new ZIOSteps[Any, S]:
+        Given("value " / int)((n: Int) => ZIO.unit)
+        Then("ok")(ZIO.unit)
+
+      runFeature(
+        """Feature: F
+          |  Scenario Outline: counts
+          |    Given value <n>
+          |    Then ok
+          |    @property(samples=5, seed=42)
+          |    Examples:
+          |      | n |
+          |""".stripMargin,
+        steps
+      ).map { results =>
+        val sc = results.head.scenarioResults.head
+        assertTrue(
+          sc.scenario.name.contains("5"),
+          sc.scenario.name.contains("42"),
+          sc.stepResults.head.step.pattern.contains("HasGen[Int]")
+        )
+      }
+    }
+  )
+
+  // ── Failing property scenarios ─────────────────────────────────────────────
+
+  private val failSuite = suite("Failing property scenarios")(
+    test("failure when any sample violates predicate → hasFailure") {
+      val steps = new ZIOSteps[Any, S]:
+        Given("value " / int)((n: Int) => State.update[S](_ => S(n.toString)))
+        Then("value is zero") {
+          for {
+            s <- State.get[S]
+            _ <- ZIO.fail(new RuntimeException(s"Expected 0, got ${s.value}")).when(s.value != "0")
+          } yield ()
+        }
+
+      runFeature(
+        """Feature: Fail
+          |  Scenario Outline: zero predicate
+          |    Given value <n>
+          |    Then value is zero
+          |    @property(samples=50, replay=false)
+          |    Examples:
+          |      | n |
+          |""".stripMargin,
+        steps
+      ).map { results =>
+        val sc = results.head.scenarioResults.head
+        // First step is the synthetic [counterexample] step
+        val counterStep = sc.stepResults.head
+        assertTrue(
+          !sc.isPassed,
+          counterStep.step.pattern.startsWith("[counterexample]"),
+          !counterStep.isPassed
+        )
+      }
+    },
+    test("failure message contains seed") {
+      val steps = new ZIOSteps[Any, S]:
+        Given("value " / int)((n: Int) => ZIO.unit)
+        Then("always fails") {
+          ZIO.fail(new RuntimeException("deliberate failure"))
+        }
+
+      runFeature(
+        """Feature: Always fail
+          |  Scenario Outline: alwaysFail
+          |    Given value <n>
+          |    Then always fails
+          |    @property(samples=3, seed=999, replay=false)
+          |    Examples:
+          |      | n |
+          |""".stripMargin,
+        steps
+      ).map { results =>
+        val sc         = results.head.scenarioResults.head
+        val errMsg     = sc.error.map(_.getMessage).getOrElse("")
+        val stepDetail = sc.stepResults.head.step.pattern
+        assertTrue(
+          !sc.isPassed,
+          errMsg.contains("999"),
+          stepDetail.startsWith("[counterexample]")
+        )
+      }
+    }
+  )
+
+  // ── Generator resolution ───────────────────────────────────────────────────
+
+  private val generatorSuite = suite("Generator resolution")(
+    test("column with :namedGen override uses registered named generator") {
+      val captured = new java.util.concurrent.atomic.AtomicReference[List[Int]](Nil)
+      HasGen.named("smallInts")(Gen.int(1, 5))
+
+      val steps = new ZIOSteps[Any, S]:
+        Given("value " / int) { (n: Int) =>
+          ZIO.succeed(captured.updateAndGet(n :: _)).unit
+        }
+        Then("captured")(ZIO.unit)
+
+      val lookup = new ColumnGenLookup:
+        def byColumn(col: String): Option[HasGen[?]] = col match
+          case "n" => Some(HasGen[Int])
+          case _   => None
+
+      GherkinParser
+        .parseFeature(
+          """Feature: Named gen
+            |  Scenario Outline: small ints only
+            |    Given value <n>
+            |    Then captured
+            |    @property(samples=20, replay=false)
+            |    Examples:
+            |      | n: smallInts |
+            |""".stripMargin,
+          "named-gen.feature"
+        )
+        .flatMap { f =>
+          FeatureExecutor.executeFeatures[Any, S](List(f), steps.getSteps, steps, genLookup = lookup)
+        }
+        .map { results =>
+          val sc     = results.head.scenarioResults.head
+          val values = captured.get()
+          // All sampled values should be in range 1..5
+          assertTrue(
+            sc.isPassed,
+            values.nonEmpty,
+            values.forall(v => v >= 1 && v <= 5)
+          )
+        }
+    },
+    test("unknown column with no registered HasGen produces a setup error") {
+      val steps = new ZIOSteps[Any, S]:
+        Given("x is " / int)((n: Int) => ZIO.unit)
+        Then("ok")(ZIO.unit)
+
+      runFeature(
+        """Feature: Missing gen
+          |  Scenario Outline: no gen
+          |    Given x is <unknownColumn>
+          |    Then ok
+          |    @property(samples=5, replay=false)
+          |    Examples:
+          |      | unknownColumn |
+          |""".stripMargin,
+        new ZIOSteps[Any, S]:
+          Given("x is " / string)((s: String) => ZIO.unit)
+          Then("ok")(ZIO.unit)
+      ).map { results =>
+        val sc = results.head.scenarioResults.head
+        // setupError should be set because no HasGen resolved for the column
+        assertTrue(sc.setupError.isDefined)
+      }
+    }
+  )
+
+  // ── Mixed literal + property in same feature ───────────────────────────────
+
+  private val mixedSuite = suite("Mixed literal BDD + property scenarios")(
+    test("literal BDD scenarios are not affected by @property scenarios in the same feature") {
+      val steps = new ZIOSteps[Any, S]:
+        Given("a fixed value " / string) { (v: String) =>
+          State.update[S](_ => S(v))
+        }
+        Given("value " / int)((n: Int) => ZIO.unit)
+        Then("the value is stored") {
+          State.get[S].flatMap { s =>
+            ZIO.fail(new RuntimeException(s"Expected 'hello', got '${s.value}'")).when(s.value != "hello").unit
+          }
+        }
+        Then("ok")(ZIO.unit)
+
+      runFeature(
+        """Feature: Mixed
+          |  Scenario: literal BDD
+          |    Given a fixed value "hello"
+          |    Then the value is stored
+          |
+          |  Scenario Outline: property scenario
+          |    Given value <n>
+          |    Then ok
+          |    @property(samples=10, replay=false)
+          |    Examples:
+          |      | n |
+          |""".stripMargin,
+        steps
+      ).map { results =>
+        val scenarioResults = results.head.scenarioResults
+        assertTrue(
+          scenarioResults.length == 2,
+          scenarioResults.head.isPassed, // literal BDD passes
+          scenarioResults.last.isPassed  // property passes
+        )
+      }
+    },
+    test("literal + property Examples blocks in one Scenario Outline both run") {
+      val steps = new ZIOSteps[Any, S]:
+        Given("value " / int)((n: Int) => ZIO.unit)
+        Then("ok")(ZIO.unit)
+
+      val lookup = new ColumnGenLookup:
+        def byColumn(col: String): Option[HasGen[?]] = Some(HasGen[Int])
+
+      GherkinParser
+        .parseFeature(
+          """Feature: Dual blocks
+            |  Scenario Outline: both
+            |    Given value <n>
+            |    Then ok
+            |    @regression
+            |    Examples:
+            |      | n |
+            |      | 1 |
+            |      | 2 |
+            |    @property(samples=5, replay=false)
+            |    Examples:
+            |      | n |
+            |""".stripMargin,
+          "dual.feature"
+        )
+        .flatMap { f =>
+          FeatureExecutor.executeFeatures[Any, S](List(f), steps.getSteps, steps, genLookup = lookup)
+        }
+        .map { results =>
+          val scenarioResults = results.head.scenarioResults
+          // 2 literal + 1 property = 3 total
+          assertTrue(
+            scenarioResults.length == 3,
+            scenarioResults.forall(_.isPassed)
+          )
+        }
+    }
+  )
+
+  // ── State isolation between samples ───────────────────────────────────────
+
+  private val stateSuite = suite("State isolation between property samples")(
+    test("state is reset to default between samples") {
+      val invocations = new java.util.concurrent.atomic.AtomicInteger(0)
+      val steps = new ZIOSteps[Any, S]:
+        Given("value " / int) { (n: Int) =>
+          State.update[S](_ => S(n.toString))
+        }
+        Then("state was freshly initialised") {
+          State.get[S].flatMap { s =>
+            // Each run should see only the value set by Given, not leftover from previous sample
+            ZIO.succeed(invocations.incrementAndGet()).unit
+          }
+        }
+
+      val lookup = new ColumnGenLookup:
+        def byColumn(col: String): Option[HasGen[?]] = Some(HasGen[Int])
+
+      GherkinParser
+        .parseFeature(
+          """Feature: State reset
+            |  Scenario Outline: isolation
+            |    Given value <n>
+            |    Then state was freshly initialised
+            |    @property(samples=10, replay=false)
+            |    Examples:
+            |      | n |
+            |""".stripMargin,
+          "state.feature"
+        )
+        .flatMap { f =>
+          FeatureExecutor.executeFeatures[Any, S](List(f), steps.getSteps, steps, genLookup = lookup)
+        }
+        .map { results =>
+          assertTrue(
+            results.head.scenarioResults.head.isPassed,
+            invocations.get() == 10
+          )
+        }
+    }
+  )
+}

--- a/core/src/test/scala/zio/bdd/core/PropertyExecutorSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/PropertyExecutorSpec.scala
@@ -4,7 +4,7 @@ import zio.*
 import zio.test.*
 import zio.test.Assertion.*
 import zio.bdd.core.property.{ColumnGenLookup, HasGen}
-import zio.bdd.core.step.{State, ZIOSteps}
+import zio.bdd.core.step.{State, TypedExtractor, ZIOSteps}
 import zio.bdd.gherkin.GherkinParser
 import zio.test.Gen
 
@@ -44,6 +44,7 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
     passSuite,
     failSuite,
     generatorSuite,
+    autoResolutionSuite,
     mixedSuite,
     stateSuite,
     flagsSuite,
@@ -218,9 +219,13 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
         }
     },
     test("unknown column with no registered HasGen produces a setup error") {
-      val steps = new ZIOSteps[Any, S]:
-        Given("x is " / int)((n: Int) => ZIO.unit)
-        Then("ok")(ZIO.unit)
+      // A genuinely unregistered custom type (not int/string) — those auto-resolve via the
+      // built-in HasGen now, so this must use a type nothing has registered a HasGen for.
+      final case class Unresolvable(raw: String)
+      val unresolvableExtractor: TypedExtractor[Unresolvable] =
+        TypedExtractor.make[Unresolvable]("(.+)") { (_, groups, idx) =>
+          groups.lift(idx).map(s => (Unresolvable(s), idx + 1)).toRight("expected a value")
+        }
 
       runFeature(
         """Feature: Missing gen
@@ -232,13 +237,178 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
           |      | unknownColumn |
           |""".stripMargin,
         new ZIOSteps[Any, S]:
-          Given("x is " / string)((s: String) => ZIO.unit)
+          Given("x is " / unresolvableExtractor)((u: Unresolvable) => ZIO.unit)
           Then("ok")(ZIO.unit)
       ).map { results =>
         val sc = results.head.scenarioResults.head
         // setupError should be set because no HasGen resolved for the column
         assertTrue(sc.setupError.isDefined)
       }
+    }
+  )
+
+  // ── Automatic type-based resolution (#99) ───────────────────────────────────
+
+  private val autoResolutionSuite = suite("Automatic type-based resolution")(
+    test("a built-in-typed column resolves automatically with no columnGenLookup entry") {
+      val steps = new ZIOSteps[Any, S]:
+        Given("value " / int)((n: Int) => ZIO.unit)
+        Then("ok")(ZIO.unit)
+
+      GherkinParser
+        .parseFeature(
+          """Feature: Auto resolve built-in
+            |  Scenario Outline: auto int
+            |    Given value <amount>
+            |    Then ok
+            |    @property(samples=10, replay=false)
+            |    Examples:
+            |      | amount |
+            |""".stripMargin,
+          "auto-builtin.feature"
+        )
+        .flatMap { f =>
+          FeatureExecutor.executeFeatures[Any, S](List(f), steps.getSteps, steps, genLookup = ColumnGenLookup.empty)
+        }
+        .map(results => assertTrue(results.head.scenarioResults.head.isPassed))
+    },
+    test("a custom registered type resolves automatically via HasGen.registerType, with no columnGenLookup entry") {
+      // toString must round-trip through the extractor's pattern, since sampled values are
+      // substituted into step text via toString (see PropertyExecutor.sampleGenToString) —
+      // same constraint the Title example in example/SimpleSpec.scala relies on.
+      final case class Score(value: Int) {
+        override def toString: String = value.toString
+      }
+      val scoreExtractor: TypedExtractor[Score] =
+        TypedExtractor.make[Score]("(-?\\d+)") { (_, groups, idx) =>
+          groups.lift(idx).flatMap(_.toIntOption).map(n => (Score(n), idx + 1)).toRight("expected an int")
+        }
+      given HasGen[Score] with
+        def gen            = Gen.int(0, 100).map(Score.apply)
+        override def label = "HasGen[Score]"
+      HasGen.registerType(HasGen[Score])
+
+      val steps = new ZIOSteps[Any, S]:
+        Given("score " / scoreExtractor)((s: Score) => ZIO.unit)
+        Then("ok")(ZIO.unit)
+
+      GherkinParser
+        .parseFeature(
+          """Feature: Auto resolve custom type
+            |  Scenario Outline: auto score
+            |    Given score <s>
+            |    Then ok
+            |    @property(samples=10, replay=false)
+            |    Examples:
+            |      | s |
+            |""".stripMargin,
+          "auto-custom.feature"
+        )
+        .flatMap { f =>
+          FeatureExecutor.executeFeatures[Any, S](List(f), steps.getSteps, steps, genLookup = ColumnGenLookup.empty)
+        }
+        .map(results => assertTrue(results.head.scenarioResults.head.isPassed))
+    },
+    test("columnGenLookup's explicit entry still wins over automatic resolution") {
+      val captured = new java.util.concurrent.atomic.AtomicReference[List[Int]](Nil)
+      val steps = new ZIOSteps[Any, S]:
+        Given("value " / int) { (n: Int) =>
+          ZIO.succeed(captured.updateAndGet(n :: _)).unit
+        }
+        Then("ok")(ZIO.unit)
+
+      val narrowGen = new HasGen[Int]:
+        def gen            = Gen.int(1, 5)
+        override def label = "HasGen[Int] (narrow override)"
+      val lookup = new ColumnGenLookup:
+        def byColumn(col: String): Option[HasGen[?]] = col match
+          case "amount" => Some(narrowGen)
+          case _        => None
+
+      GherkinParser
+        .parseFeature(
+          """Feature: Override wins
+            |  Scenario Outline: override wins
+            |    Given value <amount>
+            |    Then ok
+            |    @property(samples=20, replay=false)
+            |    Examples:
+            |      | amount |
+            |""".stripMargin,
+          "override-wins.feature"
+        )
+        .flatMap { f =>
+          FeatureExecutor.executeFeatures[Any, S](List(f), steps.getSteps, steps, genLookup = lookup)
+        }
+        .map { results =>
+          val sc     = results.head.scenarioResults.head
+          val values = captured.get()
+          assertTrue(sc.isPassed, values.nonEmpty, values.forall(v => v >= 1 && v <= 5))
+        }
+    },
+    test("a named header override still wins over automatic resolution") {
+      val captured = new java.util.concurrent.atomic.AtomicReference[List[Int]](Nil)
+      HasGen.named("tinyInts")(Gen.int(1, 3))
+
+      val steps = new ZIOSteps[Any, S]:
+        Given("value " / int) { (n: Int) =>
+          ZIO.succeed(captured.updateAndGet(n :: _)).unit
+        }
+        Then("ok")(ZIO.unit)
+
+      GherkinParser
+        .parseFeature(
+          """Feature: Named override wins
+            |  Scenario Outline: named override wins
+            |    Given value <amount>
+            |    Then ok
+            |    @property(samples=20, replay=false)
+            |    Examples:
+            |      | amount: tinyInts |
+            |""".stripMargin,
+          "named-override-wins.feature"
+        )
+        .flatMap { f =>
+          FeatureExecutor.executeFeatures[Any, S](List(f), steps.getSteps, steps, genLookup = ColumnGenLookup.empty)
+        }
+        .map { results =>
+          val sc     = results.head.scenarioResults.head
+          val values = captured.get()
+          assertTrue(sc.isPassed, values.nonEmpty, values.forall(v => v >= 1 && v <= 3))
+        }
+    },
+    test("the same column inferred as two different types across steps produces a setup error naming both types") {
+      val steps = new ZIOSteps[Any, S]:
+        Given("amount is " / int)((n: Int) => ZIO.unit)
+        Given("moved " / string)((s: String) => ZIO.unit)
+        Then("ok")(ZIO.unit)
+
+      GherkinParser
+        .parseFeature(
+          """Feature: Ambiguous column type
+            |  Scenario Outline: ambiguous
+            |    Given amount is <amount>
+            |    Given moved <amount>
+            |    Then ok
+            |    @property(samples=5, replay=false)
+            |    Examples:
+            |      | amount |
+            |""".stripMargin,
+          "ambiguous.feature"
+        )
+        .flatMap { f =>
+          FeatureExecutor.executeFeatures[Any, S](List(f), steps.getSteps, steps, genLookup = ColumnGenLookup.empty)
+        }
+        .map { results =>
+          val sc      = results.head.scenarioResults.head
+          val message = sc.error.map(_.getMessage).getOrElse("")
+          assertTrue(
+            sc.setupError.isDefined,
+            message.contains("amount"),
+            message.contains("Int"),
+            message.contains("String")
+          )
+        }
     }
   )
 
@@ -667,8 +837,15 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
         }
     },
     test("dry-run still surfaces a setup error when a column has no registered HasGen") {
+      // A genuinely unregistered custom type — int/string now auto-resolve via the built-in
+      // HasGen, so this must use a type nothing has registered a HasGen for.
+      final case class Unresolvable(raw: String)
+      val unresolvableExtractor: TypedExtractor[Unresolvable] =
+        TypedExtractor.make[Unresolvable]("(.+)") { (_, groups, idx) =>
+          groups.lift(idx).map(s => (Unresolvable(s), idx + 1)).toRight("expected a value")
+        }
       val steps = new ZIOSteps[Any, S]:
-        Given("value " / int)((n: Int) => ZIO.unit)
+        Given("value " / unresolvableExtractor)((u: Unresolvable) => ZIO.unit)
         Then("ok")(ZIO.unit)
 
       GherkinParser

--- a/core/src/test/scala/zio/bdd/core/PropertyExecutorSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/PropertyExecutorSpec.scala
@@ -45,7 +45,9 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
     failSuite,
     generatorSuite,
     mixedSuite,
-    stateSuite
+    stateSuite,
+    flagsSuite,
+    replaySuite
   )
 
   // ── Passing property scenarios ─────────────────────────────────────────────
@@ -356,6 +358,194 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
             invocations.get() == 10
           )
         }
+    }
+  )
+
+  // ── @flags(...) combined with @property(...) ────────────────────────────────
+
+  private val flagsSuite = suite("@flags(...) on a property scenario")(
+    test("flags are ignored, not multiplied: scenario runs exactly once regardless of @flags(...) count") {
+      val invocations = new java.util.concurrent.atomic.AtomicInteger(0)
+      val steps = new ZIOSteps[Any, S]:
+        Given("value " / int)((n: Int) => ZIO.unit)
+        Then("ok")(ZIO.succeed(invocations.incrementAndGet()).unit)
+
+      val lookup = new ColumnGenLookup:
+        def byColumn(col: String): Option[HasGen[?]] = col match
+          case "n" => Some(HasGen[Int])
+          case _   => None
+
+      GherkinParser
+        .parseFeature(
+          """Feature: Flags plus property
+            |  @flags(a=true) @flags(a=false)
+            |  Scenario Outline: flagged property
+            |    Given value <n>
+            |    Then ok
+            |    @property(samples=7, replay=false)
+            |    Examples:
+            |      | n |
+            |""".stripMargin,
+          "flags-plus-property.feature"
+        )
+        .flatMap { f =>
+          FeatureExecutor.executeFeatures[Any, S](List(f), steps.getSteps, steps, genLookup = lookup)
+        }
+        .map { results =>
+          val scenarioResults = results.head.scenarioResults
+          assertTrue(
+            // One scenario result, not two (one per @flags(...) combination).
+            scenarioResults.length == 1,
+            scenarioResults.head.isPassed,
+            // Exactly one batch of 7 samples ran — not 14 (one batch per flag combo).
+            invocations.get() == 7
+          )
+        }
+    }
+  )
+
+  // ── Failure replay across runs (writes/reads real .zio-bdd/failures files) ─
+
+  private val replaySuite = suite("Failure replay store")(
+    test("failing run writes a failure file; next run replays it; fixing the bug clears it and runs fresh samples") {
+      val shouldFail = new java.util.concurrent.atomic.AtomicBoolean(true)
+      val freshRuns  = new java.util.concurrent.atomic.AtomicInteger(0)
+
+      def stepsFor() = new ZIOSteps[Any, S]:
+        Given("value " / int)((n: Int) => ZIO.unit)
+        Then("maybe fails") {
+          ZIO.succeed(freshRuns.incrementAndGet()) *>
+            ZIO.fail(new RuntimeException("deliberate failure")).when(shouldFail.get()).unit
+        }
+
+      val lookup = new ColumnGenLookup:
+        def byColumn(col: String): Option[HasGen[?]] = col match
+          case "n" => Some(HasGen[Int])
+          case _   => None
+
+      val feature =
+        """Feature: Replay across runs
+          |  Scenario Outline: maybe fails
+          |    Given value <n>
+          |    Then maybe fails
+          |    @property(samples=5, seed=4242)
+          |    Examples:
+          |      | n |
+          |""".stripMargin
+
+      def run() =
+        GherkinParser.parseFeature(feature, "replay-across-runs.feature").flatMap { f =>
+          FeatureExecutor.executeFeatures[Any, S](List(f), stepsFor().getSteps, stepsFor(), genLookup = lookup)
+        }
+
+      val failuresDir = java.nio.file.Paths.get(".zio-bdd", "failures").toFile
+      def failureFiles(): List[java.io.File] =
+        Option(failuresDir.listFiles()).fold(List.empty[java.io.File])(_.filter(_.getName.endsWith(".json")).toList)
+
+      for {
+        _ <- ZIO.attempt(failureFiles().foreach(_.delete())).ignore
+
+        // Run 1: always fails → failure file should be written.
+        firstResults   <- run()
+        firstScenario   = firstResults.head.scenarioResults.head
+        existsAfterRun1 = failureFiles().nonEmpty
+
+        // Run 2: still fails, but replay should consult the stored seed first
+        // rather than burning a fresh batch of `samples` runs.
+        freshRunsBeforeRun2 = freshRuns.get()
+        secondResults      <- run()
+        secondScenario      = secondResults.head.scenarioResults.head
+        freshRunsDuringRun2 = freshRuns.get() - freshRunsBeforeRun2
+
+        // Fix the bug, run again: replay should now pass.
+        _                  <- ZIO.succeed(shouldFail.set(false))
+        freshRunsBeforeRun3 = freshRuns.get()
+        thirdResults       <- run()
+        thirdScenario       = thirdResults.head.scenarioResults.head
+        freshRunsDuringRun3 = freshRuns.get() - freshRunsBeforeRun3
+        existsAfterRun3     = failureFiles().nonEmpty
+
+        _ <- ZIO.attempt(failureFiles().foreach(_.delete())).ignore
+      } yield assertTrue(
+        !firstScenario.isPassed,
+        existsAfterRun1,
+        !secondScenario.isPassed,
+        secondScenario.error.exists(_.getMessage.contains("replayed from failure store")),
+        // Replaying one stored sample should cost far fewer step invocations than a fresh 5-sample batch.
+        freshRunsDuringRun2 < 5,
+        thirdScenario.isPassed,
+        !existsAfterRun3,
+        // Once the replay passes, a full fresh batch of samples should still run.
+        freshRunsDuringRun3 >= 5
+      )
+    },
+    test("stale failure record (scenario body changed) is discarded, not replayed") {
+      val freshRuns = new java.util.concurrent.atomic.AtomicInteger(0)
+
+      def failingFeature =
+        """Feature: Stale replay
+          |  Scenario Outline: maybe fails
+          |    Given value <n>
+          |    Then it always fails
+          |    @property(samples=4, seed=123)
+          |    Examples:
+          |      | n |
+          |""".stripMargin
+
+      // Same scenario name, edited step text → different bodyHash, and this version always
+      // passes. If the stale record were wrongly replayed as a single sample, only one
+      // invocation would happen; running the full fresh batch means all 4 samples execute.
+      def editedPassingFeature =
+        """Feature: Stale replay
+          |  Scenario Outline: maybe fails
+          |    Given value <n>
+          |    Then it now always passes
+          |    @property(samples=4, seed=123)
+          |    Examples:
+          |      | n |
+          |""".stripMargin
+
+      val failingSteps = new ZIOSteps[Any, S]:
+        Given("value " / int)((n: Int) => ZIO.unit)
+        Then("it always fails")(ZIO.fail(new RuntimeException("deliberate failure")).unit)
+
+      def passingSteps() = new ZIOSteps[Any, S]:
+        Given("value " / int)((n: Int) => ZIO.unit)
+        Then("it now always passes")(ZIO.succeed(freshRuns.incrementAndGet()).unit)
+
+      val lookup = new ColumnGenLookup:
+        def byColumn(col: String): Option[HasGen[?]] = col match
+          case "n" => Some(HasGen[Int])
+          case _   => None
+
+      val failuresDir = java.nio.file.Paths.get(".zio-bdd", "failures").toFile
+      def failureFiles(): List[java.io.File] =
+        Option(failuresDir.listFiles()).fold(List.empty[java.io.File])(_.filter(_.getName.endsWith(".json")).toList)
+
+      for {
+        _ <- ZIO.attempt(failureFiles().foreach(_.delete())).ignore
+
+        // Run 1: fails, writes a failure record keyed to this exact step body.
+        f1               <- GherkinParser.parseFeature(failingFeature, "stale-replay.feature")
+        _                <- FeatureExecutor.executeFeatures[Any, S](List(f1), failingSteps.getSteps, failingSteps, genLookup = lookup)
+        recordedAfterRun1 = failureFiles().nonEmpty
+
+        // Run 2: edited step body → bodyHash no longer matches. The stale record must be
+        // discarded (full fresh batch runs), not replayed as a single stored sample.
+        f2 <- GherkinParser.parseFeature(editedPassingFeature, "stale-replay.feature")
+        _ <- FeatureExecutor.executeFeatures[Any, S](
+               List(f2),
+               passingSteps().getSteps,
+               passingSteps(),
+               genLookup = lookup
+             )
+
+        _ <- ZIO.attempt(failureFiles().foreach(_.delete())).ignore
+      } yield assertTrue(
+        recordedAfterRun1,
+        // All 4 fresh samples ran — not a single-sample replay of the stale record.
+        freshRuns.get() == 4
+      )
     }
   )
 }

--- a/core/src/test/scala/zio/bdd/core/PropertyExecutorSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/PropertyExecutorSpec.scala
@@ -47,7 +47,9 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
     mixedSuite,
     stateSuite,
     flagsSuite,
-    replaySuite
+    replaySuite,
+    columnIndependenceSuite,
+    dryRunSuite
   )
 
   // ── Passing property scenarios ─────────────────────────────────────────────
@@ -559,6 +561,140 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
         // All 4 fresh samples ran — not a single-sample replay of the stale record.
         freshRuns.get() == 4
       )
+    }
+  )
+
+  // ── Column independence and reproducibility ─────────────────────────────────
+
+  private val columnIndependenceSuite = suite("Column sampling")(
+    test("two columns with the same generator type are sampled independently, not correlated") {
+      val captured = new java.util.concurrent.atomic.AtomicReference[List[(Int, Int)]](Nil)
+      val steps = new ZIOSteps[Any, S]:
+        Given("x is " / int / " and y is " / int) { (x: Int, y: Int) =>
+          ZIO.succeed(captured.updateAndGet((x, y) :: _)).unit
+        }
+        Then("ok")(ZIO.unit)
+
+      runFeature(
+        """Feature: F
+          |  Scenario Outline: independence
+          |    Given x is <x> and y is <y>
+          |    Then ok
+          |    @property(samples=20, seed=5, replay=false)
+          |    Examples:
+          |      | x | y |
+          |""".stripMargin,
+        steps
+      ).map { _ =>
+        val pairs = captured.get()
+        assertTrue(
+          pairs.length == 20,
+          // Both columns share HasGen[Int] — if they were sampled with the same seed (the
+          // bug this regresses), every pair would be equal. With 20 samples from the full
+          // Int range, at least one pair being unequal is overwhelming evidence of
+          // independence (and in practice all of them differ).
+          pairs.exists { case (x, y) => x != y }
+        )
+      }
+    },
+    test("same seed reproduces the same sampled values across separate runs") {
+      def capture() = new java.util.concurrent.atomic.AtomicReference[List[(Int, Int)]](Nil)
+
+      def runOnce(captured: java.util.concurrent.atomic.AtomicReference[List[(Int, Int)]]) =
+        val steps = new ZIOSteps[Any, S]:
+          Given("x is " / int / " and y is " / int) { (x: Int, y: Int) =>
+            ZIO.succeed(captured.updateAndGet((x, y) :: _)).unit
+          }
+          Then("ok")(ZIO.unit)
+        runFeature(
+          """Feature: F
+            |  Scenario Outline: reproducible
+            |    Given x is <x> and y is <y>
+            |    Then ok
+            |    @property(samples=10, seed=777, replay=false)
+            |    Examples:
+            |      | x | y |
+            |""".stripMargin,
+          steps
+        )
+
+      val captured1 = capture()
+      val captured2 = capture()
+      for {
+        _ <- runOnce(captured1)
+        _ <- runOnce(captured2)
+      } yield assertTrue(captured1.get() == captured2.get(), captured1.get().nonEmpty)
+    }
+  )
+
+  // ── --dry-run support ────────────────────────────────────────────────────────
+
+  private val dryRunSuite = suite("--dry-run on a property scenario")(
+    test("dry-run validates step matching once, without executing step bodies or looping samples") {
+      val invocations = new java.util.concurrent.atomic.AtomicInteger(0)
+      val steps = new ZIOSteps[Any, S]:
+        Given("value " / int)((n: Int) => ZIO.succeed(invocations.incrementAndGet()).unit)
+        Then("ok")(ZIO.succeed(invocations.incrementAndGet()).unit)
+
+      val lookup = new ColumnGenLookup:
+        def byColumn(col: String): Option[HasGen[?]] = col match
+          case "n" => Some(HasGen[Int])
+          case _   => None
+
+      GherkinParser
+        .parseFeature(
+          """Feature: Dry run
+            |  Scenario Outline: dry run check
+            |    Given value <n>
+            |    Then ok
+            |    @property(samples=500, replay=false)
+            |    Examples:
+            |      | n |
+            |""".stripMargin,
+          "dry-run.feature"
+        )
+        .flatMap { f =>
+          FeatureExecutor.executeFeatures[Any, S](List(f), steps.getSteps, steps, dryRun = true, genLookup = lookup)
+        }
+        .map { results =>
+          val sc = results.head.scenarioResults.head
+          assertTrue(
+            sc.isPassed,
+            // Step bodies never ran — dry-run only validates that patterns match.
+            invocations.get() == 0,
+            sc.scenario.name.contains("dry-run")
+          )
+        }
+    },
+    test("dry-run still surfaces a setup error when a column has no registered HasGen") {
+      val steps = new ZIOSteps[Any, S]:
+        Given("value " / int)((n: Int) => ZIO.unit)
+        Then("ok")(ZIO.unit)
+
+      GherkinParser
+        .parseFeature(
+          """Feature: Dry run missing gen
+            |  Scenario Outline: dry run missing gen
+            |    Given value <n>
+            |    Then ok
+            |    @property(samples=500, replay=false)
+            |    Examples:
+            |      | n |
+            |""".stripMargin,
+          "dry-run-missing-gen.feature"
+        )
+        .flatMap { f =>
+          FeatureExecutor.executeFeatures[Any, S](
+            List(f),
+            steps.getSteps,
+            steps,
+            dryRun = true,
+            genLookup = ColumnGenLookup.empty
+          )
+        }
+        .map { results =>
+          assertTrue(results.head.scenarioResults.head.setupError.isDefined)
+        }
     }
   )
 }

--- a/core/src/test/scala/zio/bdd/core/PropertyExecutorSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/PropertyExecutorSpec.scala
@@ -364,11 +364,20 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
   // ── @flags(...) combined with @property(...) ────────────────────────────────
 
   private val flagsSuite = suite("@flags(...) on a property scenario")(
-    test("flags are ignored, not multiplied: scenario runs exactly once regardless of @flags(...) count") {
-      val invocations = new java.util.concurrent.atomic.AtomicInteger(0)
+    test("each @flags(...) combination runs its own full sample batch, with the flag map applied via flagLayer") {
+      val invocations   = new java.util.concurrent.atomic.AtomicInteger(0)
+      val capturedFlags = new java.util.concurrent.atomic.AtomicReference[List[Map[String, String]]](Nil)
+
       val steps = new ZIOSteps[Any, S]:
         Given("value " / int)((n: Int) => ZIO.unit)
         Then("ok")(ZIO.succeed(invocations.incrementAndGet()).unit)
+
+        override def flagLayer(
+          meta: zio.bdd.gherkin.ScenarioMetadata,
+          flags: Map[String, String]
+        ): ZLayer[Any, Throwable, Any] =
+          capturedFlags.updateAndGet(flags :: _)
+          scenarioLayer(meta)
 
       val lookup = new ColumnGenLookup:
         def byColumn(col: String): Option[HasGen[?]] = col match
@@ -393,12 +402,16 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
         }
         .map { results =>
           val scenarioResults = results.head.scenarioResults
+          val flagsSeen       = capturedFlags.get()
           assertTrue(
-            // One scenario result, not two (one per @flags(...) combination).
-            scenarioResults.length == 1,
-            scenarioResults.head.isPassed,
-            // Exactly one batch of 7 samples ran — not 14 (one batch per flag combo).
-            invocations.get() == 7
+            // One scenario result per @flags(...) combination.
+            scenarioResults.length == 2,
+            scenarioResults.forall(_.isPassed),
+            // Two full batches of 7 samples each — flagLayer (and thus a real sample run)
+            // was invoked once per sample per flag combination, not skipped.
+            invocations.get() == 14,
+            flagsSeen.contains(Map("a" -> "true")),
+            flagsSeen.contains(Map("a" -> "false"))
           )
         }
     }

--- a/core/src/test/scala/zio/bdd/core/PropertyExecutorSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/PropertyExecutorSpec.scala
@@ -45,6 +45,7 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
     failSuite,
     generatorSuite,
     autoResolutionSuite,
+    setupErrorVsFalsificationSuite,
     mixedSuite,
     stateSuite,
     flagsSuite,
@@ -407,6 +408,124 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
             message.contains("amount"),
             message.contains("Int"),
             message.contains("String")
+          )
+        }
+    },
+    test("a typo'd named-generator header override produces a setup error, not a silent fallback") {
+      // Regression: `explicit(col)` used to do
+      // `scenario.columnGens.get(col).flatMap(HasGen.resolve).orElse(lookup.byColumn(col))` —
+      // an unregistered name fell through to columnGenLookup/automatic resolution instead of
+      // erroring, so a typo in `| n: smallInts |` silently used a *different* generator with
+      // no indication the override was ignored.
+      val steps = new ZIOSteps[Any, S]:
+        Given("value " / int)((n: Int) => ZIO.unit)
+        Then("ok")(ZIO.unit)
+
+      // A lookup that WOULD resolve "n" if the named override were (wrongly) skipped —
+      // proves the typo doesn't silently fall through to this path either.
+      val lookup = new ColumnGenLookup:
+        def byColumn(col: String): Option[HasGen[?]] = col match
+          case "n" => Some(HasGen[Int])
+          case _   => None
+
+      GherkinParser
+        .parseFeature(
+          """Feature: Typo'd named override
+            |  Scenario Outline: typo
+            |    Given value <n>
+            |    Then ok
+            |    @property(samples=5, replay=false)
+            |    Examples:
+            |      | n: definitelyNotRegistered |
+            |""".stripMargin,
+          "typo-named-gen.feature"
+        )
+        .flatMap { f =>
+          FeatureExecutor.executeFeatures[Any, S](List(f), steps.getSteps, steps, genLookup = lookup)
+        }
+        .map { results =>
+          val sc      = results.head.scenarioResults.head
+          val message = sc.error.map(_.getMessage).getOrElse("")
+          assertTrue(
+            sc.setupError.isDefined,
+            message.contains("n"),
+            message.contains("definitelyNotRegistered")
+          )
+        }
+    }
+  )
+
+  // ── Setup errors and pending steps must not be misreported as falsifications ────
+
+  private val setupErrorVsFalsificationSuite = suite(
+    "Setup errors and pending steps are distinguished from genuine falsifications"
+  )(
+    test("a beforeScenario hook failure surfaces as a setup error, not a [counterexample]") {
+      // Regression: runOneSample used to collapse every non-passed ScenarioResult — including
+      // one whose `setupError` is set because `beforeScenarioHook` failed — into "this sample
+      // falsified the property", persisting it to PropertyFailureStore and rendering it as
+      // "[counterexample] n=... (HasGen[Int])". A broken environment hook isn't evidence the
+      // property itself is false.
+      val steps = new ZIOSteps[Any, S]:
+        beforeScenario(_ => ZIO.die(new RuntimeException("environment is down")))
+        Given("value " / int)((n: Int) => ZIO.unit)
+        Then("ok")(ZIO.unit)
+
+      GherkinParser
+        .parseFeature(
+          """Feature: Broken setup
+            |  Scenario Outline: setup fails
+            |    Given value <n>
+            |    Then ok
+            |    @property(samples=5, replay=false)
+            |    Examples:
+            |      | n |
+            |""".stripMargin,
+          "setup-fails.feature"
+        )
+        .flatMap { f =>
+          FeatureExecutor.executeFeatures[Any, S](List(f), steps.getSteps, steps, genLookup = ColumnGenLookup.empty)
+        }
+        .map { results =>
+          val sc = results.head.scenarioResults.head
+          // beforeScenario's ScenarioHook is URIO — it can only fail via a defect (`die`), which
+          // ends up in setupError's Cause as a Die, not a Fail. `ScenarioResult.error`'s
+          // `failureOption` only unwraps typed Fail causes, so check the Cause directly here.
+          val causeText = sc.setupError.map(_.prettyPrint).getOrElse("")
+          assertTrue(
+            sc.setupError.isDefined,
+            causeText.contains("environment is down"),
+            !causeText.contains("counterexample"),
+            !causeText.contains("Falsified")
+          )
+        }
+    },
+    test("a pending step surfaces as pending, not a [counterexample], and is not persisted to the failure store") {
+      val steps = new ZIOSteps[Any, S]:
+        Given("value " / int)((n: Int) => ZIO.unit)
+        Then("ok")(pending("not implemented yet"))
+
+      GherkinParser
+        .parseFeature(
+          """Feature: Pending step
+            |  Scenario Outline: not implemented
+            |    Given value <n>
+            |    Then ok
+            |    @property(samples=5, replay=false)
+            |    Examples:
+            |      | n |
+            |""".stripMargin,
+          "pending-step.feature"
+        )
+        .flatMap { f =>
+          FeatureExecutor.executeFeatures[Any, S](List(f), steps.getSteps, steps, genLookup = ColumnGenLookup.empty)
+        }
+        .map { results =>
+          val sc = results.head.scenarioResults.head
+          assertTrue(
+            sc.hasPending,
+            sc.setupError.isEmpty,
+            !sc.stepResults.exists(_.step.pattern.contains("[counterexample]"))
           )
         }
     }

--- a/core/src/test/scala/zio/bdd/core/property/HasGenSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/property/HasGenSpec.scala
@@ -1,0 +1,110 @@
+package zio.bdd.core.property
+
+import izumi.reflect.Tag
+import zio.*
+import zio.test.*
+
+/**
+ * Issue #98: a Tag-keyed registry on top of `HasGen`, mirroring
+ * `zio.bdd.core.step.TypeMap`'s `Tag`-keyed lookup. Lets a `HasGen[A]` be found
+ * by `A`'s runtime `Tag` rather than only by column name — the piece
+ * `resolveTemplateColumns` (#97) needs to eventually resolve a column's
+ * generator automatically from its extractor's type (#99).
+ */
+object HasGenSpec extends ZIOSpecDefault {
+
+  // Distinct per-spec types so registering them here can't leak into (or collide
+  // with) any other spec sharing the same JVM-wide HasGen.typeRegistry singleton.
+  private final case class Widget(value: Int)
+  private final case class Gadget(value: String)
+
+  private val builtins = suite("built-in types resolve with zero registration")(
+    test("Int/Long/Double/Boolean/String/UUID all resolve without calling registerType") {
+      assertTrue(
+        HasGen.resolveByTag(Tag[Int]).isDefined,
+        HasGen.resolveByTag(Tag[Long]).isDefined,
+        HasGen.resolveByTag(Tag[Double]).isDefined,
+        HasGen.resolveByTag(Tag[Boolean]).isDefined,
+        HasGen.resolveByTag(Tag[String]).isDefined,
+        HasGen.resolveByTag(Tag[java.util.UUID]).isDefined
+      )
+    },
+    test("resolved built-in carries the expected label") {
+      assertTrue(HasGen.resolveByTag(Tag[Int]).map(_.label).contains("HasGen[Int]"))
+    },
+    test("two independently summoned Tag[Int] values resolve to the same registered instance") {
+      // Proves the registry is keyed by the underlying LightTypeTag (value equality),
+      // not by Tag instance identity — the same guarantee TypeMap relies on.
+      val first  = HasGen.resolveByTag(Tag[Int])
+      val second = HasGen.resolveByTag(summon[Tag[Int]])
+      assertTrue(first.isDefined, first.map(_.label) == second.map(_.label))
+    }
+  )
+
+  private val customTypes = suite("custom types")(
+    test("an unregistered custom type resolves to None") {
+      assertTrue(HasGen.resolveByTag(Tag[Gadget]).isEmpty)
+    },
+    test("a custom type resolves after one registerType call") {
+      given HasGen[Widget] with
+        def gen            = Gen.const(Widget(0))
+        override def label = "HasGen[Widget]"
+      HasGen.registerType(HasGen[Widget])
+      assertTrue(HasGen.resolveByTag(Tag[Widget]).map(_.label).contains("HasGen[Widget]"))
+    },
+    test("re-registering the same type replaces the previous instance rather than erroring") {
+      final case class Reregistered(value: Int)
+      given firstInstance: HasGen[Reregistered] with
+        def gen            = Gen.const(Reregistered(1))
+        override def label = "first"
+      HasGen.registerType(HasGen[Reregistered])
+      HasGen.registerType(new HasGen[Reregistered] {
+        def gen = Gen.const(Reregistered(2)); override def label = "second"
+      })
+      assertTrue(HasGen.resolveByTag(Tag[Reregistered]).map(_.label).contains("second"))
+    }
+  )
+
+  // ── Concurrency: this is a regression guard on the implementation choice, not a proof
+  // of correctness — registerType/resolveByTag are thin single-operation wrappers around
+  // TrieMap, whose own contract already guarantees safe concurrent put/get. The point of
+  // this test is to pin down that typeRegistry must stay a concurrency-safe structure: if
+  // it's ever swapped for something not thread-safe (e.g. mutable.HashMap), parallel
+  // scenario execution (see ConcurrencySpec) would corrupt it, and this test would catch
+  // that regression.
+  private val concurrencySuite = suite("concurrent registration and resolution")(
+    test("distinct types registered concurrently each resolve to their own HasGen, independently") {
+      final case class ConcA(v: Int)
+      final case class ConcB(v: Int)
+      final case class ConcC(v: Int)
+      final case class ConcD(v: Int)
+      def hasGen[A](l: String)(value: A): HasGen[A] = new HasGen[A] {
+        def gen = Gen.const(value); override def label = l
+      }
+      for {
+        _ <- ZIO.foreachPar(
+               List(
+                 ZIO.succeed(HasGen.registerType(hasGen("A")(ConcA(0)))),
+                 ZIO.succeed(HasGen.registerType(hasGen("B")(ConcB(0)))),
+                 ZIO.succeed(HasGen.registerType(hasGen("C")(ConcC(0)))),
+                 ZIO.succeed(HasGen.registerType(hasGen("D")(ConcD(0))))
+               )
+             )(identity)
+        labels <- ZIO.succeed(
+                    List(
+                      HasGen.resolveByTag(Tag[ConcA]).map(_.label),
+                      HasGen.resolveByTag(Tag[ConcB]).map(_.label),
+                      HasGen.resolveByTag(Tag[ConcC]).map(_.label),
+                      HasGen.resolveByTag(Tag[ConcD]).map(_.label)
+                    )
+                  )
+      } yield assertTrue(labels == List("A", "B", "C", "D").map(Some(_)))
+    }
+  )
+
+  def spec: Spec[TestEnvironment & Scope, Any] = suite("HasGen type-keyed registry (#98)")(
+    builtins,
+    customTypes,
+    concurrencySuite
+  )
+}

--- a/core/src/test/scala/zio/bdd/core/property/PropertyFailureStoreSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/property/PropertyFailureStoreSpec.scala
@@ -1,0 +1,89 @@
+package zio.bdd.core.property
+
+import zio.*
+import zio.test.*
+import zio.bdd.gherkin.{Scenario, Step, StepType}
+
+import java.nio.file.Paths
+
+/**
+ * Round-trip tests for `PropertyFailureStore`'s hand-rolled JSON encode/decode,
+ * focused on value content that could break a naive (non-escape-aware) parser:
+ * literal braces, quotes, backslashes, and non-ASCII text inside a sampled
+ * column value.
+ */
+object PropertyFailureStoreSpec extends ZIOSpecDefault {
+
+  private def scenario(name: String) =
+    Scenario(name = name, steps = List(Step(StepType.GivenStep, "a step")), file = Some("failure-store-spec.feature"))
+
+  private val failuresDir = Paths.get(".zio-bdd", "failures").toFile
+
+  private def cleanup(sc: Scenario) = PropertyFailureStore.clear(sc)
+
+  def spec: Spec[TestEnvironment & Scope, Any] = suite("PropertyFailureStoreSpec")(
+    test("round-trips a value containing literal braces without truncating sibling keys") {
+      val sc              = scenario("braces in value")
+      val shrunkValues    = Map("col" -> """{"nested": "looks like json"}""")
+      val generatorLabels = Map("col" -> "HasGen[Custom]")
+      for {
+        _        <- cleanup(sc)
+        _        <- PropertyFailureStore.write(sc, seed = 1L, sampleIndex = 0, shrunkValues, generatorLabels)
+        readBack <- PropertyFailureStore.read(sc)
+        _        <- cleanup(sc)
+      } yield assertTrue(
+        readBack.isDefined,
+        readBack.get.shrunkValues == shrunkValues,
+        readBack.get.generatorLabels == generatorLabels
+      )
+    },
+    test("round-trips values containing quotes and backslashes") {
+      val sc           = scenario("quotes and backslashes")
+      val shrunkValues = Map("path" -> """C:\Users\test\"quoted"\file.txt""", "note" -> "she said \"hi\\bye\"")
+      for {
+        _        <- cleanup(sc)
+        _        <- PropertyFailureStore.write(sc, seed = 2L, sampleIndex = 0, shrunkValues, Map.empty)
+        readBack <- PropertyFailureStore.read(sc)
+        _        <- cleanup(sc)
+      } yield assertTrue(readBack.isDefined, readBack.get.shrunkValues == shrunkValues)
+    },
+    test("round-trips non-ASCII text") {
+      val sc           = scenario("unicode")
+      val shrunkValues = Map("name" -> "日本語 — café — emoji 🎉")
+      for {
+        _        <- cleanup(sc)
+        _        <- PropertyFailureStore.write(sc, seed = 3L, sampleIndex = 0, shrunkValues, Map.empty)
+        readBack <- PropertyFailureStore.read(sc)
+        _        <- cleanup(sc)
+      } yield assertTrue(readBack.isDefined, readBack.get.shrunkValues == shrunkValues)
+    },
+    test("round-trips an empty shrunkValues/generatorLabels map") {
+      val sc = scenario("empty maps")
+      for {
+        _        <- cleanup(sc)
+        _        <- PropertyFailureStore.write(sc, seed = 4L, sampleIndex = 0, Map.empty, Map.empty)
+        readBack <- PropertyFailureStore.read(sc)
+        _        <- cleanup(sc)
+      } yield assertTrue(readBack.isDefined, readBack.get.shrunkValues.isEmpty, readBack.get.generatorLabels.isEmpty)
+    },
+    test("multiple columns each round-trip to their own value") {
+      val sc           = scenario("multi column")
+      val shrunkValues = Map("a" -> "1", "b" -> "two}", "c" -> """{"x"}""")
+      for {
+        _        <- cleanup(sc)
+        _        <- PropertyFailureStore.write(sc, seed = 5L, sampleIndex = 0, shrunkValues, Map.empty)
+        readBack <- PropertyFailureStore.read(sc)
+        _        <- cleanup(sc)
+      } yield assertTrue(readBack.isDefined, readBack.get.shrunkValues == shrunkValues)
+    },
+    test("clear deletes the file and read returns None afterwards") {
+      val sc = scenario("clear test")
+      for {
+        _               <- PropertyFailureStore.write(sc, seed = 6L, sampleIndex = 0, Map("n" -> "1"), Map.empty)
+        existsAfterWrite = Option(failuresDir.listFiles()).exists(_.nonEmpty)
+        _               <- PropertyFailureStore.clear(sc)
+        readBack        <- PropertyFailureStore.read(sc)
+      } yield assertTrue(existsAfterWrite, readBack.isEmpty)
+    }
+  )
+}

--- a/core/src/test/scala/zio/bdd/core/report/PrettyReporterSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/report/PrettyReporterSpec.scala
@@ -213,6 +213,45 @@ object PrettyReporterSpec extends ZIOSpecDefault {
           )
         case _ => assertTrue(false)
     },
+    test("stepBranch for a [counterexample] step renders one table row per column") {
+      import zio.bdd.core.property.PropertyExecutor.counterexampleEntrySep
+      val pattern =
+        s"[counterexample] amount=42 (HasGen[Int])${counterexampleEntrySep}limit=0 (HasGen[Long])"
+      val step = mkStep(StepType.GivenStep, pattern)
+      val sr   = StepResult(step, Left(Cause.fail(new RuntimeException("boom"))), 0L)
+      DocBuilder.stepBranch(sr, isLast = false, emptyLogs) match
+        case Doc.Branch(_, children, false) =>
+          val texts = children.collect { case Doc.Leaf(t, _) => t }
+          assertTrue(
+            texts.exists(_.contains("amount")),
+            texts.exists(_.contains("42")),
+            texts.exists(_.contains("limit")),
+            // The two columns must end up as two distinct rows, not merged into one.
+            texts.count(_.contains("HasGen")) == 2
+          )
+        case _ => assertTrue(false)
+    },
+    test("stepBranch for a [counterexample] step is not corrupted by a comma inside a value") {
+      import zio.bdd.core.property.PropertyExecutor.counterexampleEntrySep
+      // A domain type's default toString commonly contains a literal comma, e.g. a case class:
+      // Address(Main St,London). A plain comma-separated join would mis-split this into two
+      // fake columns; the dedicated entry separator must keep it as one.
+      val pattern =
+        s"[counterexample] address=Address(Main St,London) (HasGen[Address])${counterexampleEntrySep}zip=12345 (HasGen[String])"
+      val step = mkStep(StepType.GivenStep, pattern)
+      val sr   = StepResult(step, Left(Cause.fail(new RuntimeException("boom"))), 0L)
+      DocBuilder.stepBranch(sr, isLast = false, emptyLogs) match
+        case Doc.Branch(_, children, false) =>
+          val texts = children.collect { case Doc.Leaf(t, _) => t }
+          assertTrue(
+            // Exactly one row contains the full, unsplit address value...
+            texts.count(_.contains("Address(Main St,London)")) == 1,
+            // ...and a separate row for zip, not three+ rows from a naive comma split.
+            texts.exists(_.contains("zip")),
+            texts.count(_.contains("HasGen")) == 2
+          )
+        case _ => assertTrue(false)
+    },
     test("featureSummary leaf contains Passed/Failed/Ignored/Pending labels") {
       val sc   = mkScenarioResult("s", List((StepType.GivenStep, "a", StepStatus.Passed)))
       val fr   = mkFeatureResult("F", List(sc))

--- a/core/src/test/scala/zio/bdd/core/report/PrettyReporterSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/report/PrettyReporterSpec.scala
@@ -51,9 +51,9 @@ object PrettyReporterSpec extends ZIOSpecDefault {
   private val emptyLogs = CollectedLogs()
 
   private val statusColorTests = suite("StatusColor typeclass")(
-    test("StepStatus.Passed → Blue") {
+    test("StepStatus.Passed → Mint") {
       val s = summon[StatusColor[StepStatus]].style(StepStatus.Passed)
-      assertTrue(s.color == Color.Blue)
+      assertTrue(s.color == Color.Mint)
     },
     test("StepStatus.Failed → Red + cross icon") {
       val s = summon[StatusColor[StepStatus]].style(StepStatus.Failed(Cause.fail(new Exception())))
@@ -73,10 +73,10 @@ object PrettyReporterSpec extends ZIOSpecDefault {
       val s = summon[StatusColor[StepStatus]].style(StepStatus.Pending("todo"))
       assertTrue(s.color == Color.Orange)
     },
-    test("passed ScenarioResult → Yellow") {
+    test("passed ScenarioResult → Blue") {
       val sc = mkScenarioResult("s", List((StepType.GivenStep, "a step", StepStatus.Passed)))
       val s  = summon[StatusColor[ScenarioResult]].style(sc)
-      assertTrue(s.color == Color.Yellow)
+      assertTrue(s.color == Color.Blue)
     },
     test("failed ScenarioResult → Red") {
       val sc =
@@ -271,7 +271,7 @@ object PrettyReporterSpec extends ZIOSpecDefault {
     test("renders a Branch: header then indented children") {
       for {
         buf   <- BufferRenderer.make
-        header = Doc.Leaf("parent", Style(Color.Blue, "◉"))
+        header = Doc.Leaf("parent", Style(Color.Teal, "◉"))
         child  = Doc.Leaf("child", Style(Color.Green, "•"))
         _     <- buf.render(Doc.Branch(header, List(child), isLast = true))
         out   <- buf.collected
@@ -287,7 +287,7 @@ object PrettyReporterSpec extends ZIOSpecDefault {
         many = Doc.Many(
                  List(
                    Doc.Leaf("a", Style(Color.Green)),
-                   Doc.Leaf("b", Style(Color.Blue)),
+                   Doc.Leaf("b", Style(Color.Cyan)),
                    Doc.Leaf("c", Style(Color.Red))
                  )
                )

--- a/docs/gherkin.md
+++ b/docs/gherkin.md
@@ -208,6 +208,33 @@ Examples: Block B
 Scenarios from Block A carry `smoke` and `regression`. Scenarios from Block B carry
 `smoke` and `slow`.
 
+**`@property(...)` tag — generative Examples:** when an `Examples:` block (or its parent
+`Scenario Outline:`) carries a `@property(...)` tag AND the block has no data rows
+(header only), the block triggers property-based testing instead of literal expansion.
+The framework samples values from the `HasGen[T]` registry for each column and runs the
+scenario N times.
+
+```gherkin
+@property(samples=500, seed=42)
+Scenario Outline: Balance is never negative
+  Given an account with balance <balance>
+  When I withdraw <amount>
+  Then the balance is not negative
+
+  Examples:
+    | balance | amount |
+```
+
+Column headers may carry a `: generatorName` suffix to select a named generator override
+for that column:
+
+```gherkin
+  Examples:
+    | balance | amount: smallAmounts |
+```
+
+See [Property-Based Testing](property-testing.md) for the full reference.
+
 ---
 
 ## Steps

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ New to zio-bdd?  Read in this order:
 | [Hooks](hooks.md) | `beforeAll`, `afterAll`, `beforeFeature`, `afterFeature`, `beforeScenario`, `afterScenario`, `beforeScenarioTagged`, `beforeStep`, `afterStep` |
 | [Step DSL](step-dsl.md) | All extractors, `StepEffect`, `StepIO`, `InlineStepMethods`, `pending`, `withSnapshot`, soft assertions |
 | [Gherkin Syntax](gherkin.md) | Complete Gherkin reference — `Feature`, `Background`, `Scenario`, `Scenario Outline`, `Examples`, `Rule`, tags, data tables, doc strings |
+| [Property-Based Testing](property-testing.md) | `@property(...)` tag, `HasGen[T]` registry, named generator overrides, failure replay, JUnit XML output |
 | [Running Tests](running.md) | `@Suite` annotation, sbt commands, CLI flags, dry-run, tag filtering, parallelism, step timeout, IDE integration |
 | [Feature Flag Testing](testing-flags.md) | `@flags(k=v)` matrix expansion, `flagLayer`, `ScenarioMetadata.flagValues`, OpenFeature / Optimizely patterns |
 | [Reporters](reporters.md) | `pretty` (console tree), `junitxml` (CI reports), `StreamingReporter`, `LiveProgressReporter`, custom reporters |

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,8 @@ New to zio-bdd?  Read in this order:
    ZIO effects, what `R` and `S` mean, how state is isolated per scenario.
 3. **[Step DSL](step-dsl.md)** — the full extractor reference (`string`, `int`, `table[T]`,
    `docString`, `regex`, `oneOf`, etc.) plus the `StepEffect` / `StepIO` type aliases.
+4. **[Property-Based Testing](property-testing.md)** — once you're comfortable with literal
+   `Examples:` rows, learn the `@property(...)` tag to sample generated values instead.
 
 ---
 

--- a/docs/property-testing.md
+++ b/docs/property-testing.md
@@ -1,0 +1,460 @@
+# Property-Based Testing
+
+zio-bdd integrates property-based testing directly into Gherkin.  Add a `@property(...)` tag to
+a header-only `Examples:` block and the scenario runs N times with sampled values instead of
+literal rows — using ZIO Test's `Gen[Any, A]` engine under the hood.
+
+The counterexample output, failure replay, and JUnit XML format are all handled automatically.
+Existing step definitions require no changes.
+
+---
+
+## Minimal example
+
+```gherkin
+Feature: Account invariants
+
+  Scenario Outline: Withdrawal never produces a negative balance
+    Given an account with balance <balance> and limit <limit>
+    When I withdraw <amount>
+    Then the resulting balance is at least negative <limit>
+
+    @property(samples=500, seed=42, shrink=true)
+    Examples:
+      | balance | limit | amount |
+```
+
+```scala
+import zio.bdd.core.property.HasGen
+import zio.test.Gen
+
+@Suite(featureDirs = Array("src/test/resources/features"), reporters = Array("pretty", "junitxml"))
+object AccountSpec extends ZIOSteps[AccountService, AccountState]:
+
+  // Register generators for the placeholder types
+  given HasGen[Money]  = Gen.double(0, 10_000).map(Money.apply)
+  given HasGen[Limit]  = Gen.long(0, 5_000).map(Limit.apply)
+
+  Given("an account with balance " / money / " and limit " / limit) { (bal, lim) =>
+    ScenarioContext.update(_.copy(balance = bal, limit = lim))
+  }
+  When("I withdraw " / money) { (amount: Money) => ... }
+  Then("the resulting balance is at least negative " / limit) { (lim: Limit) => ... }
+```
+
+On failure the pretty reporter shows:
+
+```
+╰─ ✗ Withdrawal never produces a negative balance [seed=42]
+      ├─ ⚡ [counterexample] balance=0.01 (HasGen[Money]), limit=0 (HasGen[Limit]), amount=100.0 (HasGen[Money])
+      │     ──────────────────────────────────────────────────────────────────
+      │   │ balance │ 0.01  (HasGen[Money])
+      │   │ limit   │ 0     (HasGen[Limit])
+      │   │ amount  │ 100.0 (HasGen[Money])
+      │     ──────────────────────────────────────────────────────────────────
+      ├─ ✓ Given an account with balance 0.01 and limit 0
+      ├─ ✓ When I withdraw 100.0
+      ╰─ ✗ Then the resulting balance is at least negative 0
+            Expected balance ≥ -0, got -99.99
+```
+
+---
+
+## Tag placement
+
+`@property(...)` can be placed on:
+
+1. **The `Examples:` block** (preferred when the property is specific to that block):
+
+   ```gherkin
+   Scenario Outline: My invariant
+     Given <x>
+     Then ok
+     @property(samples=100)
+     Examples:
+       | x |
+   ```
+
+2. **The `Scenario Outline:` line** (convenient when there is only one Examples block):
+
+   ```gherkin
+   @property(samples=100)
+   Scenario Outline: My invariant
+     Given <x>
+     Then ok
+     Examples:
+       | x |
+   ```
+
+Both placements produce identical behaviour.  `combinedTags` (scenario tags + block tags) is used
+for detection, so either location works.
+
+---
+
+## Tag arguments
+
+| Argument | Default | Description |
+|---|---|---|
+| `samples` | `100` | Number of generated samples to run |
+| `seed` | random | Fixed `Long` seed for reproducible runs. Always logged so any failure carries a reproducer. |
+| `shrink` | `true` | Walk the ZIO Test shrink tree on failure to find a minimal counterexample |
+| `maxShrinks` | `1000` | Cap on shrink-tree steps |
+| `maxDiscarded` | `samples × 5` | Reserved for a future `Assume` step; not yet active |
+| `verbose` | `false` | Print full shrink path in failure output |
+| `replay` | `true` | Consult and update the failure replay file (see [Failure replay](#failure-replay)) |
+
+A bare `@property` with no arguments is valid and equivalent to `@property(samples=100)`.
+
+---
+
+## `HasGen[T]` — generator registry
+
+`HasGen[A]` is a typeclass defined in `zio.bdd.core.property` that provides a
+`Gen[Any, A]` for a given type `A`.  It is the bridge between Gherkin column names and
+ZIO Test's generator engine.
+
+You do not need to know ZIO Test to use property testing in zio-bdd, but understanding
+`Gen` helps you write richer generators.
+
+---
+
+### What is `Gen`?
+
+`Gen[R, A]` (from `zio.test`) is a generator that produces values of type `A` using
+environment `R`.  Most generators use `Gen[Any, A]` — no special environment needed.
+
+Common constructors:
+
+```scala
+import zio.test.Gen
+
+Gen.int                          // random Int (full range)
+Gen.int(1, 100)                  // random Int between 1 and 100 (inclusive)
+Gen.long(0L, 1_000_000L)         // random Long in range
+Gen.double(0.01, 9_999.99)       // random Double in range
+Gen.boolean                      // random Boolean
+Gen.alphaNumericString           // random non-empty alphanumeric String
+Gen.stringBounded(1, 10)(Gen.alphaChar)  // String of 1–10 alpha chars
+Gen.uuid                         // random UUID
+Gen.elements("A", "B", "C")      // random pick from a fixed list
+Gen.oneOf(gen1, gen2)            // random pick from multiple generators
+Gen.option(Gen.int)              // Some(Int) or None
+Gen.listOf(Gen.int)              // List of random Ints (variable length)
+Gen.const(42)                    // always produces 42
+```
+
+Generators compose with `map`, `flatMap`, and for-comprehensions:
+
+```scala
+// A generator for a domain type built from multiple fields
+val orderGen: Gen[Any, Order] =
+  for
+    id     <- Gen.uuid
+    amount <- Gen.double(0.01, 10_000.0)
+    status <- Gen.elements(OrderStatus.Pending, OrderStatus.Completed)
+  yield Order(id, amount, status)
+```
+
+---
+
+### Built-in `HasGen` instances
+
+These are provided automatically for primitive types that match the built-in
+`TypedExtractor` set.  No registration or import needed:
+
+| Type | Generator used |
+|---|---|
+| `Int` | `Gen.int` |
+| `Long` | `Gen.long` |
+| `Double` | `Gen.double` |
+| `Boolean` | `Gen.boolean` |
+| `String` | `Gen.alphaNumericString` |
+| `UUID` | `Gen.uuid` |
+
+If your placeholders use only these types and your step extractors already use the
+corresponding built-in extractors (`/ int`, `/ string`, etc.), no additional setup is
+needed — property mode works out of the box.
+
+---
+
+### Providing `HasGen` for a domain type
+
+For every domain type used as a placeholder, provide a `given HasGen[YourType]` in your
+suite object.  The `given` is defined inline using Scala 3's anonymous given syntax:
+
+```scala
+import zio.bdd.core.property.HasGen
+import zio.test.Gen
+
+object MySpec extends ZIOSteps[MyService, MyState]:
+
+  // Simple range-bounded value type
+  given HasGen[Money] = Gen.double(0.01, 10_000.0).map(Money.apply)
+
+  // Enum — pick uniformly from the valid members
+  given HasGen[Currency] = Gen.elements(Currency.GBP, Currency.USD, Currency.EUR)
+
+  // Case class with multiple fields
+  given HasGen[Address] =
+    for
+      street <- Gen.alphaNumericString
+      city   <- Gen.elements("London", "New York", "Tokyo")
+    yield Address(street, city)
+```
+
+The `given` must be in scope at the point where `columnGenLookup` resolves the type.
+Placing it directly in the suite object (or in a trait mixed into the suite) is the
+idiomatic location.
+
+#### Using `HasGen.apply` to summon an instance
+
+Once a `given HasGen[A]` is in scope, summon it with `HasGen[A]`:
+
+```scala
+// In columnGenLookup:
+override def columnGenLookup: ColumnGenLookup = new ColumnGenLookup:
+  def byColumn(col: String): Option[HasGen[?]] = col match
+    case "amount" | "balance" => Some(HasGen[Money])     // summons the given above
+    case "currency"           => Some(HasGen[Currency])
+    case _                    => None
+```
+
+---
+
+### Named generator overrides
+
+Sometimes you need a different generator for the same type in a specific column — for
+example, "small withdrawal amounts" as opposed to the full `HasGen[Money]` range.  Use
+`HasGen.named` to register a named generator and reference it in the column header:
+
+**Registration (Scala):**
+
+```scala
+// In the suite object initialiser — runs once before tests
+HasGen.named("smallAmounts")(Gen.double(0.01, 10.0).map(Money.apply))
+HasGen.named("largeLimits")(Gen.long(5_000L, 100_000L).map(Limit.apply))
+```
+
+**Reference (Gherkin):**
+
+```gherkin
+@property(samples=200)
+Examples:
+  | balance | limit: largeLimits | amount: smallAmounts |
+```
+
+- `balance` resolves via `columnGenLookup` → `HasGen[Money]` (the default generator).
+- `amount` resolves via the named registry → `"smallAmounts"` generator.
+- `limit` resolves via the named registry → `"largeLimits"` generator.
+
+Named generators are stored in a global registry (`HasGen.namedRegistry`) — they
+persist for the JVM lifetime and are shared across suites.  Choose unique, descriptive
+names to avoid accidental collision between suites.
+
+---
+
+### Wiring column resolution via `columnGenLookup`
+
+Override `columnGenLookup` on your suite to tell the executor which `HasGen` to use for
+each placeholder column name.  The built-in primitive types are always resolved
+automatically; this override is only needed for domain types.
+
+```scala
+import zio.bdd.core.property.{ColumnGenLookup, HasGen}
+
+override def columnGenLookup: ColumnGenLookup = new ColumnGenLookup:
+  def byColumn(col: String): Option[HasGen[?]] = col match
+    case "balance" | "amount" => Some(HasGen[Money])
+    case "limit"              => Some(HasGen[Limit])
+    case "currency"           => Some(HasGen[Currency])
+    case _                    => None  // falls back to built-ins; fails with a clear error if unresolved
+```
+
+**Resolution order** for a column named `"amount"`:
+
+1. Named override from the column header annotation (`| amount: smallAmounts |`) —
+   checked against `HasGen.resolve("smallAmounts")`.
+2. `columnGenLookup.byColumn("amount")`.
+3. Built-in `HasGen` instance for the column's inferred type (for primitive columns
+   matched by existing `TypedExtractor` built-ins).
+4. Setup error — the scenario fails immediately with a clear message:
+   `No HasGen registered for column 'amount'. Register given HasGen[T] for its type.`
+
+---
+
+### Complete setup checklist
+
+For a property scenario with a domain-type column to work:
+
+- [ ] Define `case class Money(value: Double)` (or whatever your type is).
+- [ ] Add `given HasGen[Money] = Gen.double(...).map(Money.apply)` in the suite object.
+- [ ] Add `case "amount" => Some(HasGen[Money])` in `columnGenLookup`.
+- [ ] Ensure the step definition uses the same `TypedExtractor[Money]` it already uses
+      for literal scenarios (e.g. `/ money`).  No step change is needed.
+- [ ] Add `@property(samples=N)` to a header-only `Examples:` block.
+
+If the column uses a built-in type (`Int`, `String`, `Long`, `Double`, `Boolean`,
+`UUID`), steps 1–3 are not required.
+
+---
+
+## Mixed literal + generated Examples
+
+Because `@property` is a per-block tag, one `Scenario Outline` can carry both pinned regression
+rows and a generative exploration block:
+
+```gherkin
+Scenario Outline: Withdrawal invariants
+  Given an account with balance <balance> and limit <limit>
+  When I withdraw <amount>
+  Then the resulting balance is at least negative <limit>
+
+  # Pinned regression cases — always run, shown as normal Example scenarios
+  @regression
+  Examples:
+    | balance | limit | amount |
+    | 0       | 0     | 1      |
+    | 100     | 0     | 100    |
+
+  # Generative exploration — 500 samples via HasGen registry
+  @property(samples=500)
+  Examples:
+    | balance | limit | amount |
+```
+
+The `@regression` block expands to two literal scenarios.  The `@property` block produces one
+property scenario that runs 500 times.  Both share the same step definitions.
+
+---
+
+## Failure replay
+
+When a property fails, the executor writes the failing seed and counterexample values to
+`.zio-bdd/failures/<scenario-slug>.json`.  On the next run, that seed is **replayed first**
+before generating new samples:
+
+```
+▶ Replaying 1 known-failing sample for "Withdrawal never produces a negative balance"...
+  ✗ Still falsifies (seed=42, sample=12) — counterexample unchanged
+  STOP. New samples not generated.
+```
+
+If the replay passes (the bug was fixed), the failure file is cleared and the full sample run
+proceeds normally.
+
+### File format
+
+```json
+{
+  "scenarioId":      "account-invariants--withdrawal-never-produces-a-negative-balance",
+  "bodyHash":        "a3f1c9",
+  "seed":            42,
+  "sampleIndex":     12,
+  "shrunkValues":    { "balance": "0.01", "limit": "0", "amount": "100.0" },
+  "generatorLabels": { "balance": "HasGen[Money]", "limit": "HasGen[Limit]", "amount": "HasGen[Money]" },
+  "timestamp":       "2026-06-23T14:32:11Z"
+}
+```
+
+**Body-hash invalidation:** if the scenario's step list changes (the scenario was edited), the
+stale failure record is discarded with a warning rather than replaying a test that no longer exists
+in the same form.
+
+**Committing the file:** `.zio-bdd/failures/` should be committed to version control.  The failing
+seeds are a signal that travels with the codebase — CI will replay them on every run until the
+regression is fixed.
+
+**Disabling replay:** `@property(replay=false)` on the tag, or `--no-replay` on the sbt CLI.
+
+---
+
+## JUnit XML output
+
+Property scenarios produce standard `<testcase>` elements that CI tools interpret normally.
+
+**Passing scenario:**
+
+```xml
+<testcase name="Withdrawal never produces a negative balance [500 samples passed, seed=42]"
+          classname="Account invariants" time="1.234">
+  <steps>
+    <step keyword="Given"
+          name="[property] 500 samples passed, seed=42 — generators: balance (HasGen[Money]), ..."
+          status="passed" time="0.000"/>
+  </steps>
+</testcase>
+```
+
+**Failing scenario:**
+
+```xml
+<testcase name="Withdrawal never produces a negative balance [seed=42]"
+          classname="Account invariants" time="0.043">
+  <steps>
+    <step keyword="Given" name="[counterexample] balance=0.01 (HasGen[Money]), ..."
+          status="failed" time="0.000">
+      <message>Falsified after 12 samples (seed=42)&#xa;Minimal counterexample: ...</message>
+    </step>
+    <step keyword="Given" name="an account with balance 0.01 and limit 0" status="passed" time="0.001"/>
+    <step keyword="When"  name="I withdraw 100.0"                          status="passed" time="0.001"/>
+    <step keyword="Then"  name="the resulting balance is at least negative 0" status="failed" time="0.001">
+      <message>Expected balance ≥ -0, got -99.99</message>
+    </step>
+  </steps>
+  <failure message="Falsified after 12 samples (seed=42)&#xa;Minimal counterexample: ..."
+           type="AssertionError"/>
+</testcase>
+```
+
+The `[counterexample]` step is first in the step list so Jenkins / GitHub Actions step-detail
+panels show the sampled values immediately, before the actual failing step.
+
+---
+
+## Worked example
+
+The `example/` module ships a complete working example:
+
+- **Feature file:** `example/src/test/resources/features/greeting_properties.feature`
+- **Step suite:** `example/src/test/scala/zio/bdd/example/SimpleSpec.scala`
+
+The feature tests three invariants of `GreetingService`, including one intentionally broken scenario
+that demonstrates the failure output:
+
+```gherkin
+@positive @property(samples=500, seed=42, shrink=true)
+Scenario Outline: Greeting always starts with "Hello," and ends with "!"
+  Given a user named <name>
+  When the user is greeted
+  Then the greeting starts with "Hello,"
+  And the greeting ends with "!"
+  And the greeting contains the name
+
+  Examples:
+    | name |
+
+@positive @property(samples=100, seed=7, replay=false)
+Scenario Outline: Greeting is shorter than 5 characters (intentionally broken)
+  Given a user named <name>
+  When the user is greeted
+  Then the greeting length is less than 5
+
+  Examples:
+    | name |
+```
+
+Run with:
+
+```sh
+sbt "example/test"
+```
+
+---
+
+## What is NOT yet supported
+
+| Feature | Status |
+|---|---|
+| Full ZIO Test shrink-tree walking | v1 records the failing seed; minimal counterexample via shrink traversal is planned for v2 |
+| `Assume` / filter step to discard samples | Planned for v2 (`maxDiscarded` arg is reserved) |
+| Parallel sample execution | All samples for one property scenario run sequentially; scenario-level parallelism still applies across multiple property scenarios |

--- a/docs/property-testing.md
+++ b/docs/property-testing.md
@@ -39,19 +39,24 @@ object AccountSpec extends ZIOSteps[AccountService, AccountState]:
   given HasGen[Limit] with
     def gen = Gen.long(0, 5_000).map(Limit.apply)
 
+  // One-time registration makes Money/Limit resolve automatically by type for every
+  // column of that type — no per-column columnGenLookup entry needed below.
+  HasGen.registerType(HasGen[Money])
+  HasGen.registerType(HasGen[Limit])
+
   Given("an account with balance " / money / " and limit " / limit) { (bal, lim) =>
     ScenarioContext.update(_.copy(balance = bal, limit = lim))
   }
   When("I withdraw " / money) { (amount: Money) => ... }
   Then("the resulting balance is at least negative " / limit) { (lim: Limit) => ... }
 
-  // Every property column — including these — must still be routed by name in
-  // columnGenLookup; see "Wiring column resolution" below.
+  // columnGenLookup is now the override path, not mandatory — every column above already
+  // resolves automatically via registerType. Only needed for a narrower/different
+  // generator than the automatic choice, e.g. constraining `amount` to smaller values:
   override def columnGenLookup: ColumnGenLookup = new ColumnGenLookup:
     def byColumn(col: String): Option[HasGen[?]] = col match
-      case "balance" | "amount" => Some(HasGen[Money])
-      case "limit"              => Some(HasGen[Limit])
-      case _                    => None
+      case "amount" => Some(new HasGen[Money] { def gen = Gen.double(0, 100).map(Money.apply) })
+      case _        => None
 ```
 
 On failure the pretty reporter shows:
@@ -183,19 +188,24 @@ them:
 | `String` | `Gen.alphaNumericString` |
 | `UUID` | `Gen.uuid` |
 
-**This does not mean property mode works with zero setup.** Column-to-generator
-resolution is always by *column name*, never by inferred type — there is no mechanism
-that looks at a step's `/ int` extractor and concludes "this column is an `Int`, use
-`HasGen[Int]`". Every property column, including ones that only need a built-in type,
-must still have an entry in `columnGenLookup` (see below) that explicitly returns
-`Some(HasGen[Int])` (or whichever built-in applies) for that column name. What the
-built-ins save you from is writing `Gen.int` yourself — not from wiring the column.
+**A built-in-typed column needs no `columnGenLookup` entry at all.** The executor infers
+a column's type from the `TypedExtractor` that governs it in your step definitions (e.g.
+`/ int`), then resolves that type automatically against `HasGen`'s built-in registry — no
+mechanism existed for this before; now it does. `columnGenLookup` is the *override* path:
+reach for it when you want a narrower or different generator than the automatic choice,
+or to resolve an ambiguity (see [Wiring column resolution](#wiring-column-resolution-via-columngenlookup)
+below). A column with no explicit override and a built-in extractor type just works:
+
+```gherkin
+Given a value of <retries>
+@property(samples=100)
+Examples:
+  | retries |
+```
 
 ```scala
-override def columnGenLookup: ColumnGenLookup = new ColumnGenLookup:
-  def byColumn(col: String): Option[HasGen[?]] = col match
-    case "retries" => Some(HasGen[Int])    // built-in HasGen[Int], still routed explicitly
-    case _         => None
+// No columnGenLookup entry needed for `retries` — it resolves automatically from the
+// `int` extractor in `Given("a value of " / int)`.
 ```
 
 ---
@@ -247,10 +257,17 @@ given HasGen[Money] with
 
 #### Using `HasGen.apply` to summon an instance
 
-Once a `given HasGen[A]` is in scope, summon it with `HasGen[A]`:
+Once a `given HasGen[A]` is in scope, summon it with `HasGen[A]`. This is the same idiom
+used both for an explicit `columnGenLookup` override and for `HasGen.registerType` (the
+one-time-per-type registration that makes automatic resolution work — see
+[Wiring column resolution](#wiring-column-resolution-via-columngenlookup) below):
 
 ```scala
-// In columnGenLookup:
+// One-time registration — Money/Currency now resolve automatically by type:
+HasGen.registerType(HasGen[Money])
+HasGen.registerType(HasGen[Currency])
+
+// Or, as an explicit per-column override in columnGenLookup:
 override def columnGenLookup: ColumnGenLookup = new ColumnGenLookup:
   def byColumn(col: String): Option[HasGen[?]] = col match
     case "amount" | "balance" => Some(HasGen[Money])     // summons the given above
@@ -294,20 +311,21 @@ names to avoid accidental collision between suites.
 
 ### Wiring column resolution via `columnGenLookup`
 
-Override `columnGenLookup` on your suite to tell the executor which `HasGen` to use for
-each placeholder column name. **This override is required for every property column** —
-domain types and built-in types alike. There is no automatic fallback by inferred type;
-resolution is entirely by column name.
+`columnGenLookup` is the *override* path, not a mandatory per-column registry. Most
+columns — anything whose extractor produces a built-in type, or a domain type registered
+via `HasGen.registerType` (see below) — resolve automatically with no entry here at all.
+Override `columnGenLookup` when you want a different generator than the automatic choice
+(a narrower range, a domain type that hasn't been registered, or to disambiguate a
+conflict):
 
 ```scala
 import zio.bdd.core.property.{ColumnGenLookup, HasGen}
 
 override def columnGenLookup: ColumnGenLookup = new ColumnGenLookup:
   def byColumn(col: String): Option[HasGen[?]] = col match
-    case "balance" | "amount" => Some(HasGen[Money])
-    case "limit"              => Some(HasGen[Limit])
-    case "currency"           => Some(HasGen[Currency])
-    case _                    => None  // unresolved → setup error (see below)
+    case "amount" => Some(HasGen[Money])  // Money isn't registered via registerType, so
+                                           // it needs an explicit entry (or call registerType instead)
+    case _        => None                 // everything else resolves automatically
 ```
 
 **Resolution order** for a column named `"amount"`:
@@ -315,32 +333,43 @@ override def columnGenLookup: ColumnGenLookup = new ColumnGenLookup:
 1. Named override from the column header annotation (`| amount: smallAmounts |`) —
    checked against `HasGen.resolve("smallAmounts")`.
 2. `columnGenLookup.byColumn("amount")`.
-3. Setup error — the scenario fails immediately with a clear message:
-   ``No HasGen registered for column 'amount'. Register `given HasGen[T]` for its type.``
+3. **Automatic type-based lookup:** the executor finds the `Tag[_]` the column's extractor
+   produces (from the step definition that governs it) and resolves it via
+   `HasGen.resolveByTag` — this is where the six built-ins, and any type registered via
+   `HasGen.registerType`, resolve with no further wiring.
+4. Setup error — the scenario fails immediately with a clear message naming the column
+   and, if a type was inferred, that type: e.g.
+   ``Column 'amount' was inferred as Money but no HasGen is registered for that type.
+   Register one via `given HasGen[Money] with ...` then `HasGen.registerType(HasGen[Money])`,
+   or add an explicit `columnGenLookup` entry for 'amount'.``
 
-There is deliberately no third "automatic built-in by type" step: a column is just a
-string name parsed from the Gherkin header, with no attached type information, so the
-executor cannot infer that a column named `"amount"` should resolve to `HasGen[Int]`
-versus `HasGen[Money]` versus anything else. Step 2 must say so explicitly, even when the
-`HasGen` instance being routed to is one of the built-ins.
+**Ambiguity:** if the same column name is used in two different steps and each step's
+extractor infers a *different* type, that's reported as a setup error too (not
+first-match-wins) — the message names the column and both conflicting types, since no
+single generator could be right for both.
 
 ---
 
 ### Complete setup checklist
 
-For a property scenario with a domain-type column to work:
+For a property scenario with a **built-in-typed** column (`Int`, `String`, `Long`,
+`Double`, `Boolean`, `UUID`) to work, there is no checklist — it resolves automatically
+from the step's extractor with zero setup.
 
-- [ ] Define `case class Money(value: Double)` (or whatever your type is).
-- [ ] Add `given HasGen[Money] with { def gen = Gen.double(...).map(Money.apply) }` in the
-      suite object.
-- [ ] Add `case "amount" => Some(HasGen[Money])` in `columnGenLookup`.
+For a property scenario with a **domain-type** column, pick one of two paths:
+
+- **Register the type once** (works for every column of that type, no per-column wiring):
+  - [ ] Define `case class Money(value: Double)` (or whatever your type is).
+  - [ ] Add `given HasGen[Money] with { def gen = Gen.double(...).map(Money.apply) }`.
+  - [ ] Call `HasGen.registerType(HasGen[Money])` once (e.g. in the suite's object body).
+- **Or route it explicitly per column** (useful for a one-off override):
+  - [ ] Define the `given HasGen[Money]` as above.
+  - [ ] Add `case "amount" => Some(HasGen[Money])` in `columnGenLookup`.
+
+Either way:
 - [ ] Ensure the step definition uses the same `TypedExtractor[Money]` it already uses
-      for literal scenarios (e.g. `/ money`).  No step change is needed.
+      for literal scenarios (e.g. `/ money`). No step change is needed.
 - [ ] Add `@property(samples=N)` to a header-only `Examples:` block.
-
-If the column uses a built-in type (`Int`, `String`, `Long`, `Double`, `Boolean`,
-`UUID`), steps 1–2 are not required — but step 3 (`columnGenLookup` wiring) still is;
-just route the column to `Some(HasGen[Int])` (etc.) directly, no custom `given` needed.
 
 ---
 
@@ -423,6 +452,17 @@ one value per column, substitutes it, and validates that every step pattern matc
 executing any step body, writing to the failure store, or consulting an existing replay record.
 A column with no resolvable `HasGen` still surfaces the usual setup error during a dry run, since
 that's a configuration problem independent of whether step bodies execute.
+
+**Use it as a fast CI pre-check.** Column resolution (including the automatic type-based
+lookup above) already runs before any sampling on every normal test run, so a missing
+`HasGen` fails fast as an ordinary test failure even without `--dry-run`. `--dry-run` goes
+one step further and skips real step-body execution too, across every suite, for a
+near-instant "is every property column resolvable and does every step pattern match"
+smoke check — useful as an early CI stage before the full (slower) test run:
+
+```sh
+sbt "Test/testOnly * -- --dry-run"
+```
 
 ---
 
@@ -563,4 +603,4 @@ sbt "example/testOnly zio.bdd.example.SimpleSpec -- --include-tags negative"
 | Full ZIO Test shrink-tree walking | v1 records the failing seed; minimal counterexample via shrink traversal is planned for v2 |
 | `Assume` / filter step to discard samples | Planned for v2 (`maxDiscarded` arg is reserved) |
 | Parallel sample execution | All samples for one property scenario run sequentially; scenario-level parallelism still applies across multiple property scenarios |
-| Automatic built-in-type resolution | Not supported — every column, including built-in-typed ones, must be routed explicitly via `columnGenLookup`; see [Built-in `HasGen` instances](#built-in-hasgen-instances) above |
+| Compile-time detection of missing `HasGen` instances | Not possible — `.feature` files are plain text parsed at runtime, and Scala can't enumerate `given HasGen[_]` instances at compile time either. A missing `HasGen` fails fast as an ordinary test failure (column resolution runs before any sampling); `--dry-run` gives an even faster all-suites pre-check — see [`--dry-run`](#--dry-run) above |

--- a/docs/property-testing.md
+++ b/docs/property-testing.md
@@ -415,6 +415,17 @@ If you don't override `flagLayer`, it defaults to `scenarioLayer(meta)` — flag
 
 ---
 
+## `--dry-run`
+
+`--dry-run` (validates step matching without executing step bodies) is honored by property
+scenarios too: instead of running the configured `samples` count for real, it samples exactly
+one value per column, substitutes it, and validates that every step pattern matches — without
+executing any step body, writing to the failure store, or consulting an existing replay record.
+A column with no resolvable `HasGen` still surfaces the usual setup error during a dry run, since
+that's a configuration problem independent of whether step bodies execute.
+
+---
+
 ## Failure replay
 
 When a property fails, the executor writes the failing seed and counterexample values to

--- a/docs/property-testing.md
+++ b/docs/property-testing.md
@@ -25,21 +25,33 @@ Feature: Account invariants
 ```
 
 ```scala
-import zio.bdd.core.property.HasGen
+import zio.bdd.core.property.{ColumnGenLookup, HasGen}
 import zio.test.Gen
 
 @Suite(featureDirs = Array("src/test/resources/features"), reporters = Array("pretty", "junitxml"))
 object AccountSpec extends ZIOSteps[AccountService, AccountState]:
 
-  // Register generators for the placeholder types
-  given HasGen[Money]  = Gen.double(0, 10_000).map(Money.apply)
-  given HasGen[Limit]  = Gen.long(0, 5_000).map(Limit.apply)
+  // Register generators for the placeholder types. `HasGen` is a plain trait (not a
+  // function type), so a `given` instance needs a `with` body — not `= <gen value>`.
+  given HasGen[Money] with
+    def gen = Gen.double(0, 10_000).map(Money.apply)
+
+  given HasGen[Limit] with
+    def gen = Gen.long(0, 5_000).map(Limit.apply)
 
   Given("an account with balance " / money / " and limit " / limit) { (bal, lim) =>
     ScenarioContext.update(_.copy(balance = bal, limit = lim))
   }
   When("I withdraw " / money) { (amount: Money) => ... }
   Then("the resulting balance is at least negative " / limit) { (lim: Limit) => ... }
+
+  // Every property column — including these — must still be routed by name in
+  // columnGenLookup; see "Wiring column resolution" below.
+  override def columnGenLookup: ColumnGenLookup = new ColumnGenLookup:
+    def byColumn(col: String): Option[HasGen[?]] = col match
+      case "balance" | "amount" => Some(HasGen[Money])
+      case "limit"              => Some(HasGen[Limit])
+      case _                    => None
 ```
 
 On failure the pretty reporter shows:
@@ -159,8 +171,8 @@ val orderGen: Gen[Any, Order] =
 
 ### Built-in `HasGen` instances
 
-These are provided automatically for primitive types that match the built-in
-`TypedExtractor` set.  No registration or import needed:
+`HasGen` instances are already provided for these types — no `given` needed to define
+them:
 
 | Type | Generator used |
 |---|---|
@@ -171,16 +183,28 @@ These are provided automatically for primitive types that match the built-in
 | `String` | `Gen.alphaNumericString` |
 | `UUID` | `Gen.uuid` |
 
-If your placeholders use only these types and your step extractors already use the
-corresponding built-in extractors (`/ int`, `/ string`, etc.), no additional setup is
-needed — property mode works out of the box.
+**This does not mean property mode works with zero setup.** Column-to-generator
+resolution is always by *column name*, never by inferred type — there is no mechanism
+that looks at a step's `/ int` extractor and concludes "this column is an `Int`, use
+`HasGen[Int]`". Every property column, including ones that only need a built-in type,
+must still have an entry in `columnGenLookup` (see below) that explicitly returns
+`Some(HasGen[Int])` (or whichever built-in applies) for that column name. What the
+built-ins save you from is writing `Gen.int` yourself — not from wiring the column.
+
+```scala
+override def columnGenLookup: ColumnGenLookup = new ColumnGenLookup:
+  def byColumn(col: String): Option[HasGen[?]] = col match
+    case "retries" => Some(HasGen[Int])    // built-in HasGen[Int], still routed explicitly
+    case _         => None
+```
 
 ---
 
 ### Providing `HasGen` for a domain type
 
 For every domain type used as a placeholder, provide a `given HasGen[YourType]` in your
-suite object.  The `given` is defined inline using Scala 3's anonymous given syntax:
+suite object. `HasGen[A]` is a plain trait with one abstract member (`def gen: Gen[Any, A]`),
+not a function type — so a `given` instance needs a `with` body, not `given HasGen[X] = <value>`:
 
 ```scala
 import zio.bdd.core.property.HasGen
@@ -189,22 +213,37 @@ import zio.test.Gen
 object MySpec extends ZIOSteps[MyService, MyState]:
 
   // Simple range-bounded value type
-  given HasGen[Money] = Gen.double(0.01, 10_000.0).map(Money.apply)
+  given HasGen[Money] with
+    def gen = Gen.double(0.01, 10_000.0).map(Money.apply)
 
   // Enum — pick uniformly from the valid members
-  given HasGen[Currency] = Gen.elements(Currency.GBP, Currency.USD, Currency.EUR)
+  given HasGen[Currency] with
+    def gen = Gen.elements(Currency.GBP, Currency.USD, Currency.EUR)
 
   // Case class with multiple fields
-  given HasGen[Address] =
-    for
-      street <- Gen.alphaNumericString
-      city   <- Gen.elements("London", "New York", "Tokyo")
-    yield Address(street, city)
+  given HasGen[Address] with
+    def gen =
+      for
+        street <- Gen.alphaNumericString
+        city   <- Gen.elements("London", "New York", "Tokyo")
+      yield Address(street, city)
 ```
 
 The `given` must be in scope at the point where `columnGenLookup` resolves the type.
 Placing it directly in the suite object (or in a trait mixed into the suite) is the
 idiomatic location.
+
+**Override `label` for readable counterexamples.** The default `label` falls back to
+`gen.getClass.getSimpleName`, which is often an uninformative anonymous-class name (e.g.
+`HasGen[Gen]`) for a `for`-comprehension or `Gen.elements(...)`-built generator. Override
+it explicitly so failure output reads `amount=42 (HasGen[Money])` instead of
+`amount=42 (HasGen[Gen])`:
+
+```scala
+given HasGen[Money] with
+  def gen            = Gen.double(0.01, 10_000.0).map(Money.apply)
+  override def label = "HasGen[Money]"
+```
 
 #### Using `HasGen.apply` to summon an instance
 
@@ -256,8 +295,9 @@ names to avoid accidental collision between suites.
 ### Wiring column resolution via `columnGenLookup`
 
 Override `columnGenLookup` on your suite to tell the executor which `HasGen` to use for
-each placeholder column name.  The built-in primitive types are always resolved
-automatically; this override is only needed for domain types.
+each placeholder column name. **This override is required for every property column** —
+domain types and built-in types alike. There is no automatic fallback by inferred type;
+resolution is entirely by column name.
 
 ```scala
 import zio.bdd.core.property.{ColumnGenLookup, HasGen}
@@ -267,7 +307,7 @@ override def columnGenLookup: ColumnGenLookup = new ColumnGenLookup:
     case "balance" | "amount" => Some(HasGen[Money])
     case "limit"              => Some(HasGen[Limit])
     case "currency"           => Some(HasGen[Currency])
-    case _                    => None  // falls back to built-ins; fails with a clear error if unresolved
+    case _                    => None  // unresolved → setup error (see below)
 ```
 
 **Resolution order** for a column named `"amount"`:
@@ -275,10 +315,14 @@ override def columnGenLookup: ColumnGenLookup = new ColumnGenLookup:
 1. Named override from the column header annotation (`| amount: smallAmounts |`) —
    checked against `HasGen.resolve("smallAmounts")`.
 2. `columnGenLookup.byColumn("amount")`.
-3. Built-in `HasGen` instance for the column's inferred type (for primitive columns
-   matched by existing `TypedExtractor` built-ins).
-4. Setup error — the scenario fails immediately with a clear message:
-   `No HasGen registered for column 'amount'. Register given HasGen[T] for its type.`
+3. Setup error — the scenario fails immediately with a clear message:
+   ``No HasGen registered for column 'amount'. Register `given HasGen[T]` for its type.``
+
+There is deliberately no third "automatic built-in by type" step: a column is just a
+string name parsed from the Gherkin header, with no attached type information, so the
+executor cannot infer that a column named `"amount"` should resolve to `HasGen[Int]`
+versus `HasGen[Money]` versus anything else. Step 2 must say so explicitly, even when the
+`HasGen` instance being routed to is one of the built-ins.
 
 ---
 
@@ -287,14 +331,16 @@ override def columnGenLookup: ColumnGenLookup = new ColumnGenLookup:
 For a property scenario with a domain-type column to work:
 
 - [ ] Define `case class Money(value: Double)` (or whatever your type is).
-- [ ] Add `given HasGen[Money] = Gen.double(...).map(Money.apply)` in the suite object.
+- [ ] Add `given HasGen[Money] with { def gen = Gen.double(...).map(Money.apply) }` in the
+      suite object.
 - [ ] Add `case "amount" => Some(HasGen[Money])` in `columnGenLookup`.
 - [ ] Ensure the step definition uses the same `TypedExtractor[Money]` it already uses
       for literal scenarios (e.g. `/ money`).  No step change is needed.
 - [ ] Add `@property(samples=N)` to a header-only `Examples:` block.
 
 If the column uses a built-in type (`Int`, `String`, `Long`, `Double`, `Boolean`,
-`UUID`), steps 1–3 are not required.
+`UUID`), steps 1–2 are not required — but step 3 (`columnGenLookup` wiring) still is;
+just route the column to `Some(HasGen[Int])` (etc.) directly, no custom `given` needed.
 
 ---
 
@@ -325,22 +371,49 @@ Scenario Outline: Withdrawal invariants
 The `@regression` block expands to two literal scenarios.  The `@property` block produces one
 property scenario that runs 500 times.  Both share the same step definitions.
 
+**A `@property` block that also has literal data rows is not an error** — it's treated as a
+plain literal block instead, rows and all, and no samples are generated. This is a deliberate
+"don't lose data" guard against the case where `@property` was added or left on a block whose
+rows weren't removed: the `@property` tag stays on `scenario.tags` for inspection, but
+`scenario.propertyConfig` is `None`, so it expands one scenario per literal row exactly like an
+untagged `Examples:` block. If you intend a property block, leave it header-only (just the
+column names, no data rows).
+
+---
+
+## Combining with `@flags(...)`
+
+`@flags(...)` (the [feature-flag matrix](testing-flags.md)) and `@property(...)` cannot be
+meaningfully combined. A property scenario carrying one or more `@flags(k=v)` tags runs
+exactly **once** — the flags are not multiplied into separate runs, and no flag value is ever
+injected into the property execution (`PropertyExecutor` has no notion of `flagLayer`). This is
+intentional: multiplying would otherwise mean running the full sample batch once per flag
+combination with the same (ignored) behaviour every time — wasted sample budget for zero signal.
+If you need to vary a value across a property run, drive it through `HasGen`/`columnGenLookup`
+(or a literal `@regression`-style Examples block per flag value) instead of `@flags(...)`.
+
 ---
 
 ## Failure replay
 
 When a property fails, the executor writes the failing seed and counterexample values to
-`.zio-bdd/failures/<scenario-slug>.json`.  On the next run, that seed is **replayed first**
-before generating new samples:
+`.zio-bdd/failures/<scenario-slug>.json`.  On the next run, that exact counterexample is
+**replayed first**, as a single sample, before generating any new samples:
 
-```
-▶ Replaying 1 known-failing sample for "Withdrawal never produces a negative balance"...
-  ✗ Still falsifies (seed=42, sample=12) — counterexample unchanged
-  STOP. New samples not generated.
-```
+- **Still falsifies:** the scenario result is reported as failed (with `[replayed from failure
+  store]` appended to the failure message) and — exactly as on first failure — *no* fresh
+  samples are generated. You get immediate feedback without burning a new sample budget.
+- **Now passes** (the bug was fixed): the stale failure file is deleted, and the executor falls
+  through to a full fresh batch of `samples` runs with a new seed — the replay is a fast
+  pre-check, not a substitute for the regular run.
 
-If the replay passes (the bug was fixed), the failure file is cleared and the full sample run
-proceeds normally.
+### Stale records (scenario body changed)
+
+If the scenario's step list changes (the scenario was edited) since a failure was recorded, the
+stored counterexample no longer corresponds to the current scenario body. `PropertyFailureStore`
+detects this via a `bodyHash` of the step list: on mismatch it logs a `ZIO.logWarning` and
+deletes the stale file, then proceeds with a full fresh batch — it never replays a test that no
+longer exists in that form.
 
 ### File format
 
@@ -356,13 +429,11 @@ proceeds normally.
 }
 ```
 
-**Body-hash invalidation:** if the scenario's step list changes (the scenario was edited), the
-stale failure record is discarded with a warning rather than replaying a test that no longer exists
-in the same form.
-
-**Committing the file:** `.zio-bdd/failures/` should be committed to version control.  The failing
-seeds are a signal that travels with the codebase — CI will replay them on every run until the
-regression is fixed.
+**Committing the file:** in *your own project* (not in zio-bdd's own repo, which gitignores
+`.zio-bdd/` since it's test-run output, not an intentionally pinned regression),
+`.zio-bdd/failures/` can be committed to version control if you want a failing seed to travel
+with the codebase — CI then replays it on every run until the regression is fixed and the file
+is naturally deleted.
 
 **Disabling replay:** `@property(replay=false)` on the tag, or `--no-replay` on the sbt CLI.
 
@@ -418,22 +489,18 @@ The `example/` module ships a complete working example:
 - **Feature file:** `example/src/test/resources/features/greeting_properties.feature`
 - **Step suite:** `example/src/test/scala/zio/bdd/example/SimpleSpec.scala`
 
-The feature tests three invariants of `GreetingService`, including one intentionally broken scenario
-that demonstrates the failure output:
+The feature tests four invariants of `GreetingService`, covering each `HasGen` style and
+tag placement described above:
+
+| Scenario | Demonstrates |
+|---|---|
+| `Greeting always starts with "Hello," and ends with "!"` | Named override (`HasGen.named("name")`), `@property` on the `Examples:` block |
+| `Greeting is always longer than 7 characters` | Same named-override generator, a second invariant |
+| `Greeting is shorter than 5 characters (intentionally broken)` | Intentionally falsifying scenario, tagged `@negative` (not `@positive`) so it's excluded from the default `--include-tags positive` run — see below |
+| `Greeting always contains the name regardless of title` | Two `HasGen` styles in one scenario: named override (`name`) and domain-type `given HasGen[Title]` (`title`); `@property` on the `Scenario Outline:` line instead of the `Examples:` block |
 
 ```gherkin
-@positive @property(samples=500, seed=42, shrink=true)
-Scenario Outline: Greeting always starts with "Hello," and ends with "!"
-  Given a user named <name>
-  When the user is greeted
-  Then the greeting starts with "Hello,"
-  And the greeting ends with "!"
-  And the greeting contains the name
-
-  Examples:
-    | name |
-
-@positive @property(samples=100, seed=7, replay=false)
+@negative @property(samples=100, seed=7, replay=false)
 Scenario Outline: Greeting is shorter than 5 characters (intentionally broken)
   Given a user named <name>
   When the user is greeted
@@ -443,10 +510,16 @@ Scenario Outline: Greeting is shorter than 5 characters (intentionally broken)
     | name |
 ```
 
-Run with:
+Run the default (passing) set with:
 
 ```sh
 sbt "example/test"
+```
+
+Run the intentionally-broken scenario explicitly to see the counterexample output:
+
+```sh
+sbt "example/testOnly zio.bdd.example.SimpleSpec -- --include-tags negative"
 ```
 
 ---
@@ -458,3 +531,5 @@ sbt "example/test"
 | Full ZIO Test shrink-tree walking | v1 records the failing seed; minimal counterexample via shrink traversal is planned for v2 |
 | `Assume` / filter step to discard samples | Planned for v2 (`maxDiscarded` arg is reserved) |
 | Parallel sample execution | All samples for one property scenario run sequentially; scenario-level parallelism still applies across multiple property scenarios |
+| `@flags(...)` combined with `@property(...)` | Not supported — see [Combining with `@flags(...)`](#combining-with-flags) above |
+| Automatic built-in-type resolution | Not supported — every column, including built-in-typed ones, must be routed explicitly via `columnGenLookup`; see [Built-in `HasGen` instances](#built-in-hasgen-instances) above |

--- a/docs/property-testing.md
+++ b/docs/property-testing.md
@@ -383,14 +383,35 @@ column names, no data rows).
 
 ## Combining with `@flags(...)`
 
-`@flags(...)` (the [feature-flag matrix](testing-flags.md)) and `@property(...)` cannot be
-meaningfully combined. A property scenario carrying one or more `@flags(k=v)` tags runs
-exactly **once** — the flags are not multiplied into separate runs, and no flag value is ever
-injected into the property execution (`PropertyExecutor` has no notion of `flagLayer`). This is
-intentional: multiplying would otherwise mean running the full sample batch once per flag
-combination with the same (ignored) behaviour every time — wasted sample budget for zero signal.
-If you need to vary a value across a property run, drive it through `HasGen`/`columnGenLookup`
-(or a literal `@regression`-style Examples block per flag value) instead of `@flags(...)`.
+`@flags(...)` (the [feature-flag matrix](testing-flags.md)) and `@property(...)` compose: a
+property scenario carrying one or more `@flags(k=v)` tags runs one **full, independent sample
+batch per flag combination** — e.g. verifying an invariant holds with a feature flag both on and
+off, across N generated samples each time.
+
+```gherkin
+@flags(useNewPricing=true) @flags(useNewPricing=false)
+@property(samples=200, seed=7)
+Scenario Outline: Total is never negative regardless of pricing engine
+  Given a cart with <itemCount> items at <unitPrice> each
+  Then the total is never negative
+
+  Examples:
+    | itemCount | unitPrice |
+```
+
+This produces two scenario results — `... [useNewPricing=true]` and
+`... [useNewPricing=false]` — each running its own 200-sample batch. Each sample is executed
+with `suite.flagLayer(meta, flags)` (the same override point used for literal `@flags(...)`
+scenarios), so the flag values reach the environment the same way they would in a literal
+scenario:
+
+```scala
+override def flagLayer(meta: ScenarioMetadata, flags: Map[String, String]) =
+  environment >>> PricingConfig.layer(flags)
+```
+
+If you don't override `flagLayer`, it defaults to `scenarioLayer(meta)` — flags are visible in
+`meta.flagValues` but not injected into the environment, same as for literal scenarios.
 
 ---
 
@@ -531,5 +552,4 @@ sbt "example/testOnly zio.bdd.example.SimpleSpec -- --include-tags negative"
 | Full ZIO Test shrink-tree walking | v1 records the failing seed; minimal counterexample via shrink traversal is planned for v2 |
 | `Assume` / filter step to discard samples | Planned for v2 (`maxDiscarded` arg is reserved) |
 | Parallel sample execution | All samples for one property scenario run sequentially; scenario-level parallelism still applies across multiple property scenarios |
-| `@flags(...)` combined with `@property(...)` | Not supported — see [Combining with `@flags(...)`](#combining-with-flags) above |
 | Automatic built-in-type resolution | Not supported — every column, including built-in-typed ones, must be routed explicitly via `columnGenLookup`; see [Built-in `HasGen` instances](#built-in-hasgen-instances) above |

--- a/example/README.md
+++ b/example/README.md
@@ -22,6 +22,10 @@ The example includes a feature file with tagged scenarios:
     - `Greet an empty user` (`@ignore`)
     - `Greet a different user` (`@negative`)
 
+The example also includes `example/src/test/resources/features/greeting_properties.feature`,
+demonstrating `@property(...)` generative Examples blocks — see
+[docs/property-testing.md](../docs/property-testing.md).
+
 ## Running Tests
 
 Use the following SBT commands from the project root to run the tests:

--- a/example/src/test/resources/features/greeting_properties.feature
+++ b/example/src/test/resources/features/greeting_properties.feature
@@ -1,0 +1,37 @@
+@core @property-testing
+Feature: Greeting invariants
+
+  # Property test: any non-empty name always produces a greeting of the
+  # expected form.  500 generated names are sampled; no literal rows needed.
+  @positive @property(samples=500, seed=42, shrink=true)
+  Scenario Outline: Greeting always starts with "Hello," and ends with "!"
+    Given a user named <name>
+    When the user is greeted
+    Then the greeting starts with "Hello,"
+    And the greeting ends with "!"
+    And the greeting contains the name
+
+    Examples:
+      | name |
+
+  # Property test: the greeting length is always > 7 characters (length of
+  # "Hello, " + at least one character + "!").
+  @positive @property(samples=200, seed=99)
+  Scenario Outline: Greeting is always longer than 7 characters
+    Given a user named <name>
+    When the user is greeted
+    Then the greeting length is greater than 7
+
+    Examples:
+      | name |
+
+  # Intentionally failing property: greetings are never shorter than 5 chars,
+  # so this invariant is always falsified on the very first sample.
+  @negative @property(samples=100, seed=7, replay=false)
+  Scenario Outline: Greeting is shorter than 5 characters (intentionally broken)
+    Given a user named <name>
+    When the user is greeted
+    Then the greeting length is less than 5
+
+    Examples:
+      | name |

--- a/example/src/test/resources/features/greeting_properties.feature
+++ b/example/src/test/resources/features/greeting_properties.feature
@@ -35,3 +35,19 @@ Feature: Greeting invariants
 
     Examples:
       | name |
+
+  # Two HasGen columns in the same property scenario, each resolved a different way:
+  #   - name  → named override (HasGen.named("name"))
+  #   - title → domain-type generator (given HasGen[Title])
+  # Also demonstrates the @property tag placed on the Scenario Outline line itself,
+  # rather than on the Examples: block — both placements are equivalent.
+  @positive @property(samples=300, seed=17)
+  Scenario Outline: Greeting always contains the name regardless of title
+    Given a user named <name>
+    And a title <title>
+    When the user is greeted
+    Then the title is a known honorific
+    And the greeting contains the name
+
+    Examples:
+      | name | title |

--- a/example/src/test/resources/features/greeting_properties.feature
+++ b/example/src/test/resources/features/greeting_properties.feature
@@ -36,18 +36,28 @@ Feature: Greeting invariants
     Examples:
       | name |
 
-  # Two HasGen columns in the same property scenario, each resolved a different way:
-  #   - name  → named override (HasGen.named("name"))
-  #   - title → domain-type generator (given HasGen[Title])
+  # Three HasGen columns in the same property scenario, each resolved a different way —
+  # demonstrates that automatic type-based resolution needs no registration at all for a
+  # built-in type, one `HasGen.registerType` call (ever, not per-column) for a domain type,
+  # and columnGenLookup only where the automatic choice isn't the one actually wanted:
+  #   - name  → resolves automatically to HasGen[String], but overridden via
+  #             `columnGenLookup` + `HasGen.named("name")` for readable output
+  #   - title → a domain type (Title); resolves automatically by type because
+  #             `HasGen.registerType(HasGen[Title])` ran once in SimpleSpec — no
+  #             `columnGenLookup` entry
+  #   - age   → a built-in type (Int); resolves automatically with *zero* setup — no
+  #             `given`, no `registerType`, no `columnGenLookup` entry
   # Also demonstrates the @property tag placed on the Scenario Outline line itself,
   # rather than on the Examples: block — both placements are equivalent.
   @positive @property(samples=300, seed=17)
-  Scenario Outline: Greeting always contains the name regardless of title
+  Scenario Outline: Greeting always contains the name regardless of title or age
     Given a user named <name>
     And a title <title>
+    And the user's age is <age>
     When the user is greeted
     Then the title is a known honorific
+    And the age is recorded
     And the greeting contains the name
 
     Examples:
-      | name | title |
+      | name | title | age |

--- a/example/src/test/scala/zio/bdd/example/SimpleSpec.scala
+++ b/example/src/test/scala/zio/bdd/example/SimpleSpec.scala
@@ -3,40 +3,113 @@ package zio.bdd.example
 import zio.*
 import zio.bdd.core.Assertions.assertTrue
 import zio.bdd.core.Suite
+import zio.bdd.core.property.{ColumnGenLookup, HasGen}
 import zio.bdd.core.step.ZIOSteps
-import zio.bdd.example.Config
+import zio.bdd.example.{Config => AppConfig}
 import zio.schema.{DeriveSchema, Schema}
+import zio.test.Gen
 
 case class ScenarioContext(userName: String, greeting: String)
 
-object ScenarioContext {
+object ScenarioContext:
   implicit val schema: Schema[ScenarioContext] = DeriveSchema.gen[ScenarioContext]
-}
 
 @Suite(
-  featureDir = "example/src/test/resources/features",
-  reporters = Array("pretty", "junitxml"),
+  featureDirs = Array("example/src/test/resources/features"),
+  reporters   = Array("pretty", "junitxml"),
   parallelism = 1,
-  includeTags = Array("positive"), // Pre-filter to only run @positive scenarios
-  logLevel = "debug"
+  includeTags = Array("positive"),
+  logLevel    = "info"
 )
-object SimpleSpec extends ZIOSteps[GreetingService, ScenarioContext] {
+object SimpleSpec extends ZIOSteps[GreetingService, ScenarioContext]:
+
+  // ── HasGen registration ────────────────────────────────────────────────
+  // Override the built-in HasGen[String] (alphanumeric) with a generator that
+  // produces capitalised human-readable names — makes failure output readable:
+  //   [counterexample] name=Mxqzb → name=Alice
+  HasGen.named("name")(
+    for {
+      first <- Gen.char('A', 'Z')
+      rest  <- Gen.stringBounded(1, 9)(Gen.char('a', 'z'))
+    } yield first.toString + rest
+  )
+
+  // ── Functional BDD steps (simple.feature) ────────────────────────────────
+
   Given("a user named " / string) { (name: String) =>
     ScenarioContext.update(_.copy(userName = name))
   }
 
   When("the user is greeted") {
     for {
-        ctx <- ScenarioContext.get
-        _   <- ZIO.logInfo(s"Greeting user ${ctx.userName}")
-        _ <- ScenarioContext.update(_.copy(greeting = s"Hello, ${ctx.userName}!"))
+      ctx <- ScenarioContext.get
+      _   <- ZIO.logInfo(s"Greeting user ${ctx.userName}")
+      _   <- ScenarioContext.update(_.copy(greeting = s"Hello, ${ctx.userName}!"))
     } yield ()
   }
 
   Then("the greeting should be " / string) { (expectedGreeting: String) =>
-    ScenarioContext.get.map(_.greeting).map(actualGreeting => assertTrue(actualGreeting == expectedGreeting, s"Expected '$expectedGreeting', but got '$actualGreeting'"))
+    ScenarioContext.get.map(_.greeting).map { actualGreeting =>
+      assertTrue(actualGreeting == expectedGreeting, s"Expected '$expectedGreeting', but got '$actualGreeting'")
+    }
   }
 
+  // ── Property assertion steps (greeting_properties.feature) ───────────────
+
+  Then("the greeting starts with " / string) { (prefix: String) =>
+    ScenarioContext.get.flatMap { ctx =>
+      assertTrue(
+        ctx.greeting.startsWith(prefix),
+        s"Expected greeting to start with '$prefix', got '${ctx.greeting}'"
+      )
+    }
+  }
+
+  Then("the greeting ends with " / string) { (suffix: String) =>
+    ScenarioContext.get.flatMap { ctx =>
+      assertTrue(
+        ctx.greeting.endsWith(suffix),
+        s"Expected greeting to end with '$suffix', got '${ctx.greeting}'"
+      )
+    }
+  }
+
+  Then("the greeting contains the name") {
+    ScenarioContext.get.flatMap { ctx =>
+      assertTrue(
+        ctx.greeting.contains(ctx.userName),
+        s"Expected '${ctx.greeting}' to contain name '${ctx.userName}'"
+      )
+    }
+  }
+
+  Then("the greeting length is greater than " / int) { (minLen: Int) =>
+    ScenarioContext.get.flatMap { ctx =>
+      assertTrue(
+        ctx.greeting.length > minLen,
+        s"Expected greeting length > $minLen, got ${ctx.greeting.length}: '${ctx.greeting}'"
+      )
+    }
+  }
+
+  Then("the greeting length is less than " / int) { (maxLen: Int) =>
+    ScenarioContext.get.flatMap { ctx =>
+      assertTrue(
+        ctx.greeting.length < maxLen,
+        s"Expected greeting length < $maxLen, got ${ctx.greeting.length}: '${ctx.greeting}'"
+      )
+    }
+  }
+
+  // ── Column generator lookup ────────────────────────────────────────────
+  // Routes the `name` column in @property Examples blocks to the named
+  // "name" generator registered above.
+  override def columnGenLookup: ColumnGenLookup = new ColumnGenLookup:
+    def byColumn(col: String): Option[HasGen[?]] = col match
+      case "name" => HasGen.resolve("name")
+      case _      => None
+
+  // ── ZLayer ────────────────────────────────────────────────────────────────
+
   override def environment: ZLayer[Any, Throwable, GreetingService] =
-    ZLayer.succeed(Config("Hello")) >>> GreetingService.live
-}
+    ZLayer.succeed(AppConfig("Hello")) >>> GreetingService.live

--- a/example/src/test/scala/zio/bdd/example/SimpleSpec.scala
+++ b/example/src/test/scala/zio/bdd/example/SimpleSpec.scala
@@ -125,12 +125,15 @@ object SimpleSpec extends ZIOSteps[GreetingService, ScenarioContext]:
   }
 
   // ── Column generator lookup ────────────────────────────────────────────
-  // Routes @property Examples columns to their HasGen instance. Three distinct styles:
-  //   - "name"  → a *named* override registered above via HasGen.named("name")(...)
-  //   - "title" → a *domain-type* generator resolved via the `given HasGen[Title]` above
-  //   - any built-in-typed column (Int/Long/Double/Boolean/String/UUID) would still need
-  //     an entry here too — HasGen's built-ins are summonable, but column→type routing is
-  //     always explicit; there's no automatic name-to-type inference.
+  // columnGenLookup is the *override* path, not mandatory wiring — both columns below
+  // are governed by a `string` extractor (Given("a user named " / string), Given("a
+  // title " / string)), so they'd resolve automatically to the built-in HasGen[String]
+  // (unconstrained alphanumeric text) with no entry here at all. Both are overridden
+  // anyway because the automatic choice isn't the generator we actually want:
+  //   - "name"  → a *named* override (HasGen.named("name")(...) above) for readable
+  //     capitalised names instead of alphanumeric gibberish.
+  //   - "title" → a *domain-type* generator (`given HasGen[Title]` above) so it only
+  //     ever generates one of the three known honorifics, not arbitrary text.
   override def columnGenLookup: ColumnGenLookup = new ColumnGenLookup:
     def byColumn(col: String): Option[HasGen[?]] = col match
       case "name"  => HasGen.resolve("name")

--- a/example/src/test/scala/zio/bdd/example/SimpleSpec.scala
+++ b/example/src/test/scala/zio/bdd/example/SimpleSpec.scala
@@ -9,10 +9,16 @@ import zio.bdd.example.{Config => AppConfig}
 import zio.schema.{DeriveSchema, Schema}
 import zio.test.Gen
 
-case class ScenarioContext(userName: String, greeting: String)
+case class ScenarioContext(userName: String, greeting: String, title: String = "")
 
 object ScenarioContext:
   implicit val schema: Schema[ScenarioContext] = DeriveSchema.gen[ScenarioContext]
+
+// A small domain type — demonstrates wiring `given HasGen[T]` for a type that isn't one of
+// HasGen's primitive built-ins (Int/Long/Double/Boolean/String/UUID), as opposed to the
+// `HasGen.named(...)` override used for the `name` column below.
+enum Title:
+  case Mr, Ms, Dr
 
 @Suite(
   featureDirs = Array("example/src/test/resources/features"),
@@ -33,6 +39,12 @@ object SimpleSpec extends ZIOSteps[GreetingService, ScenarioContext]:
       rest  <- Gen.stringBounded(1, 9)(Gen.char('a', 'z'))
     } yield first.toString + rest
   )
+
+  // Domain-type generator via Scala 3 `given` — the other way to supply a `HasGen[T]`,
+  // for a type that's specific to this suite rather than a reusable named override.
+  given HasGen[Title] with
+    def gen            = Gen.elements(Title.Mr, Title.Ms, Title.Dr)
+    override def label = "HasGen[Title]"
 
   // ── Functional BDD steps (simple.feature) ────────────────────────────────
 
@@ -101,13 +113,29 @@ object SimpleSpec extends ZIOSteps[GreetingService, ScenarioContext]:
     }
   }
 
+  Given("a title " / string) { (title: String) =>
+    ScenarioContext.update(_.copy(title = title))
+  }
+
+  Then("the title is a known honorific") {
+    ScenarioContext.get.flatMap { ctx =>
+      val known = Title.values.map(_.toString).toSet
+      assertTrue(known.contains(ctx.title), s"Expected one of $known, got '${ctx.title}'")
+    }
+  }
+
   // ── Column generator lookup ────────────────────────────────────────────
-  // Routes the `name` column in @property Examples blocks to the named
-  // "name" generator registered above.
+  // Routes @property Examples columns to their HasGen instance. Three distinct styles:
+  //   - "name"  → a *named* override registered above via HasGen.named("name")(...)
+  //   - "title" → a *domain-type* generator resolved via the `given HasGen[Title]` above
+  //   - any built-in-typed column (Int/Long/Double/Boolean/String/UUID) would still need
+  //     an entry here too — HasGen's built-ins are summonable, but column→type routing is
+  //     always explicit; there's no automatic name-to-type inference.
   override def columnGenLookup: ColumnGenLookup = new ColumnGenLookup:
     def byColumn(col: String): Option[HasGen[?]] = col match
-      case "name" => HasGen.resolve("name")
-      case _      => None
+      case "name"  => HasGen.resolve("name")
+      case "title" => Some(HasGen[Title])
+      case _       => None
 
   // ── ZLayer ────────────────────────────────────────────────────────────────
 

--- a/example/src/test/scala/zio/bdd/example/SimpleSpec.scala
+++ b/example/src/test/scala/zio/bdd/example/SimpleSpec.scala
@@ -4,28 +4,40 @@ import zio.*
 import zio.bdd.core.Assertions.assertTrue
 import zio.bdd.core.Suite
 import zio.bdd.core.property.{ColumnGenLookup, HasGen}
-import zio.bdd.core.step.ZIOSteps
+import zio.bdd.core.step.{TypedExtractor, ZIOSteps}
 import zio.bdd.example.{Config => AppConfig}
 import zio.schema.{DeriveSchema, Schema}
 import zio.test.Gen
 
-case class ScenarioContext(userName: String, greeting: String, title: String = "")
+case class ScenarioContext(userName: String, greeting: String, title: String = "", age: Int = 0)
 
 object ScenarioContext:
   implicit val schema: Schema[ScenarioContext] = DeriveSchema.gen[ScenarioContext]
 
 // A small domain type — demonstrates wiring `given HasGen[T]` for a type that isn't one of
-// HasGen's primitive built-ins (Int/Long/Double/Boolean/String/UUID), as opposed to the
-// `HasGen.named(...)` override used for the `name` column below.
+// HasGen's primitive built-ins (Int/Long/Double/Boolean/String/UUID).
 enum Title:
   case Mr, Ms, Dr
 
+// A dedicated extractor for Title (rather than reusing `string`) so the `<title>` column's
+// step extractor actually carries `Tag[Title]` — that's what lets `@property` resolve its
+// generator *automatically*, by type, with zero `columnGenLookup` entry (see
+// `HasGen.registerType` below). `Title.values.map(_.toString)` ("Mr", "Ms", "Dr") must match
+// this pattern, since sampled values are substituted into step text via `toString`.
+val title: TypedExtractor[Title] = TypedExtractor.make[Title]("(Mr|Ms|Dr)") { (_, groups, idx) =>
+  groups
+    .lift(idx)
+    .flatMap(s => Title.values.find(_.toString == s))
+    .map(t => (t, idx + 1))
+    .toRight(s"Expected one of Mr|Ms|Dr at group $idx")
+}
+
 @Suite(
   featureDirs = Array("example/src/test/resources/features"),
-  reporters   = Array("pretty", "junitxml"),
+  reporters = Array("pretty", "junitxml"),
   parallelism = 1,
   includeTags = Array("positive"),
-  logLevel    = "info"
+  logLevel = "info"
 )
 object SimpleSpec extends ZIOSteps[GreetingService, ScenarioContext]:
 
@@ -45,6 +57,13 @@ object SimpleSpec extends ZIOSteps[GreetingService, ScenarioContext]:
   given HasGen[Title] with
     def gen            = Gen.elements(Title.Mr, Title.Ms, Title.Dr)
     override def label = "HasGen[Title]"
+
+  // One-time registration so `@property` can find HasGen[Title] *by type* — required
+  // because Scala can't enumerate arbitrary `given HasGen[_]` instances at runtime (see
+  // HasGen.registerType's doc comment). After this call, every column whose step extractor
+  // produces a Title (like `title` above) resolves its generator automatically: no
+  // `columnGenLookup` entry needed, unlike the `name` column below.
+  HasGen.registerType(HasGen[Title])
 
   // ── Functional BDD steps (simple.feature) ────────────────────────────────
 
@@ -113,8 +132,8 @@ object SimpleSpec extends ZIOSteps[GreetingService, ScenarioContext]:
     }
   }
 
-  Given("a title " / string) { (title: String) =>
-    ScenarioContext.update(_.copy(title = title))
+  Given("a title " / title) { (t: Title) =>
+    ScenarioContext.update(_.copy(title = t.toString))
   }
 
   Then("the title is a known honorific") {
@@ -124,21 +143,38 @@ object SimpleSpec extends ZIOSteps[GreetingService, ScenarioContext]:
     }
   }
 
+  // Built-in-type demo: `age` is governed by the stock `int` extractor, so its generator
+  // is the pre-registered `HasGen[Int]` (= `Gen.int`, the full Int range) — no `given
+  // HasGen[Int]`, no `registerType` call, no `columnGenLookup` entry. Every built-in type
+  // (Int/Long/Double/Boolean/String/UUID) works this way out of the box.
+  And("the user's age is " / int) { (age: Int) =>
+    ScenarioContext.update(_.copy(age = age))
+  }
+
+  // Deliberately tautological (true for *every* Int, including Int.MinValue/MaxValue): the
+  // point of this step is to prove the sampled value reached the scenario via automatic
+  // resolution, not to assert domain behaviour — `age` isn't used anywhere else.
+  Then("the age is recorded") {
+    ScenarioContext.get.flatMap { ctx =>
+      assertTrue(ctx.age >= Int.MinValue && ctx.age <= Int.MaxValue, s"Expected an Int, got ${ctx.age}")
+    }
+  }
+
   // ── Column generator lookup ────────────────────────────────────────────
-  // columnGenLookup is the *override* path, not mandatory wiring — both columns below
-  // are governed by a `string` extractor (Given("a user named " / string), Given("a
-  // title " / string)), so they'd resolve automatically to the built-in HasGen[String]
-  // (unconstrained alphanumeric text) with no entry here at all. Both are overridden
-  // anyway because the automatic choice isn't the generator we actually want:
-  //   - "name"  → a *named* override (HasGen.named("name")(...) above) for readable
-  //     capitalised names instead of alphanumeric gibberish.
-  //   - "title" → a *domain-type* generator (`given HasGen[Title]` above) so it only
-  //     ever generates one of the three known honorifics, not arbitrary text.
+  // columnGenLookup is the *override* path, not mandatory wiring. Of the three columns
+  // exercised in greeting_properties.feature's "regardless of title or age" scenario:
+  //   - "title" (Title, a domain type) and "age" (Int, a built-in type) both resolve with
+  //     zero entries here — automatically, by the Tag their step extractor produces (see
+  //     `title`'s extractor and `HasGen.registerType(HasGen[Title])` above; built-ins are
+  //     pre-registered in HasGen itself).
+  //   - "name" is the one column actually using this override: it's governed by `string`,
+  //     so it would *also* resolve automatically (to unconstrained alphanumeric text) —
+  //     this entry exists purely to swap in the more readable named generator from
+  //     `HasGen.named("name")(...)` above instead of accepting that default.
   override def columnGenLookup: ColumnGenLookup = new ColumnGenLookup:
     def byColumn(col: String): Option[HasGen[?]] = col match
-      case "name"  => HasGen.resolve("name")
-      case "title" => Some(HasGen[Title])
-      case _       => None
+      case "name" => HasGen.resolve("name")
+      case _      => None
 
   // ── ZLayer ────────────────────────────────────────────────────────────────
 

--- a/gherkin/src/main/scala/zio/bdd/gherkin/GherkinParser.scala
+++ b/gherkin/src/main/scala/zio/bdd/gherkin/GherkinParser.scala
@@ -40,6 +40,67 @@ object ScenarioMetadata {
  * `@flags(a=true) @flags(a=false)` → two runs, one with a=true, one with
  * a=false
  */
+/**
+ * Parses `@property(samples=N, seed=S, shrink=true, ...)` tags from Gherkin
+ * Examples blocks.
+ *
+ * When an Examples block carries an `@property(...)` tag and has no data rows
+ * (header-only), the test framework runs the scenario as a property test —
+ * sampling generated values for each column via the `HasGen[T]` registry
+ * instead of executing literal rows.
+ *
+ * Supported args:
+ *   - `samples` — number of samples (default 100)
+ *   - `seed` — fixed Long seed for reproducibility (default: random, always
+ *     logged)
+ *   - `shrink` — enable shrinking on failure (default true)
+ *   - `maxShrinks` — cap on shrink-tree walks (default 1000)
+ *   - `maxDiscarded` — cap on discarded samples (default samples × 5)
+ *   - `verbose` — print full shrink trace in failure output (default false)
+ *   - `replay` — consult/update the failures file (default true)
+ *
+ * A bare `@property` with no args is equivalent to `@property(samples=100)`.
+ */
+object PropertyTag:
+  private val tagPattern = """^property(?:\(([^)]*)\))?$""".r
+
+  case class PropertyConfig(
+    samples: Int = 100,
+    seed: Option[Long] = None,
+    shrink: Boolean = true,
+    maxShrinks: Int = 1000,
+    maxDiscarded: Option[Int] = None,
+    verbose: Boolean = false,
+    replay: Boolean = true
+  )
+
+  def parse(tag: String): Option[PropertyConfig] =
+    tagPattern.findFirstMatchIn(tag.trim.stripPrefix("@")).map { m =>
+      val args = Option(m.group(1)).getOrElse("")
+      val kv = args
+        .split(",")
+        .flatMap { kv =>
+          kv.trim.split("=", 2) match
+            case Array(k, v) if k.trim.nonEmpty => Some(k.trim.toLowerCase -> v.trim)
+            case Array(k) if k.trim.nonEmpty    => Some(k.trim.toLowerCase -> "true")
+            case _                              => None
+        }
+        .toMap
+      PropertyConfig(
+        samples = kv.get("samples").flatMap(_.toIntOption).getOrElse(100),
+        seed = kv.get("seed").flatMap(_.toLongOption),
+        shrink = kv.get("shrink").map(_ != "false").getOrElse(true),
+        maxShrinks = kv.get("maxshrinks").flatMap(_.toIntOption).getOrElse(1000),
+        maxDiscarded = kv.get("maxdiscarded").flatMap(_.toIntOption),
+        verbose = kv.get("verbose").map(_ == "true").getOrElse(false),
+        replay = kv.get("replay").map(_ != "false").getOrElse(true)
+      )
+    }
+
+  /** Extract the first @property config from a list of tags, if any. */
+  def extract(tags: List[String]): Option[PropertyConfig] =
+    tags.iterator.flatMap(parse).nextOption()
+
 object FlagsTag:
   private val tagPattern = """^flags\(([^)]+)\)$""".r
 
@@ -88,7 +149,11 @@ case class Scenario(
   tags: List[String] = Nil,
   steps: List[Step],
   file: Option[String] = None,
-  line: Option[Int] = None
+  line: Option[Int] = None,
+  // Non-None when this scenario was produced from a @property Examples block.
+  // Contains the parsed config and per-column generator overrides.
+  propertyConfig: Option[PropertyTag.PropertyConfig] = None,
+  columnGens: Map[String, String] = Map.empty
 ) {
   def id: Int            = s"scenario:$name:${file.getOrElse("unknown")}:${line.getOrElse(0)}".hashCode
   def isIgnored: Boolean = tags.exists(_.equalsIgnoreCase("ignore"))
@@ -456,7 +521,10 @@ object GherkinParser {
     tags: List[String],
     headers: List[String],
     rows: List[List[String]],
-    lineNo: Int
+    lineNo: Int,
+    // Per-column named generator overrides, e.g. `| amount: smallAmounts |`
+    // Absent for all non-property (literal) Examples blocks.
+    columnGens: Map[String, String] = Map.empty
   )
 
   private case class RawScenario(
@@ -585,12 +653,26 @@ object GherkinParser {
           case Some(TableRowLine(_, _)) => parseDataTable(cursor, file)
           case _                        => DataTable(Nil, Nil)
         }
+        val combinedTags = (prePendedTags ++ lineTags).distinct
+        // Split header cells on the first ':' to separate placeholder key from
+        // optional named-generator override, e.g. `| amount: smallAmounts |`.
+        // Plain cells with no ':' are unchanged.
+        val (plainHeaders, columnGens) = table.headers.foldLeft((List.empty[String], Map.empty[String, String])) {
+          case ((hs, gs), cell) =>
+            cell.split(":", 2) match
+              case Array(key, gen) =>
+                val k = key.trim
+                val g = gen.trim
+                (hs :+ k, if (g.nonEmpty) gs + (k -> g) else gs)
+              case _ => (hs :+ cell.trim, gs)
+        }
         RawExamplesBlock(
           name = name,
-          tags = (prePendedTags ++ lineTags).distinct,
-          headers = table.headers,
+          tags = combinedTags,
+          headers = plainHeaders,
           rows = table.rows.map(_.cells),
-          lineNo = lineNo
+          lineNo = lineNo,
+          columnGens = columnGens
         )
       case other =>
         throw ParseError(s"Expected Examples/Scenarios keyword, got: $other", 0, file)
@@ -684,22 +766,41 @@ object GherkinParser {
         val combinedTags = (rawSc.tags ++ block.tags).distinct
         val baseLabel    = if (block.name.nonEmpty) s"${rawSc.name} - ${block.name}" else rawSc.name
 
-        if (block.headers.isEmpty || block.rows.isEmpty) {
-          // Outline with no example rows — emit once as a placeholder with no param substitution
-          List(Scenario(s"$baseLabel - (no examples)", combinedTags, allSteps, Some(file), Some(rawSc.lineNo)))
-        } else {
-          block.rows.zipWithIndex.map { case (rowValues, i) =>
-            val data       = block.headers.zip(rowValues).toMap
-            val paramBg    = backgroundSteps.map(expandStep(_, data, file))
-            val paramSteps = rawSc.steps.map(expandStep(_, data, file))
-            Scenario(
-              name = s"$baseLabel - Example ${i + 1}",
-              tags = combinedTags,
-              steps = paramBg.collect { case Right(s) => s } ++ paramSteps.collect { case Right(s) => s },
-              file = Some(file),
-              line = Some(rawSc.lineNo)
+        // @property block: header-only (no rows) → one property scenario carrying config + column gens.
+        // Check combinedTags (scenario + block) so @property on either the Scenario Outline line
+        // OR the Examples block line both trigger property mode.
+        // If rows are also present on a @property block, treat as literal (user error; still run them).
+        PropertyTag.extract(combinedTags) match {
+          case Some(config) if block.rows.isEmpty =>
+            List(
+              Scenario(
+                name = baseLabel,
+                tags = combinedTags,
+                steps = allSteps,
+                file = Some(file),
+                line = Some(rawSc.lineNo),
+                propertyConfig = Some(config),
+                columnGens = block.columnGens
+              )
             )
-          }
+          case _ =>
+            if (block.headers.isEmpty || block.rows.isEmpty) {
+              // Outline with no example rows — emit once as a placeholder with no param substitution
+              List(Scenario(s"$baseLabel - (no examples)", combinedTags, allSteps, Some(file), Some(rawSc.lineNo)))
+            } else {
+              block.rows.zipWithIndex.map { case (rowValues, i) =>
+                val data       = block.headers.zip(rowValues).toMap
+                val paramBg    = backgroundSteps.map(expandStep(_, data, file))
+                val paramSteps = rawSc.steps.map(expandStep(_, data, file))
+                Scenario(
+                  name = s"$baseLabel - Example ${i + 1}",
+                  tags = combinedTags,
+                  steps = paramBg.collect { case Right(s) => s } ++ paramSteps.collect { case Right(s) => s },
+                  file = Some(file),
+                  line = Some(rawSc.lineNo)
+                )
+              }
+            }
         }
       }
     }

--- a/gherkin/src/main/scala/zio/bdd/gherkin/GherkinParser.scala
+++ b/gherkin/src/main/scala/zio/bdd/gherkin/GherkinParser.scala
@@ -87,7 +87,10 @@ object PropertyTag:
         }
         .toMap
       PropertyConfig(
-        samples = kv.get("samples").flatMap(_.toIntOption).getOrElse(100),
+        // A non-positive count would silently produce a trivially-"passing" property scenario
+        // (zero samples actually run), so it's treated the same as missing/unparseable and
+        // falls back to the default rather than being honored literally.
+        samples = kv.get("samples").flatMap(_.toIntOption).filter(_ > 0).getOrElse(100),
         seed = kv.get("seed").flatMap(_.toLongOption),
         shrink = kv.get("shrink").map(_ != "false").getOrElse(true),
         maxShrinks = kv.get("maxshrinks").flatMap(_.toIntOption).getOrElse(1000),
@@ -153,9 +156,16 @@ case class Scenario(
   // Non-None when this scenario was produced from a @property Examples block.
   // Contains the parsed config and per-column generator overrides.
   propertyConfig: Option[PropertyTag.PropertyConfig] = None,
-  columnGens: Map[String, String] = Map.empty
+  columnGens: Map[String, String] = Map.empty,
+  // Set by PropertyExecutor when it renames a scenario to display the sample count/seed
+  // (e.g. "... [500 samples passed, seed=42]") after execution. `id` is keyed on `name`, so
+  // without this the renamed copy would get a different `id` than the one logs were
+  // collected under during the run (annotated before the rename happened), and reporters
+  // would silently fail to find them. `None` for every scenario that isn't a renamed
+  // property-scenario result, in which case `id` is computed from `name` as before.
+  stableId: Option[Int] = None
 ) {
-  def id: Int            = s"scenario:$name:${file.getOrElse("unknown")}:${line.getOrElse(0)}".hashCode
+  def id: Int            = stableId.getOrElse(s"scenario:$name:${file.getOrElse("unknown")}:${line.getOrElse(0)}".hashCode)
   def isIgnored: Boolean = tags.exists(_.equalsIgnoreCase("ignore"))
 
   def prettyString(indentLevel: Int): String = {

--- a/gherkin/src/test/scala/zio/bdd/gherkin/PropertyTagParserSpec.scala
+++ b/gherkin/src/test/scala/zio/bdd/gherkin/PropertyTagParserSpec.scala
@@ -1,0 +1,313 @@
+package zio.bdd.gherkin
+
+import zio.*
+import zio.test.*
+import zio.test.Assertion.*
+
+/**
+ * Tests for Mode P (property testing) syntax support in the Gherkin parser.
+ *
+ * Covers:
+ *   - \@property tag parsing (bare, full args, various combinations)
+ *   - \@property on Examples block produces Scenario.propertyConfig
+ *   - header cell `:genName` annotation parsed into Scenario.columnGens
+ *   - existing literal Examples behaviour is completely unchanged
+ *   - mixed literal + property blocks in one Scenario Outline
+ *   - \@property block with rows present falls back to literal expansion (user
+ *     error guard)
+ */
+object PropertyTagParserSpec extends ZIOSpecDefault {
+
+  private def parse(content: String) =
+    GherkinParser.parseFeature(content, "test.feature")
+
+  def spec: Spec[TestEnvironment & Scope, Any] = suite("PropertyTagParserSpec")(
+    propertyTagSuite,
+    parserIntegrationSuite,
+    regressionSuite
+  )
+
+  // ── PropertyTag.parse ──────────────────────────────────────────────────────
+
+  private val propertyTagSuite = suite("PropertyTag.parse")(
+    test("bare @property defaults to samples=100, seed=None, shrink=true") {
+      val cfg = PropertyTag.parse("property")
+      assertTrue(
+        cfg.isDefined,
+        cfg.get.samples == 100,
+        cfg.get.seed.isEmpty,
+        cfg.get.shrink == true,
+        cfg.get.verbose == false,
+        cfg.get.replay == true
+      )
+    },
+    test("@property with args parses all fields") {
+      val cfg = PropertyTag.parse("property(samples=50, seed=12345, shrink=false, verbose=true, replay=false)")
+      assertTrue(
+        cfg.isDefined,
+        cfg.get.samples == 50,
+        cfg.get.seed.contains(12345L),
+        cfg.get.shrink == false,
+        cfg.get.verbose == true,
+        cfg.get.replay == false
+      )
+    },
+    test("@property with @ prefix is parsed (tag stored without @)") {
+      val cfg = PropertyTag.parse("@property(samples=25)")
+      assertTrue(cfg.isDefined, cfg.get.samples == 25)
+    },
+    test("@property ignores unknown keys gracefully") {
+      val cfg = PropertyTag.parse("property(samples=10, unknownKey=foo)")
+      assertTrue(cfg.isDefined, cfg.get.samples == 10)
+    },
+    test("non-property tags return None") {
+      assertTrue(
+        PropertyTag.parse("smoke").isEmpty,
+        PropertyTag.parse("flags(a=b)").isEmpty,
+        PropertyTag.parse("ignore").isEmpty
+      )
+    },
+    test("PropertyTag.extract returns first match from a list of tags") {
+      val tags = List("smoke", "property(samples=99)", "regression")
+      val cfg  = PropertyTag.extract(tags)
+      assertTrue(cfg.isDefined, cfg.get.samples == 99)
+    },
+    test("PropertyTag.extract returns None when no @property tag present") {
+      val tags = List("smoke", "regression", "flags(a=b)")
+      assertTrue(PropertyTag.extract(tags).isEmpty)
+    }
+  )
+
+  // ── Parser integration ─────────────────────────────────────────────────────
+
+  private val parserIntegrationSuite = suite("GherkinParser + @property Examples")(
+    test("@property Examples block with header-only produces one scenario with propertyConfig") {
+      parse(
+        """Feature: Account invariants
+          |  Scenario Outline: balance never goes negative
+          |    Given an account with balance <amount>
+          |    Then the balance is not negative
+          |
+          |    @property(samples=50, seed=1)
+          |    Examples:
+          |      | amount |
+          |""".stripMargin
+      ).map { feature =>
+        val scenarios = feature.scenarios
+        assertTrue(
+          scenarios.length == 1,
+          scenarios.head.propertyConfig.isDefined,
+          scenarios.head.propertyConfig.get.samples == 50,
+          scenarios.head.propertyConfig.get.seed.contains(1L),
+          scenarios.head.columnGens.isEmpty // no overrides in this block
+        )
+      }
+    },
+    test("@property Examples block: column with :genName produces columnGens map") {
+      parse(
+        """Feature: Column overrides
+          |  Scenario Outline: test
+          |    Given account balance <amount>
+          |    When limit is <limit>
+          |    Then it works
+          |
+          |    @property(samples=10)
+          |    Examples:
+          |      | amount: smallAmounts | limit |
+          |""".stripMargin
+      ).map { feature =>
+        val sc = feature.scenarios.head
+        assertTrue(
+          sc.propertyConfig.isDefined,
+          sc.columnGens.get("amount").contains("smallAmounts"),
+          !sc.columnGens.contains("limit") // plain column, no override
+        )
+      }
+    },
+    test("literal Examples block is NOT affected by @property on a sibling block") {
+      parse(
+        """Feature: Mixed
+          |  Scenario Outline: dual blocks
+          |    Given value is <val>
+          |    Then step passes
+          |
+          |    @regression
+          |    Examples:
+          |      | val |
+          |      | a   |
+          |      | b   |
+          |
+          |    @property(samples=20)
+          |    Examples:
+          |      | val |
+          |""".stripMargin
+      ).map { feature =>
+        val scenarios = feature.scenarios
+        // 2 literal scenarios from @regression block + 1 property scenario
+        val literal  = scenarios.filter(_.propertyConfig.isEmpty)
+        val property = scenarios.filter(_.propertyConfig.isDefined)
+        assertTrue(
+          literal.length == 2,
+          property.length == 1,
+          property.head.propertyConfig.get.samples == 20
+        )
+      }
+    },
+    test("@property block that also has data rows falls back to literal expansion") {
+      // User error: a @property block should not have rows. We fall back to literal to avoid silent data loss.
+      parse(
+        """Feature: Property with rows
+          |  Scenario Outline: fallback
+          |    Given value is <val>
+          |    Then step passes
+          |
+          |    @property(samples=5)
+          |    Examples:
+          |      | val |
+          |      | 42  |
+          |""".stripMargin
+      ).map { feature =>
+        val scenarios = feature.scenarios
+        // One literal scenario (row expansion), NOT a property scenario
+        assertTrue(
+          scenarios.length == 1,
+          scenarios.head.propertyConfig.isEmpty
+        )
+      }
+    },
+    test("scenario without Examples block is not treated as property") {
+      parse(
+        """Feature: Normal scenario
+          |  Scenario: simple
+          |    Given a step
+          |    Then another step
+          |""".stripMargin
+      ).map { feature =>
+        val sc = feature.scenarios.head
+        assertTrue(sc.propertyConfig.isEmpty, sc.columnGens.isEmpty)
+      }
+    },
+    test("multiple column overrides all parsed") {
+      parse(
+        """Feature: Multi overrides
+          |  Scenario Outline: test
+          |    Given balance <a> and limit <b> and amount <c>
+          |    Then ok
+          |
+          |    @property(samples=5)
+          |    Examples:
+          |      | a: genA | b: genB | c |
+          |""".stripMargin
+      ).map { feature =>
+        val sc = feature.scenarios.head
+        assertTrue(
+          sc.columnGens.get("a").contains("genA"),
+          sc.columnGens.get("b").contains("genB"),
+          !sc.columnGens.contains("c")
+        )
+      }
+    }
+  )
+
+  // ── Regression — existing Examples logic unchanged ─────────────────────────
+
+  private val regressionSuite = suite("Existing Examples/Outline behaviour unchanged")(
+    test("single Examples block with rows still produces N expanded scenarios") {
+      parse(
+        """Feature: Outline
+          |  Scenario Outline: multi row
+          |    Given value is <val>
+          |    Then step passes
+          |  Examples:
+          |    | val |
+          |    | x   |
+          |    | y   |
+          |    | z   |
+          |""".stripMargin
+      ).map { feature =>
+        assertTrue(feature.scenarios.length == 3, feature.scenarios.forall(_.propertyConfig.isEmpty))
+      }
+    },
+    test("multiple Examples blocks each expand independently") {
+      parse(
+        """Feature: Multi blocks
+          |  Scenario Outline: outline
+          |    Given val <v>
+          |    Then ok
+          |  Examples: A
+          |    | v |
+          |    | 1 |
+          |    | 2 |
+          |  Examples: B
+          |    | v |
+          |    | 3 |
+          |""".stripMargin
+      ).map { feature =>
+        assertTrue(
+          feature.scenarios.length == 3,
+          feature.scenarios.forall(_.propertyConfig.isEmpty)
+        )
+      }
+    },
+    test("plain column header with colon inside value is NOT misinterpreted as gen override") {
+      // e.g. a header like "time:hh:mm" — split on first ':' only gives ("time", "hh:mm")
+      // which is a valid gen name. Verify no crash; the gen won't be registered so
+      // the value should just be taken as a column name when there's no @property tag.
+      parse(
+        """Feature: Colon in header
+          |  Scenario Outline: test
+          |    Given time is <time:hh:mm>
+          |    Then ok
+          |  Examples:
+          |    | time:hh:mm |
+          |    | 10:30      |
+          |""".stripMargin
+      ).map { feature =>
+        // Without @property the block is literal; columnGens irrelevant; scenario should parse
+        assertTrue(feature.scenarios.length == 1, feature.scenarios.head.propertyConfig.isEmpty)
+      }
+    },
+    test("@property tag on Scenario (not Examples) is NOT treated as property scenario when block has rows") {
+      // Rows present → falls through to literal expansion regardless of where @property lives.
+      parse(
+        """Feature: Tag on scenario
+          |  @property(samples=5)
+          |  Scenario Outline: outline
+          |    Given value is <val>
+          |    Then ok
+          |  Examples:
+          |    | val |
+          |    | 1   |
+          |""".stripMargin
+      ).map { feature =>
+        // @property on scenario + rows in block → literal expansion (rows win)
+        val sc = feature.scenarios.head
+        assertTrue(
+          sc.propertyConfig.isEmpty,               // rows guard prevents property mode
+          sc.tags.exists(_.startsWith("property")) // tag still retained
+        )
+      }
+    },
+    test("@property tag on Scenario Outline with header-only Examples triggers property mode") {
+      // This is the pattern used in example/greeting_properties.feature —
+      // @property sits on the Scenario Outline and the Examples block is header-only.
+      parse(
+        """Feature: Tag on scenario outline
+          |  @property(samples=10, seed=1)
+          |  Scenario Outline: outline
+          |    Given a user named <name>
+          |    Then ok
+          |  Examples:
+          |    | name |
+          |""".stripMargin
+      ).map { feature =>
+        val sc = feature.scenarios.head
+        assertTrue(
+          sc.propertyConfig.isDefined,
+          sc.propertyConfig.get.samples == 10,
+          sc.propertyConfig.get.seed.contains(1L)
+        )
+      }
+    }
+  )
+}

--- a/gherkin/src/test/scala/zio/bdd/gherkin/PropertyTagParserSpec.scala
+++ b/gherkin/src/test/scala/zio/bdd/gherkin/PropertyTagParserSpec.scala
@@ -24,7 +24,8 @@ object PropertyTagParserSpec extends ZIOSpecDefault {
   def spec: Spec[TestEnvironment & Scope, Any] = suite("PropertyTagParserSpec")(
     propertyTagSuite,
     parserIntegrationSuite,
-    regressionSuite
+    regressionSuite,
+    stableIdSuite
   )
 
   // ── PropertyTag.parse ──────────────────────────────────────────────────────
@@ -59,6 +60,11 @@ object PropertyTagParserSpec extends ZIOSpecDefault {
     test("@property ignores unknown keys gracefully") {
       val cfg = PropertyTag.parse("property(samples=10, unknownKey=foo)")
       assertTrue(cfg.isDefined, cfg.get.samples == 10)
+    },
+    test("@property(samples=0) and negative samples fall back to the default rather than running zero samples") {
+      val zero     = PropertyTag.parse("property(samples=0)")
+      val negative = PropertyTag.parse("property(samples=-5)")
+      assertTrue(zero.isDefined, zero.get.samples == 100, negative.isDefined, negative.get.samples == 100)
     },
     test("non-property tags return None") {
       assertTrue(
@@ -356,6 +362,24 @@ object PropertyTagParserSpec extends ZIOSpecDefault {
           sc.propertyConfig.get.seed.contains(1L)
         )
       }
+    }
+  )
+
+  // ── Scenario.id / stableId ───────────────────────────────────────────────────
+
+  private val stableIdSuite = suite("Scenario.id / stableId")(
+    test("id is derived from name/file/line when stableId is unset") {
+      val sc = Scenario(name = "a", steps = Nil, file = Some("f.feature"), line = Some(3))
+      assertTrue(sc.id == s"scenario:a:f.feature:3".hashCode)
+    },
+    test("renaming a scenario changes its id, unless stableId pins the original") {
+      val original          = Scenario(name = "a", steps = Nil, file = Some("f.feature"), line = Some(3))
+      val renamedWithoutPin = original.copy(name = "a [5 samples passed]")
+      val renamedWithPin    = original.copy(name = "a [5 samples passed]", stableId = Some(original.id))
+      assertTrue(
+        renamedWithoutPin.id != original.id, // the bug PropertyExecutor's stableId works around
+        renamedWithPin.id == original.id
+      )
     }
   )
 }

--- a/gherkin/src/test/scala/zio/bdd/gherkin/PropertyTagParserSpec.scala
+++ b/gherkin/src/test/scala/zio/bdd/gherkin/PropertyTagParserSpec.scala
@@ -124,6 +124,54 @@ object PropertyTagParserSpec extends ZIOSpecDefault {
         )
       }
     },
+    test("@property on the Scenario Outline line (not the Examples block) is also detected") {
+      parse(
+        """Feature: Tag placement
+          |  @property(samples=30, seed=7)
+          |  Scenario Outline: tagged on outline line
+          |    Given account balance <amount>
+          |    Then it works
+          |
+          |    Examples:
+          |      | amount |
+          |""".stripMargin
+      ).map { feature =>
+        val sc = feature.scenarios.head
+        assertTrue(
+          feature.scenarios.length == 1,
+          sc.propertyConfig.isDefined,
+          sc.propertyConfig.get.samples == 30,
+          sc.propertyConfig.get.seed.contains(7L)
+        )
+      }
+    },
+    test("@property on the Scenario Outline line and on the Examples block both detect identically") {
+      def cfgFor(content: String) = parse(content).map(_.scenarios.head.propertyConfig)
+      val onOutline =
+        """Feature: F
+          |  @property(samples=15)
+          |  Scenario Outline: x
+          |    Given v <n>
+          |    Then ok
+          |
+          |    Examples:
+          |      | n |
+          |""".stripMargin
+      val onBlock =
+        """Feature: F
+          |  Scenario Outline: x
+          |    Given v <n>
+          |    Then ok
+          |
+          |    @property(samples=15)
+          |    Examples:
+          |      | n |
+          |""".stripMargin
+      for {
+        c1 <- cfgFor(onOutline)
+        c2 <- cfgFor(onBlock)
+      } yield assertTrue(c1.isDefined, c2.isDefined, c1.get.samples == c2.get.samples)
+    },
     test("literal Examples block is NOT affected by @property on a sibling block") {
       parse(
         """Feature: Mixed


### PR DESCRIPTION
## Summary

Implements #91 — a new property-based testing mode driven entirely through Gherkin's existing `Examples:` syntax, no new keywords.

- `@property(samples=N, seed=S, shrink=true, maxShrinks=…, maxDiscarded=…, verbose=…, replay=…)` on a header-only `Examples:` block (or its `Scenario Outline:` line) runs the scenario against N generated samples instead of literal rows.
- `HasGen[T]` typeclass resolves a `zio.test.Gen` per column, with built-ins for `Int`/`Long`/`Double`/`Boolean`/`String`/`UUID`. Named overrides via `HasGen.named(name)(gen)` + the `| column: generatorName |` header syntax, and `ZIOSteps#columnGenLookup` for suite-level column routing.
- Falsifying samples are persisted to `.zio-bdd/failures/` and replayed first on the next run for fast reproduction.
- `pretty` and `junitxml` reporters both render the counterexample without dumping internal zio-bdd/ZIO stack frames.

**v1 scope note:** sampling + seed-based replay only — full shrink-tree walking is deferred to v2 (per `PropertyExecutor`'s own doc comment).

Bundled alongside (called out separately since not strictly in scope for #91, but shipped together intentionally):
- `PrettyReporter` color-palette refresh (new accessibility-tuned hues, renamed `Color` cases with back-compat aliases) plus generic stack-frame filtering for all failures, not just property ones.
- `JUnitXMLFormatter` failure rendering rewritten to `cause.squash` + filtered user-stack-frames for all failures.
- `LogCollector`: the runtime logger is now replaced (not augmented) during step execution, so `ZIO.log*` calls aren't double-printed to stdout.

New `example/src/test/resources/features/greeting_properties.feature` + `SimpleSpec` updates demonstrate the feature end-to-end, including a scenario that intentionally falsifies its invariant (tagged `@negative` so it's excluded from the default `@positive`-filtered run) to show counterexample reporting — run it explicitly with `--include-tags negative`.

## Test plan

- [x] `sbt compile` / `sbt Test/compile` / `sbt example/Test/compile` — all modules compile clean
- [x] `sbt scalafmtCheckAll` — passes
- [x] `sbt test` — gherkin: 136 passed, core: 443 passed, 0 failed (includes new `PropertyTagParserSpec`, `PropertyExecutorSpec`)
- [x] `sbt example/test` — 3 passed, 3 ignored (default `@positive`/`@core` filter), 0 failed
- [x] Manually ran the example with `--include-tags negative` to confirm the intentionally-broken property scenario renders a counterexample table in the `pretty` reporter as expected