### PR TITLE
Add runtime Tag[A] to TypedExtractor[A] (#96)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import xerial.sbt.Sonatype.sonatypeCentralHost
 import StepGeneratorPlugin.autoImport.*
+import com.typesafe.tools.mima.core.*
 
 inThisBuild(
   List(
@@ -45,7 +46,17 @@ lazy val mimaSettings = Seq(
     // contain a '-'), so the 1.0.0 release itself is not checked against 0.1.0 or 1.0.0-RCx.
     .filter(v => v.startsWith("1.") && !v.contains("-"))
     .map(organization.value %% moduleName.value % _)
-    .toSet
+    .toSet,
+  // #96 added a `Tag[A]` member to `TypedExtractor[A]` (a prerequisite for type-based
+  // HasGen discovery in property testing, #99) so `table`/`tableWithMapping` gained a
+  // `Tag[T]` context bound and `TableExtractor` gained a `Tag[List[T]]` constructor param.
+  // Source-compatible, not binary-compatible against 1.0.0.
+  mimaBinaryIssueFilters ++= Seq(
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.step.DefaultTypedExtractor.table"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.step.DefaultTypedExtractor.tableWithMapping"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.step.TableExtractor.this"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("zio.bdd.core.step.TypedExtractor.tag")
+  )
 )
 
 lazy val root = (project in file("."))

--- a/core/src/main/scala/zio/bdd/core/step/TypedExtractors.scala
+++ b/core/src/main/scala/zio/bdd/core/step/TypedExtractors.scala
@@ -1,5 +1,6 @@
 package zio.bdd.core.step
 
+import izumi.reflect.Tag
 import zio.schema.{DynamicValue, Schema, StandardType}
 
 import java.math.{BigDecimal => JBigDecimal}
@@ -8,6 +9,24 @@ import java.util.UUID
 trait TypedExtractor[A] {
   def extract(input: StepInput, groups: List[String], groupIndex: Int): Either[String, (A, Int)]
   def pattern: String
+  def tag: Tag[A]
+}
+
+object TypedExtractor {
+
+  /**
+   * Smart constructor: builds a `TypedExtractor[A]` and supplies its `tag`
+   * automatically from a context bound, so custom extractor authors don't have
+   * to write `def tag: Tag[A] = Tag[A]` by hand.
+   */
+  def make[A: Tag](pat: String)(
+    extractFn: (StepInput, List[String], Int) => Either[String, (A, Int)]
+  ): TypedExtractor[A] = new TypedExtractor[A] {
+    def extract(input: StepInput, groups: List[String], groupIndex: Int): Either[String, (A, Int)] =
+      extractFn(input, groups, groupIndex)
+    def pattern: String = pat
+    def tag: Tag[A]     = summon[Tag[A]]
+  }
 }
 
 trait DefaultTypedExtractor {
@@ -16,81 +35,67 @@ trait DefaultTypedExtractor {
    * Matches any text, optionally double-quoted. Quotes are stripped from the
    * captured value.
    */
-  val string: TypedExtractor[String] = new TypedExtractor[String] {
-    def extract(input: StepInput, groups: List[String], groupIndex: Int): Either[String, (String, Int)] =
-      groups
-        .lift(groupIndex)
-        .map { s =>
-          val trimmed = s.trim
-          val unquoted =
-            if (trimmed.startsWith("\"") && trimmed.endsWith("\""))
-              trimmed.substring(1, trimmed.length - 1)
-            else trimmed
-          (unquoted, groupIndex + 1)
-        }
-        .toRight(s"Expected string at group $groupIndex")
-
-    def pattern: String = "(\".*\"|.*)"
+  val string: TypedExtractor[String] = TypedExtractor.make[String]("(\".*\"|.*)") { (_, groups, groupIndex) =>
+    groups
+      .lift(groupIndex)
+      .map { s =>
+        val trimmed = s.trim
+        val unquoted =
+          if (trimmed.startsWith("\"") && trimmed.endsWith("\""))
+            trimmed.substring(1, trimmed.length - 1)
+          else trimmed
+        (unquoted, groupIndex + 1)
+      }
+      .toRight(s"Expected string at group $groupIndex")
   }
 
   /** Matches a single word (no whitespace). */
-  val word: TypedExtractor[String] = new TypedExtractor[String] {
-    def extract(input: StepInput, groups: List[String], groupIndex: Int): Either[String, (String, Int)] =
-      groups
-        .lift(groupIndex)
-        .map(s => (s.trim, groupIndex + 1))
-        .toRight(s"Expected word at group $groupIndex")
-
-    def pattern: String = "(\\S+)"
+  val word: TypedExtractor[String] = TypedExtractor.make[String]("(\\S+)") { (_, groups, groupIndex) =>
+    groups
+      .lift(groupIndex)
+      .map(s => (s.trim, groupIndex + 1))
+      .toRight(s"Expected word at group $groupIndex")
   }
 
   /** Matches the entire remainder of the step text (greedy). */
-  val rest: TypedExtractor[String] = new TypedExtractor[String] {
-    def extract(input: StepInput, groups: List[String], groupIndex: Int): Either[String, (String, Int)] =
-      groups
-        .lift(groupIndex)
-        .map(s => (s, groupIndex + 1))
-        .toRight(s"Expected rest-of-line at group $groupIndex")
-
-    def pattern: String = "(.+)"
+  val rest: TypedExtractor[String] = TypedExtractor.make[String]("(.+)") { (_, groups, groupIndex) =>
+    groups
+      .lift(groupIndex)
+      .map(s => (s, groupIndex + 1))
+      .toRight(s"Expected rest-of-line at group $groupIndex")
   }
 
   /** Matches non-negative integers. */
-  val int: TypedExtractor[Int] = new TypedExtractor[Int] {
-    def extract(input: StepInput, groups: List[String], groupIndex: Int): Either[String, (Int, Int)] =
-      groups
-        .lift(groupIndex)
-        .flatMap(s => scala.util.Try(s.toInt).toOption)
-        .map(i => (i, groupIndex + 1))
-        .toRight(s"Expected int at group $groupIndex")
-    def pattern: String = "(-?\\d+)"
+  val int: TypedExtractor[Int] = TypedExtractor.make[Int]("(-?\\d+)") { (_, groups, groupIndex) =>
+    groups
+      .lift(groupIndex)
+      .flatMap(s => scala.util.Try(s.toInt).toOption)
+      .map(i => (i, groupIndex + 1))
+      .toRight(s"Expected int at group $groupIndex")
   }
 
   /** Matches integer and decimal numbers. */
-  val double: TypedExtractor[Double] = new TypedExtractor[Double] {
-    def extract(input: StepInput, groups: List[String], groupIndex: Int): Either[String, (Double, Int)] =
+  val double: TypedExtractor[Double] = TypedExtractor.make[Double]("([-+]?[0-9]*\\.?[0-9]+)") {
+    (_, groups, groupIndex) =>
       groups
         .lift(groupIndex)
         .flatMap(s => scala.util.Try(s.toDouble).toOption)
         .map(d => (d, groupIndex + 1))
         .toRight(s"Expected double at group $groupIndex")
-    def pattern: String = "([-+]?[0-9]*\\.?[0-9]+)"
   }
 
   /** Matches long integers. */
-  val long: TypedExtractor[Long] = new TypedExtractor[Long] {
-    def extract(input: StepInput, groups: List[String], groupIndex: Int): Either[String, (Long, Int)] =
-      groups
-        .lift(groupIndex)
-        .flatMap(s => scala.util.Try(s.toLong).toOption)
-        .map(l => (l, groupIndex + 1))
-        .toRight(s"Expected long at group $groupIndex")
-    def pattern: String = "(-?\\d+)"
+  val long: TypedExtractor[Long] = TypedExtractor.make[Long]("(-?\\d+)") { (_, groups, groupIndex) =>
+    groups
+      .lift(groupIndex)
+      .flatMap(s => scala.util.Try(s.toLong).toOption)
+      .map(l => (l, groupIndex + 1))
+      .toRight(s"Expected long at group $groupIndex")
   }
 
   /** Matches `true` or `false` (case-insensitive). */
-  val boolean: TypedExtractor[Boolean] = new TypedExtractor[Boolean] {
-    def extract(input: StepInput, groups: List[String], groupIndex: Int): Either[String, (Boolean, Int)] =
+  val boolean: TypedExtractor[Boolean] = TypedExtractor.make[Boolean]("(true|false|True|False|TRUE|FALSE)") {
+    (_, groups, groupIndex) =>
       groups
         .lift(groupIndex)
         .flatMap { s =>
@@ -102,60 +107,52 @@ trait DefaultTypedExtractor {
         }
         .map(b => (b, groupIndex + 1))
         .toRight(s"Expected boolean (true/false) at group $groupIndex")
-
-    def pattern: String = "(true|false|True|False|TRUE|FALSE)"
   }
 
   /**
    * Matches decimal numbers as BigDecimal (exact precision — use for financial
    * values).
    */
-  val bigDecimal: TypedExtractor[BigDecimal] = new TypedExtractor[BigDecimal] {
-    def extract(input: StepInput, groups: List[String], groupIndex: Int): Either[String, (BigDecimal, Int)] =
+  val bigDecimal: TypedExtractor[BigDecimal] = TypedExtractor.make[BigDecimal]("([-+]?[0-9]*\\.?[0-9]+)") {
+    (_, groups, groupIndex) =>
       groups
         .lift(groupIndex)
         .flatMap(s => scala.util.Try(BigDecimal(new JBigDecimal(s.trim))).toOption)
         .map(d => (d, groupIndex + 1))
         .toRight(s"Expected BigDecimal at group $groupIndex")
-
-    def pattern: String = "([-+]?[0-9]*\\.?[0-9]+)"
   }
 
   /** Matches UUID strings (8-4-4-4-12 hex format). */
-  val uuid: TypedExtractor[UUID] = new TypedExtractor[UUID] {
-    def extract(input: StepInput, groups: List[String], groupIndex: Int): Either[String, (UUID, Int)] =
-      groups
-        .lift(groupIndex)
-        .flatMap(s => scala.util.Try(UUID.fromString(s.trim)).toOption)
-        .map(u => (u, groupIndex + 1))
-        .toRight(s"Expected UUID at group $groupIndex")
-
-    def pattern: String = "([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+  val uuid: TypedExtractor[UUID] = TypedExtractor.make[UUID](
+    "([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+  ) { (_, groups, groupIndex) =>
+    groups
+      .lift(groupIndex)
+      .flatMap(s => scala.util.Try(UUID.fromString(s.trim)).toOption)
+      .map(u => (u, groupIndex + 1))
+      .toRight(s"Expected UUID at group $groupIndex")
   }
 
   /**
    * Extracts a typed data table. Column headers must match the Scala field
    * names of T exactly.
    */
-  def table[T](using schema: Schema[T]): TypedExtractor[List[T]] = TableExtractor(schema, Map.empty)
+  def table[T: Tag](using schema: Schema[T]): TypedExtractor[List[T]] = TableExtractor(schema, Map.empty)
 
   /**
    * Extracts a typed data table with an explicit header-name mapping. Useful
    * when the feature file uses display names (e.g. "Account Open Date") that
    * differ from the Scala field names (e.g. "accountOpenDate").
    */
-  def tableWithMapping[T](headerMap: Map[String, String])(using schema: Schema[T]): TypedExtractor[List[T]] =
+  def tableWithMapping[T: Tag](headerMap: Map[String, String])(using schema: Schema[T]): TypedExtractor[List[T]] =
     TableExtractor(schema, headerMap)
 
   /**
    * Extracts the doc string argument (triple-quoted text) of a step as a raw
    * String.
    */
-  val docString: TypedExtractor[String] = new TypedExtractor[String] {
-    def extract(input: StepInput, groups: List[String], groupIndex: Int): Either[String, (String, Int)] =
-      input.docString.map(ds => (ds, groupIndex)).toRight("Doc string expected but not provided")
-
-    def pattern: String = ""
+  val docString: TypedExtractor[String] = TypedExtractor.make[String]("") { (input, _, groupIndex) =>
+    input.docString.map(ds => (ds, groupIndex)).toRight("Doc string expected but not provided")
   }
 
   /**
@@ -185,14 +182,11 @@ trait DefaultTypedExtractor {
    * @param pat
    *   A regex string with exactly one top-level capturing group.
    */
-  def regex(pat: String): TypedExtractor[String] = new TypedExtractor[String] {
-    def extract(input: StepInput, groups: List[String], groupIndex: Int): Either[String, (String, Int)] =
-      groups
-        .lift(groupIndex)
-        .map(s => (Option(s).getOrElse(""), groupIndex + 1))
-        .toRight(s"Expected regex match at group $groupIndex (pattern: $pat)")
-
-    def pattern: String = pat
+  def regex(pat: String): TypedExtractor[String] = TypedExtractor.make[String](pat) { (_, groups, groupIndex) =>
+    groups
+      .lift(groupIndex)
+      .map(s => (Option(s).getOrElse(""), groupIndex + 1))
+      .toRight(s"Expected regex match at group $groupIndex (pattern: $pat)")
   }
 
   /**
@@ -215,17 +209,16 @@ trait DefaultTypedExtractor {
    * }
    * }}}
    */
-  def oneOf(alternatives: String*): TypedExtractor[String] = new TypedExtractor[String] {
-    def extract(input: StepInput, groups: List[String], groupIndex: Int): Either[String, (String, Int)] =
+  def oneOf(alternatives: String*): TypedExtractor[String] = {
+    // Alternatives are sorted longest-first so the regex engine tries the longest match first,
+    // preventing "is" from matching before "is not" in overlapping sets.
+    val pat = "(" + alternatives.sortBy(-_.length).map(java.util.regex.Pattern.quote).mkString("|") + ")"
+    TypedExtractor.make[String](pat) { (_, groups, groupIndex) =>
       groups
         .lift(groupIndex)
         .map(s => (s, groupIndex + 1))
         .toRight(s"Expected one of [${alternatives.mkString(", ")}] at group $groupIndex")
-
-    // Alternatives are sorted longest-first so the regex engine tries the longest match first,
-    // preventing "is" from matching before "is not" in overlapping sets.
-    def pattern: String =
-      "(" + alternatives.sortBy(-_.length).map(java.util.regex.Pattern.quote).mkString("|") + ")"
+    }
   }
 
   /**
@@ -247,14 +240,11 @@ trait DefaultTypedExtractor {
    * `Boolean` instead of `Option[String]` for callers that only need the
    * presence flag.
    */
-  def optional(text: String): TypedExtractor[Option[String]] = new TypedExtractor[Option[String]] {
-    def extract(input: StepInput, groups: List[String], groupIndex: Int): Either[String, (Option[String], Int)] = {
+  def optional(text: String): TypedExtractor[Option[String]] =
+    TypedExtractor.make[Option[String]](s"(${java.util.regex.Pattern.quote(text)})?") { (_, groups, groupIndex) =>
       val captured = groups.lift(groupIndex).flatMap(s => Option(s).filter(_.nonEmpty))
       Right((captured, groupIndex + 1))
     }
-
-    def pattern: String = s"(${java.util.regex.Pattern.quote(text)})?"
-  }
 }
 
 /**
@@ -266,7 +256,8 @@ trait DefaultTypedExtractor {
  *      `@ColumnName("Header Text")` annotation on the case class field 3. Exact
  *      Scala field name (default)
  */
-final class TableExtractor[T](schema: Schema[T], headerMap: Map[String, String]) extends TypedExtractor[List[T]] {
+final class TableExtractor[T](schema: Schema[T], headerMap: Map[String, String])(using val tag: Tag[List[T]])
+    extends TypedExtractor[List[T]] {
 
   // Build a reverse mapping: header-text → Scala-field-name
   // combining explicit headerMap with @ColumnName annotations from the schema.


### PR DESCRIPTION
## Summary
- Adds a `tag: Tag[A]` member to `TypedExtractor[A]` so the runtime type an extractor produces can be inspected — a prerequisite for automatic type-based `HasGen` discovery in property testing (#99).
- Adds a `TypedExtractor.make[A: Tag](pattern)(extractFn)` smart constructor, and rewrites every built-in extractor (`string`, `word`, `rest`, `int`, `long`, `double`, `boolean`, `bigDecimal`, `uuid`, `docString`, `regex`, `oneOf`, `optional`) to use it, so the tag comes from the context bound rather than being hand-written at each site.
- `table`/`tableWithMapping` gain a `Tag[T]` context bound; `TableExtractor` takes the derived `Tag[List[T]]` via a `using val` constructor parameter to satisfy the trait.
- Purely additive metadata — no behavior change. Adds MiMa filters for the resulting source/binary breaks.

Closes #96.

## Test plan
- [x] `sbt scalafmtCheckAll`
- [x] `sbt compile`
- [x] `sbt test` (434 tests passed on master)
- [x] `sbt mimaReportBinaryIssues` (clean with the added filters)