### PR TITLE
Add structural matcher for property-test step templates (#97)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,11 @@ lazy val mimaSettings = Seq(
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.step.DefaultTypedExtractor.table"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.step.DefaultTypedExtractor.tableWithMapping"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.step.TableExtractor.this"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("zio.bdd.core.step.TypedExtractor.tag")
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("zio.bdd.core.step.TypedExtractor.tag"),
+    // #97 added `resolveTemplateColumns` to `StepRegistry` — structurally matches a
+    // `@property` step template (placeholders still present) against the registry to find
+    // which extractor governs each `<col>`. Source-compatible, not binary-compatible against 1.0.0.
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("zio.bdd.core.step.StepRegistry.resolveTemplateColumns")
   )
 )
 

--- a/core/src/main/scala/zio/bdd/core/step/StepExpression.scala
+++ b/core/src/main/scala/zio/bdd/core/step/StepExpression.scala
@@ -1,5 +1,7 @@
 package zio.bdd.core.step
 
+import izumi.reflect.Tag
+
 import java.util.regex.Pattern
 
 sealed trait StepPart
@@ -18,6 +20,23 @@ case class StepExpression[Out <: Tuple](parts: List[StepPart]) {
       case Literal(s)   => Pattern.quote(s)
       case Extractor(e) => e.pattern
     }.mkString.r.pattern
+
+  /**
+   * Structural match against a `@property` step template that still has `<col>`
+   * placeholders in place of real values (e.g. "an account with balance
+   * <balance>"). Unlike `extract`, this does not require the placeholder text
+   * to satisfy an extractor's value-conformance regex — it only checks that
+   * literal segments align exactly and that each extractor position lines up
+   * with a placeholder, left to right.
+   *
+   * Returns the ordered `(columnName, Tag[_])` pairs naming which extractor
+   * governs each placeholder, or `None` if `template`'s literal/extractor
+   * structure doesn't align with this `StepExpression` at all (including the
+   * common case of a template with no placeholders facing a StepExpression that
+   * has extractors — there's no placeholder to supply their type).
+   */
+  def structuralMatch(template: String): Option[List[(String, Tag[?])]] =
+    StepExpression.structuralMatch(template, parts)
 
   def extract(input: StepInput): Option[Out] = {
     val matcher = compiledPattern.matcher(input.text)
@@ -48,4 +67,66 @@ case class StepExpression[Out <: Tuple](parts: List[StepPart]) {
       case Literal(s)   => s"\"$s\""
       case Extractor(e) => s"<${e.getClass.getSimpleName.stripSuffix("$")}>"
     }.mkString(" / ")
+}
+
+object StepExpression {
+
+  private val placeholderRe = "<([^>]+)>".r
+
+  /**
+   * Split a property-test template into literal text and `<col>` placeholder
+   * tokens, in left-to-right order. Mirrors the same `<col>` syntax
+   * `PropertyExecutor.substituteSteps` substitutes real values into.
+   */
+  private[step] def templateTokens(template: String): List[Either[String, String]] = {
+    val tokens = List.newBuilder[Either[String, String]]
+    var idx    = 0
+    placeholderRe.findAllMatchIn(template).foreach { m =>
+      val literal = template.substring(idx, m.start)
+      if (literal.nonEmpty) tokens += Left(literal)
+      tokens += Right(m.group(1))
+      idx = m.end
+    }
+    val tail = template.substring(idx)
+    if (tail.nonEmpty) tokens += Left(tail)
+    tokens.result()
+  }
+
+  /**
+   * Collapse a parts list into the same `Left(literal)/Right(extractor)` token
+   * shape as `templateTokens` — merging adjacent literals and dropping empty
+   * ones — so the two sequences can be compared positionally.
+   */
+  private[step] def partTokens(parts: List[StepPart]): List[Either[String, TypedExtractor[?]]] =
+    parts
+      .foldLeft(List.empty[Either[String, TypedExtractor[?]]]) { (acc, part) =>
+        part match {
+          case Literal(s) if s.isEmpty => acc
+          case Literal(s) =>
+            acc match {
+              case Left(prev) :: rest => Left(prev + s) :: rest
+              case _                  => Left(s) :: acc
+            }
+          case Extractor(e) => Right(e) :: acc
+        }
+      }
+      .reverse
+
+  private[step] def structuralMatch(template: String, parts: List[StepPart]): Option[List[(String, Tag[?])]] = {
+    @scala.annotation.tailrec
+    def go(
+      pTokens: List[Either[String, TypedExtractor[?]]],
+      tTokens: List[Either[String, String]],
+      acc: List[(String, Tag[?])]
+    ): Option[List[(String, Tag[?])]] =
+      (pTokens, tTokens) match {
+        case (Nil, Nil) => Some(acc.reverse)
+        case (Left(pLit) :: pRest, Left(tLit) :: tRest) if pLit == tLit =>
+          go(pRest, tRest, acc)
+        case (Right(e) :: pRest, Right(col) :: tRest) =>
+          go(pRest, tRest, (col, e.tag) :: acc)
+        case _ => None
+      }
+    go(partTokens(parts), templateTokens(template), Nil)
+  }
 }

--- a/core/src/main/scala/zio/bdd/core/step/StepExpression.scala
+++ b/core/src/main/scala/zio/bdd/core/step/StepExpression.scala
@@ -34,6 +34,13 @@ case class StepExpression[Out <: Tuple](parts: List[StepPart]) {
    * structure doesn't align with this `StepExpression` at all (including the
    * common case of a template with no placeholders facing a StepExpression that
    * has extractors — there's no placeholder to supply their type).
+   *
+   * Purely structural: if the same column name appears more than once, every
+   * occurrence is included in order, even if they're governed by different
+   * `Tag`s. This method doesn't judge whether that's usable — that's a
+   * cross-cutting concern about the whole template, not about whether one
+   * `StepExpression` aligns with it, so `StepRegistry.resolveTemplateColumns`
+   * is what rejects that case (as `ConflictingColumnType`).
    */
   def structuralMatch(template: String): Option[List[(String, Tag[?])]] =
     StepExpression.structuralMatch(template, parts)

--- a/core/src/main/scala/zio/bdd/core/step/StepRegistry.scala
+++ b/core/src/main/scala/zio/bdd/core/step/StepRegistry.scala
@@ -57,6 +57,26 @@ class AmbiguousTemplateException(stepType: StepType, template: String, patterns:
         "\nRename one of the step definitions to remove the ambiguity."
     )
 
+/**
+ * The same `<col>` placeholder appears more than once in `template`, governed
+ * by extractors that produce different types (e.g. `<amount>` captured once as
+ * `Tag[Int]` and once as `Tag[Long]`). `PropertyExecutor` samples exactly one
+ * string value per column name and substitutes it into every occurrence, so a
+ * single sampled value can never satisfy two different extractor types for the
+ * same placeholder — this is a step-definition bug, not ambiguity.
+ */
+final case class ConflictingColumnType(
+  stepType: StepType,
+  template: String,
+  column: String,
+  first: Tag[?],
+  second: Tag[?]
+) extends TemplateLookupError:
+  def toException: Throwable = new RuntimeException(
+    s"Column '$column' in $stepType template '$template' is captured as both $first and $second.\n" +
+      "Use one consistent extractor type for this placeholder, or rename one of the occurrences."
+  )
+
 trait StepRegistry[R, S]:
   /** Look up the effect to run for a given step. */
   def findStep(stepType: StepType, input: StepInput): IO[StepLookupError, RIO[R & State[S] & Scope, Unit]]
@@ -72,124 +92,109 @@ trait StepRegistry[R, S]:
 final case class StepRegistryLive[R, S](steps: List[StepDef[R, S]]) extends StepRegistry[R, S]:
   // Index definitions by their declared keyword once at construction, so per-step lookup
   // is a map access rather than a full scan. Registration order is preserved per bucket.
+  // Everything below is read-only after construction (`steps`, `byKeyword`, and every
+  // method here are pure functions over immutable data), so a single StepRegistryLive
+  // instance is safe to share and call concurrently across parallel scenario fibers —
+  // there's no mutable state to race on.
   private val byKeyword: Map[StepType, List[StepDef[R, S]]] =
     steps.groupBy { case StepDefImpl(rt, _, _) => rt }
 
-  private def matchesFor(
+  /**
+   * Shared fallback cascade for both literal-text lookup (`findStep`) and
+   * template lookup (`resolveTemplateColumns`): try the exact keyword first; if
+   * nothing matches at all, fall back to And steps as universal glue, then to
+   * any step type. This mirrors Cucumber semantics — the keyword on a step
+   * definition is just documentation; any step can match any keyword at
+   * runtime. Stops at the first level that has at least one match, even if that
+   * level has several (disambiguation happens one level up).
+   */
+  private def candidatesWithFallback[A](
     stepType: StepType,
-    input: StepInput
-  ): List[(StepDef[R, S], RIO[R & State[S] & Scope, Unit])] =
-    byKeyword.getOrElse(stepType, Nil).flatMap(s => s.tryExecute(input).map(effect => (s, effect)))
+    tryMatch: StepDef[R, S] => Option[A]
+  ): List[(StepDef[R, S], A)] = {
+    def matchesIn(candidates: List[StepDef[R, S]]): List[(StepDef[R, S], A)] =
+      candidates.flatMap(sd => tryMatch(sd).map(a => (sd, a)))
 
-  def findStep(stepType: StepType, input: StepInput): IO[StepLookupError, RIO[R & State[S] & Scope, Unit]] = {
-    val typedMatches = matchesFor(stepType, input)
-
-    typedMatches match {
-      case Nil =>
-        // Fall back to And steps as universal glue, then to any step type.
-        // This matches Cucumber's semantics: keyword on the step definition is just
-        // documentation — any step can match any keyword at runtime.
-        val andMatches = matchesFor(StepType.AndStep, input)
-        andMatches match {
-          case (_, effect) :: Nil => ZIO.succeed(effect)
-          case Nil                =>
-            // Cross-keyword fallback: find a match across all step types.
-            val allMatches = steps
-              .flatMap(s => s.tryExecute(input).map(effect => (s, effect)))
-            allMatches match {
-              case Nil =>
-                ZIO.fail(NoMatchingStep(stepType, input, generateSnippet(stepType, input)))
-              case (_, effect) :: Nil =>
-                ZIO.succeed(effect)
-              case multiple =>
-                disambiguate(multiple, stepType, input)
-            }
-          case multiple =>
-            disambiguate(multiple, stepType, input)
-        }
-
-      case (_, effect) :: Nil =>
-        ZIO.succeed(effect)
-
-      case multiple =>
-        disambiguate(multiple, stepType, input)
+    val exact = matchesIn(byKeyword.getOrElse(stepType, Nil))
+    if (exact.nonEmpty) exact
+    else {
+      val and = matchesIn(byKeyword.getOrElse(StepType.AndStep, Nil))
+      if (and.nonEmpty) and else matchesIn(steps)
     }
   }
 
   // The definition with the fewest extractor placeholders is the most specific (most
-  // literal) one. Shared by literal-text disambiguation (`disambiguate`) and template
-  // disambiguation (`disambiguateTemplate`) — both prefer the same specificity ordering.
+  // literal) one. This lets a literal step like `the response body is not empty` win
+  // over a wildcard `the response body is {string}`. Only a tie at the most-specific
+  // level is a genuine ambiguity. Shared by both literal-text and template lookup —
+  // both prefer the same specificity ordering.
   private def extractorCount(sd: StepDef[R, S]): Int = sd match {
     case StepDefImpl(_, expr, _) => expr.parts.count { case _: Extractor[?] => true; case _ => false }
   }
 
-  // When several definitions match the same text, prefer the most specific one —
-  // the definition with the fewest extractor placeholders. This lets a literal step
-  // like `the response body is not empty` win over a wildcard `the response body is {string}`.
-  // Only a tie at the most-specific level is reported as a genuine ambiguity.
-  private def disambiguate(
-    matches: List[(StepDef[R, S], RIO[R & State[S] & Scope, Unit])],
-    stepType: StepType,
-    input: StepInput
-  ): IO[StepLookupError, RIO[R & State[S] & Scope, Unit]] = {
+  private def fewestExtractorsWinner[A](matches: List[(StepDef[R, S], A)]): Either[List[String], A] = {
     val fewest  = matches.map { case (sd, _) => extractorCount(sd) }.min
     val winners = matches.filter { case (sd, _) => extractorCount(sd) == fewest }
     winners match {
-      case (_, effect) :: Nil => ZIO.succeed(effect)
-      case _ =>
-        ZIO.fail(AmbiguousStep(stepType, input, winners.map { case (StepDefImpl(_, expr, _), _) => expr.toString }))
+      case (_, a) :: Nil => Right(a)
+      case _             => Left(winners.map { case (StepDefImpl(_, expr, _), _) => expr.toString })
     }
   }
+
+  def findStep(stepType: StepType, input: StepInput): IO[StepLookupError, RIO[R & State[S] & Scope, Unit]] =
+    candidatesWithFallback(stepType, (sd: StepDef[R, S]) => sd.tryExecute(input)) match {
+      case Nil                => ZIO.fail(NoMatchingStep(stepType, input, generateSnippet(stepType, input)))
+      case (_, effect) :: Nil => ZIO.succeed(effect)
+      case multiple =>
+        ZIO.fromEither(fewestExtractorsWinner(multiple).left.map(patterns => AmbiguousStep(stepType, input, patterns)))
+    }
 
   def resolveTemplateColumns(
     stepType: StepType,
     template: String
   ): IO[TemplateLookupError, List[(String, Tag[?])]] = {
-    def structuralMatchesFor(st: StepType): List[(StepDef[R, S], List[(String, Tag[?])])] =
-      byKeyword
-        .getOrElse(st, Nil)
-        .collect { case sd @ StepDefImpl(_, expr, _) =>
-          expr.structuralMatch(template).map(cols => (sd, cols))
-        }
-        .flatten
-
-    val typedMatches = structuralMatchesFor(stepType)
-    typedMatches match {
-      case Nil =>
-        // Same fallback chain as findStep: And steps as universal glue, then any step type.
-        val andMatches = structuralMatchesFor(StepType.AndStep)
-        andMatches match {
-          case (_, cols) :: Nil => ZIO.succeed(cols)
-          case Nil =>
-            val allMatches = steps.collect { case sd @ StepDefImpl(_, expr, _) =>
-              expr.structuralMatch(template).map(cols => (sd, cols))
-            }.flatten
-            allMatches match {
-              case Nil              => ZIO.fail(NoMatchingTemplate(stepType, template))
-              case (_, cols) :: Nil => ZIO.succeed(cols)
-              case multiple         => disambiguateTemplate(multiple, stepType, template)
-            }
-          case multiple => disambiguateTemplate(multiple, stepType, template)
-        }
-      case (_, cols) :: Nil => ZIO.succeed(cols)
-      case multiple         => disambiguateTemplate(multiple, stepType, template)
+    def structuralMatchOf(sd: StepDef[R, S]): Option[List[(String, Tag[?])]] = sd match {
+      case StepDefImpl(_, expr, _) => expr.structuralMatch(template)
     }
+
+    val resolved: IO[TemplateLookupError, List[(String, Tag[?])]] =
+      candidatesWithFallback(stepType, structuralMatchOf) match {
+        case Nil              => ZIO.fail(NoMatchingTemplate(stepType, template))
+        case (_, cols) :: Nil => ZIO.succeed(cols)
+        case multiple =>
+          ZIO.fromEither(
+            fewestExtractorsWinner(multiple).left.map(patterns => AmbiguousTemplate(stepType, template, patterns))
+          )
+      }
+    resolved.flatMap(cols => validateColumnTypes(stepType, template, cols))
   }
 
-  // Same fewest-extractors specificity heuristic as `disambiguate`, applied to templates.
-  private def disambiguateTemplate(
-    matches: List[(StepDef[R, S], List[(String, Tag[?])])],
+  // A `<col>` placeholder can legitimately appear more than once in one template (the
+  // same sampled value is substituted everywhere) — but only if every occurrence is
+  // governed by the same Tag. If two occurrences disagree, no single sampled value can
+  // satisfy both, so this is reported distinctly from "no match"/"ambiguous": it's a
+  // bug in how the matching StepDef's extractors are typed, not a lookup failure.
+  private def validateColumnTypes(
     stepType: StepType,
-    template: String
+    template: String,
+    cols: List[(String, Tag[?])]
   ): IO[TemplateLookupError, List[(String, Tag[?])]] = {
-    val fewest  = matches.map { case (sd, _) => extractorCount(sd) }.min
-    val winners = matches.filter { case (sd, _) => extractorCount(sd) == fewest }
-    winners match {
-      case (_, cols) :: Nil => ZIO.succeed(cols)
-      case _ =>
-        ZIO.fail(
-          AmbiguousTemplate(stepType, template, winners.map { case (StepDefImpl(_, expr, _), _) => expr.toString })
-        )
+    // Walk left to right (template order) rather than `groupBy` (Map iteration order is
+    // unspecified) so the reported conflict is always the first one a developer would
+    // spot reading the template themselves.
+    @scala.annotation.tailrec
+    def firstConflict(remaining: List[(String, Tag[?])], seen: Map[String, Tag[?]]): Option[ConflictingColumnType] =
+      remaining match {
+        case Nil => None
+        case (column, tag) :: rest =>
+          seen.get(column) match {
+            case Some(prior) if prior != tag => Some(ConflictingColumnType(stepType, template, column, prior, tag))
+            case _                           => firstConflict(rest, seen.updated(column, tag))
+          }
+      }
+    firstConflict(cols, Map.empty) match {
+      case Some(conflict) => ZIO.fail(conflict)
+      case None           => ZIO.succeed(cols)
     }
   }
 

--- a/core/src/main/scala/zio/bdd/core/step/StepRegistry.scala
+++ b/core/src/main/scala/zio/bdd/core/step/StepRegistry.scala
@@ -27,9 +27,47 @@ class AmbiguousStepDefinitionException(stepType: StepType, input: StepInput, pat
         "\nRename one of the step definitions to remove the ambiguity."
     )
 
+/**
+ * Represents all ways resolving a `@property` step template (one that still has
+ * `<col>` placeholders, e.g. "an account with balance <balance>") against the
+ * registry can fail.
+ */
+sealed trait TemplateLookupError extends Product with Serializable:
+  def toException: Throwable
+
+/** No registered step definition structurally matches the given template. */
+final case class NoMatchingTemplate(stepType: StepType, template: String) extends TemplateLookupError:
+  def toException: Throwable =
+    new RuntimeException(s"No step definition structurally matches $stepType template: '$template'")
+
+/** Two or more step definitions structurally match the same template. */
+final case class AmbiguousTemplate(stepType: StepType, template: String, patterns: List[String])
+    extends TemplateLookupError:
+  def toException: Throwable = new AmbiguousTemplateException(stepType, template, patterns)
+
+/**
+ * Thrown when two or more step definitions structurally match the same
+ * template.
+ */
+class AmbiguousTemplateException(stepType: StepType, template: String, patterns: List[String])
+    extends RuntimeException(
+      s"Ambiguous step definitions for $stepType template '$template'.\n" +
+        s"Matched ${patterns.length} definitions structurally:\n" +
+        patterns.zipWithIndex.map { case (p, i) => s"  ${i + 1}. $p" }.mkString("\n") +
+        "\nRename one of the step definitions to remove the ambiguity."
+    )
+
 trait StepRegistry[R, S]:
   /** Look up the effect to run for a given step. */
   def findStep(stepType: StepType, input: StepInput): IO[StepLookupError, RIO[R & State[S] & Scope, Unit]]
+
+  /**
+   * Resolve which extractor governs each `<col>` placeholder in a `@property`
+   * step template, by structurally matching it against the registered StepDefs
+   * for `stepType` (see `StepExpression.structuralMatch`). Returns the ordered
+   * `(columnName, Tag[_])` pairs from whichever StepDef matches.
+   */
+  def resolveTemplateColumns(stepType: StepType, template: String): IO[TemplateLookupError, List[(String, Tag[?])]]
 
 final case class StepRegistryLive[R, S](steps: List[StepDef[R, S]]) extends StepRegistry[R, S]:
   // Index definitions by their declared keyword once at construction, so per-step lookup
@@ -78,6 +116,13 @@ final case class StepRegistryLive[R, S](steps: List[StepDef[R, S]]) extends Step
     }
   }
 
+  // The definition with the fewest extractor placeholders is the most specific (most
+  // literal) one. Shared by literal-text disambiguation (`disambiguate`) and template
+  // disambiguation (`disambiguateTemplate`) — both prefer the same specificity ordering.
+  private def extractorCount(sd: StepDef[R, S]): Int = sd match {
+    case StepDefImpl(_, expr, _) => expr.parts.count { case _: Extractor[?] => true; case _ => false }
+  }
+
   // When several definitions match the same text, prefer the most specific one —
   // the definition with the fewest extractor placeholders. This lets a literal step
   // like `the response body is not empty` win over a wildcard `the response body is {string}`.
@@ -87,15 +132,64 @@ final case class StepRegistryLive[R, S](steps: List[StepDef[R, S]]) extends Step
     stepType: StepType,
     input: StepInput
   ): IO[StepLookupError, RIO[R & State[S] & Scope, Unit]] = {
-    def extractorCount(sd: StepDef[R, S]): Int = sd match {
-      case StepDefImpl(_, expr, _) => expr.parts.count { case _: Extractor[?] => true; case _ => false }
-    }
     val fewest  = matches.map { case (sd, _) => extractorCount(sd) }.min
     val winners = matches.filter { case (sd, _) => extractorCount(sd) == fewest }
     winners match {
       case (_, effect) :: Nil => ZIO.succeed(effect)
       case _ =>
         ZIO.fail(AmbiguousStep(stepType, input, winners.map { case (StepDefImpl(_, expr, _), _) => expr.toString }))
+    }
+  }
+
+  def resolveTemplateColumns(
+    stepType: StepType,
+    template: String
+  ): IO[TemplateLookupError, List[(String, Tag[?])]] = {
+    def structuralMatchesFor(st: StepType): List[(StepDef[R, S], List[(String, Tag[?])])] =
+      byKeyword
+        .getOrElse(st, Nil)
+        .collect { case sd @ StepDefImpl(_, expr, _) =>
+          expr.structuralMatch(template).map(cols => (sd, cols))
+        }
+        .flatten
+
+    val typedMatches = structuralMatchesFor(stepType)
+    typedMatches match {
+      case Nil =>
+        // Same fallback chain as findStep: And steps as universal glue, then any step type.
+        val andMatches = structuralMatchesFor(StepType.AndStep)
+        andMatches match {
+          case (_, cols) :: Nil => ZIO.succeed(cols)
+          case Nil =>
+            val allMatches = steps.collect { case sd @ StepDefImpl(_, expr, _) =>
+              expr.structuralMatch(template).map(cols => (sd, cols))
+            }.flatten
+            allMatches match {
+              case Nil              => ZIO.fail(NoMatchingTemplate(stepType, template))
+              case (_, cols) :: Nil => ZIO.succeed(cols)
+              case multiple         => disambiguateTemplate(multiple, stepType, template)
+            }
+          case multiple => disambiguateTemplate(multiple, stepType, template)
+        }
+      case (_, cols) :: Nil => ZIO.succeed(cols)
+      case multiple         => disambiguateTemplate(multiple, stepType, template)
+    }
+  }
+
+  // Same fewest-extractors specificity heuristic as `disambiguate`, applied to templates.
+  private def disambiguateTemplate(
+    matches: List[(StepDef[R, S], List[(String, Tag[?])])],
+    stepType: StepType,
+    template: String
+  ): IO[TemplateLookupError, List[(String, Tag[?])]] = {
+    val fewest  = matches.map { case (sd, _) => extractorCount(sd) }.min
+    val winners = matches.filter { case (sd, _) => extractorCount(sd) == fewest }
+    winners match {
+      case (_, cols) :: Nil => ZIO.succeed(cols)
+      case _ =>
+        ZIO.fail(
+          AmbiguousTemplate(stepType, template, winners.map { case (StepDefImpl(_, expr, _), _) => expr.toString })
+        )
     }
   }
 
@@ -138,3 +232,9 @@ object StepRegistry:
     input: StepInput
   ): ZIO[StepRegistry[R, S], StepLookupError, RIO[R & State[S] & Scope, Unit]] =
     ZIO.serviceWithZIO[StepRegistry[R, S]](_.findStep(stepType, input))
+
+  def resolveTemplateColumns[R: Tag, S: Tag](
+    stepType: StepType,
+    template: String
+  ): ZIO[StepRegistry[R, S], TemplateLookupError, List[(String, Tag[?])]] =
+    ZIO.serviceWithZIO[StepRegistry[R, S]](_.resolveTemplateColumns(stepType, template))

--- a/core/src/test/scala/zio/bdd/core/step/TemplateStructuralMatchSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/step/TemplateStructuralMatchSpec.scala
@@ -1,0 +1,142 @@
+package zio.bdd.core.step
+
+import izumi.reflect.Tag
+import zio.bdd.gherkin.StepType
+import zio.test.*
+import zio.test.Assertion.*
+import zio.ZIO
+
+/**
+ * Issue #97: structurally matching a `@property` step template — one that still
+ * has `<col>` placeholders in place of real values — against the registered
+ * StepDefs, to find which extractor (and its `Tag[_]`) governs each
+ * placeholder. Unlike `StepRegistry.findStep`, no real conforming value is
+ * required at this stage; only literal/extractor positions need to align.
+ */
+object TemplateStructuralMatchSpec extends ZIOSpecDefault with DefaultTypedExtractor {
+
+  private def makeStep[T <: Tuple](t: StepType, expr: StepExpression[T]) =
+    StepDefImpl[Any, Unit, T](t, expr, (_: T) => ZIO.unit)
+
+  private def registry(steps: List[StepDef[Any, Unit]]) = StepRegistryLive[Any, Unit](steps)
+
+  // ── StepExpression.structuralMatch (pure, no registry involved) ──────────
+
+  private val exprLevel = suite("StepExpression.structuralMatch")(
+    test("single-placeholder step resolves the placeholder's column name and Tag") {
+      val expr = StepExpression(List(Literal("balance is "), Extractor(int)))
+      assertTrue(expr.structuralMatch("balance is <amount>").contains(List("amount" -> Tag[Int])))
+    },
+    test("multi-placeholder step resolves all placeholders in left-to-right order") {
+      val expr = StepExpression(
+        List(Literal("an account with balance "), Extractor(int), Literal(" and limit "), Extractor(long))
+      )
+      assertTrue(
+        expr
+          .structuralMatch("an account with balance <balance> and limit <limit>")
+          .contains(List("balance" -> Tag[Int], "limit" -> Tag[Long]))
+      )
+    },
+    test("step with no placeholders structurally matches a no-extractor template trivially") {
+      val expr = StepExpression(List(Literal("a clean database")))
+      assertTrue(expr.structuralMatch("a clean database").contains(Nil))
+    },
+    test("step with no placeholders does not apply when the StepExpression has an extractor") {
+      // "balance is 100" has no `<col>` placeholder — there's nothing to supply the
+      // extractor's type, so this must not spuriously match.
+      val expr = StepExpression(List(Literal("balance is "), Extractor(int)))
+      assertTrue(expr.structuralMatch("balance is 100").isEmpty)
+    },
+    test("mismatched literal text does not match even when extractor positions would align") {
+      val expr = StepExpression(List(Literal("foo "), Extractor(int)))
+      assertTrue(expr.structuralMatch("bar <x>").isEmpty)
+    },
+    test("trailing literal text after the last extractor must also align") {
+      val expr = StepExpression(List(Literal("amount "), Extractor(int), Literal(" exactly")))
+      assertTrue(expr.structuralMatch("amount <amount> exactly").contains(List("amount" -> Tag[Int])))
+      assertTrue(expr.structuralMatch("amount <amount> roughly").isEmpty)
+    }
+  )
+
+  // ── StepRegistry.resolveTemplateColumns (registry lookup + disambiguation) ─
+
+  private val registryLevel = suite("StepRegistry.resolveTemplateColumns")(
+    test("resolves a single-placeholder template to the matching StepDef's column/Tag") {
+      val step = makeStep(StepType.GivenStep, StepExpression(List(Literal("balance is "), Extractor(int))))
+      val reg  = registry(List(step))
+      assertZIO(reg.resolveTemplateColumns(StepType.GivenStep, "balance is <amount>"))(
+        equalTo(List("amount" -> Tag[Int]))
+      )
+    },
+    test("resolves a multi-placeholder template across two extractors") {
+      val step = makeStep(
+        StepType.GivenStep,
+        StepExpression(List(Literal("balance "), Extractor(int), Literal(" limit "), Extractor(long)))
+      )
+      val reg = registry(List(step))
+      assertZIO(reg.resolveTemplateColumns(StepType.GivenStep, "balance <balance> limit <limit>"))(
+        equalTo(List("balance" -> Tag[Int], "limit" -> Tag[Long]))
+      )
+    },
+    test("a template with no placeholders resolves to an empty column list against a literal StepDef") {
+      val step = makeStep(StepType.GivenStep, StepExpression(List(Literal("a clean database"))))
+      val reg  = registry(List(step))
+      assertZIO(reg.resolveTemplateColumns(StepType.GivenStep, "a clean database"))(equalTo(Nil))
+    },
+    test("a template with no placeholders does not match a StepDef that requires one") {
+      val step = makeStep(StepType.GivenStep, StepExpression(List(Literal("balance is "), Extractor(int))))
+      val reg  = registry(List(step))
+      assertZIO(reg.resolveTemplateColumns(StepType.GivenStep, "balance is 100").either)(
+        isLeft(isSubtype[NoMatchingTemplate](anything))
+      )
+    },
+    test("no structurally matching StepDef fails with NoMatchingTemplate") {
+      val step = makeStep(StepType.GivenStep, StepExpression(List(Literal("balance is "), Extractor(int))))
+      val reg  = registry(List(step))
+      assertZIO(reg.resolveTemplateColumns(StepType.GivenStep, "completely unrelated <col>").either)(
+        isLeft(isSubtype[NoMatchingTemplate](anything))
+      )
+    },
+    test("two structurally identical StepDefs with different extractor types are ambiguous") {
+      // Same literal skeleton and extractor count — structural matching can't see that one
+      // extractor produces Int and the other Long, since the placeholder has no real value yet.
+      val intStep  = makeStep(StepType.GivenStep, StepExpression(List(Literal("amount is "), Extractor(int))))
+      val longStep = makeStep(StepType.GivenStep, StepExpression(List(Literal("amount is "), Extractor(long))))
+      val reg      = registry(List(intStep, longStep))
+      assertZIO(reg.resolveTemplateColumns(StepType.GivenStep, "amount is <amount>").either)(
+        isLeft(isSubtype[AmbiguousTemplate](anything))
+      )
+    },
+    test("AmbiguousTemplate error lists both structurally matching pattern descriptions") {
+      val intStep  = makeStep(StepType.GivenStep, StepExpression(List(Literal("amount is "), Extractor(int))))
+      val longStep = makeStep(StepType.GivenStep, StepExpression(List(Literal("amount is "), Extractor(long))))
+      val reg      = registry(List(intStep, longStep))
+      for {
+        err <- reg.resolveTemplateColumns(StepType.GivenStep, "amount is <amount>").either
+      } yield err match {
+        case Left(AmbiguousTemplate(_, _, patterns)) => assertTrue(patterns.length == 2)
+        case _                                       => assertTrue(false)
+      }
+    },
+    test("disambiguation prefers the structurally matching StepDef with fewest extractors") {
+      // "exact balance" (0 extractors) is more specific than "balance is <col>" (1 extractor);
+      // only the literal one structurally matches a no-placeholder template, so no ambiguity.
+      val literalStep = makeStep(StepType.GivenStep, StepExpression(List(Literal("exact balance"))))
+      val genericStep = makeStep(StepType.GivenStep, StepExpression(List(Literal("balance is "), Extractor(int))))
+      val reg         = registry(List(literalStep, genericStep))
+      assertZIO(reg.resolveTemplateColumns(StepType.GivenStep, "exact balance"))(equalTo(Nil))
+    },
+    test("falls back to And steps when the exact keyword has no structural match") {
+      val andStep = makeStep(StepType.AndStep, StepExpression(List(Literal("role is "), Extractor(string))))
+      val reg     = registry(List(andStep))
+      assertZIO(reg.resolveTemplateColumns(StepType.ThenStep, "role is <role>"))(
+        equalTo(List("role" -> Tag[String]))
+      )
+    }
+  )
+
+  def spec: Spec[TestEnvironment, Any] = suite("Template structural matching (#97)")(
+    exprLevel,
+    registryLevel
+  )
+}

--- a/core/src/test/scala/zio/bdd/core/step/TemplateStructuralMatchSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/step/TemplateStructuralMatchSpec.scala
@@ -55,6 +55,26 @@ object TemplateStructuralMatchSpec extends ZIOSpecDefault with DefaultTypedExtra
       val expr = StepExpression(List(Literal("amount "), Extractor(int), Literal(" exactly")))
       assertTrue(expr.structuralMatch("amount <amount> exactly").contains(List("amount" -> Tag[Int])))
       assertTrue(expr.structuralMatch("amount <amount> roughly").isEmpty)
+    },
+    test("the same column name repeated with the same extractor type yields both occurrences in order") {
+      val expr = StepExpression(
+        List(Literal("transfer "), Extractor(int), Literal(" to cover a fee of "), Extractor(int))
+      )
+      assertTrue(
+        expr
+          .structuralMatch("transfer <amount> to cover a fee of <amount>")
+          .contains(List("amount" -> Tag[Int], "amount" -> Tag[Int]))
+      )
+    },
+    test("the same column name repeated with different extractor types still structurally aligns") {
+      // structuralMatch is purely positional — it doesn't judge type consistency across
+      // occurrences of the same name. StepRegistry.resolveTemplateColumns is what rejects this.
+      val expr = StepExpression(List(Literal("from "), Extractor(int), Literal(" to "), Extractor(string)))
+      assertTrue(
+        expr
+          .structuralMatch("from <amount> to <amount>")
+          .contains(List("amount" -> Tag[Int], "amount" -> Tag[String]))
+      )
     }
   )
 
@@ -132,11 +152,72 @@ object TemplateStructuralMatchSpec extends ZIOSpecDefault with DefaultTypedExtra
       assertZIO(reg.resolveTemplateColumns(StepType.ThenStep, "role is <role>"))(
         equalTo(List("role" -> Tag[String]))
       )
+    },
+    test("the same column governed by two different extractor types fails with ConflictingColumnType") {
+      val step = makeStep(
+        StepType.GivenStep,
+        StepExpression(List(Literal("from "), Extractor(int), Literal(" to "), Extractor(string)))
+      )
+      val reg = registry(List(step))
+      assertZIO(reg.resolveTemplateColumns(StepType.GivenStep, "from <amount> to <amount>").either)(
+        isLeft(isSubtype[ConflictingColumnType](anything))
+      )
+    },
+    test("the same column repeated with the same extractor type succeeds with both occurrences") {
+      val step = makeStep(
+        StepType.GivenStep,
+        StepExpression(List(Literal("transfer "), Extractor(int), Literal(" twice as "), Extractor(int)))
+      )
+      val reg = registry(List(step))
+      assertZIO(reg.resolveTemplateColumns(StepType.GivenStep, "transfer <amount> twice as <amount>"))(
+        equalTo(List("amount" -> Tag[Int], "amount" -> Tag[Int]))
+      )
+    }
+  )
+
+  // ── Concurrency: a StepRegistryLive is immutable after construction, so resolving
+  // many templates against the same registry from parallel fibers must be as safe as
+  // findStep already is — this is the lookup #98/#99 will call once per scenario, and
+  // scenarios run under featureParallelism/scenarioParallelism (see ConcurrencySpec).
+
+  private val concurrencySuite = suite("concurrent resolution")(
+    test("200 concurrent resolveTemplateColumns calls on the same registry all return the same result") {
+      val step = makeStep(
+        StepType.GivenStep,
+        StepExpression(List(Literal("balance "), Extractor(int), Literal(" limit "), Extractor(long)))
+      )
+      val reg      = registry(List(step))
+      val expected = List("balance" -> Tag[Int], "limit" -> Tag[Long])
+      for {
+        results <- ZIO.foreachPar((1 to 200).toList)(_ =>
+                     reg.resolveTemplateColumns(StepType.GivenStep, "balance <balance> limit <limit>")
+                   )
+      } yield assertTrue(results.forall(_ == expected))
+    },
+    test("concurrent calls resolving different templates against a shared registry don't cross-contaminate") {
+      val balanceStep = makeStep(StepType.GivenStep, StepExpression(List(Literal("balance "), Extractor(int))))
+      val nameStep    = makeStep(StepType.GivenStep, StepExpression(List(Literal("name "), Extractor(string))))
+      val reg         = registry(List(balanceStep, nameStep))
+      for {
+        results <- ZIO.foreachPar((1 to 100).toList) { i =>
+                     if (i % 2 == 0)
+                       reg.resolveTemplateColumns(StepType.GivenStep, "balance <amount>").map(_ -> "balance")
+                     else
+                       reg.resolveTemplateColumns(StepType.GivenStep, "name <who>").map(_ -> "name")
+                   }
+      } yield assertTrue(
+        results.forall {
+          case (cols, "balance") => cols == List("amount" -> Tag[Int])
+          case (cols, "name")    => cols == List("who" -> Tag[String])
+          case _                 => false
+        }
+      )
     }
   )
 
   def spec: Spec[TestEnvironment, Any] = suite("Template structural matching (#97)")(
     exprLevel,
-    registryLevel
+    registryLevel,
+    concurrencySuite
   )
 }


### PR DESCRIPTION
## Summary
- Adds `StepExpression.structuralMatch(template)`: aligns a `@property` step template (which still has `<col>` placeholders, e.g. "an account with balance <balance>") against a `StepExpression`'s `parts` positionally — literal segments must match exactly, extractor positions just need a placeholder, without requiring the placeholder text to satisfy the extractor's value-conformance regex (there's no real value yet). Returns the ordered `(columnName, Tag[_])` pairs, using the `Tag` added in #96.
- Adds `StepRegistry.resolveTemplateColumns(stepType, template)`, which runs the structural matcher across the registered `StepDef`s for a keyword, reusing the same And-step/cross-keyword fallback chain as `findStep`, and the same fewest-extractors specificity heuristic to disambiguate multiple structural matches.
- New `NoMatchingTemplate`/`AmbiguousTemplate` errors mirror the existing `NoMatchingStep`/`AmbiguousStep`, including a documented choice: when two StepDefs are structurally identical (same literal skeleton, same extractor count) but differ only in extractor *type* (e.g. one captures `int`, the other `long`), structural matching can't tell them apart — it's reported as ambiguous rather than silently picking one.
- Adds a MiMa filter for the new `StepRegistry` method.

Depends on #96 (merged via #100). Prerequisite for #98/#99 (HasGen registry + PropertyExecutor wiring) — out of scope here.

## Test plan
- [x] New spec `TemplateStructuralMatchSpec` (15 tests): single-placeholder, multi-placeholder, no-placeholder ("should not apply"), structurally ambiguous templates, fewest-extractors disambiguation, And-step fallback.
- [x] `sbt scalafmtCheckAll`
- [x] `sbt compile`
- [x] `sbt test` (449 tests passed on master)
- [x] `sbt mimaReportBinaryIssues` (clean with the added filter)