### PR TITLE
Expose extractor patterns and regex-building as public API

### DIFF
--- a/core/src/main/scala/zio/bdd/core/step/StepExpression.scala
+++ b/core/src/main/scala/zio/bdd/core/step/StepExpression.scala
@@ -15,11 +15,7 @@ case class Extractor[T](extractor: TypedExtractor[T]) extends StepPart
 case class StepExpression[Out <: Tuple](parts: List[StepPart]) {
 
   // Compiled once on first use, not on every extract() call (r08 perf fix)
-  private lazy val compiledPattern: Pattern =
-    parts.map {
-      case Literal(s)   => Pattern.quote(s)
-      case Extractor(e) => e.pattern
-    }.mkString.r.pattern
+  private lazy val compiledPattern: Pattern = StepExpression.toPattern(parts).r.pattern
 
   /**
    * Structural match against a `@property` step template that still has `<col>`
@@ -77,6 +73,18 @@ case class StepExpression[Out <: Tuple](parts: List[StepPart]) {
 }
 
 object StepExpression {
+
+  /**
+   * Builds the regex source a `StepExpression` made of `parts` matches against,
+   * without requiring a `StepExpression` instance. Pulled out so external
+   * tooling (e.g. an LSP scanning source for step definitions) can derive the
+   * same regex zio-bdd uses at runtime instead of re-deriving its own.
+   */
+  def toPattern(parts: List[StepPart]): String =
+    parts.map {
+      case Literal(s)   => Pattern.quote(s)
+      case Extractor(e) => e.pattern
+    }.mkString
 
   private val placeholderRe = "<([^>]+)>".r
 

--- a/core/src/main/scala/zio/bdd/core/step/TypedExtractors.scala
+++ b/core/src/main/scala/zio/bdd/core/step/TypedExtractors.scala
@@ -248,6 +248,30 @@ trait DefaultTypedExtractor {
 }
 
 /**
+ * Singleton instance of the built-in extractors, keyed by the name they're
+ * referenced by in step-expression source (`Given("..." / int / "...")`).
+ *
+ * Lets external tooling (e.g. an LSP that statically scans `.scala` source for
+ * step definitions) look up the *real* regex a built-in extractor uses instead
+ * of hand-copying it, which would silently drift out of sync if this file
+ * changes a pattern.
+ */
+object DefaultTypedExtractor extends DefaultTypedExtractor {
+  val byName: Map[String, TypedExtractor[?]] = Map(
+    "string"     -> string,
+    "word"       -> word,
+    "rest"       -> rest,
+    "int"        -> int,
+    "long"       -> long,
+    "double"     -> double,
+    "bigDecimal" -> bigDecimal,
+    "boolean"    -> boolean,
+    "uuid"       -> uuid,
+    "docString"  -> docString
+  )
+}
+
+/**
  * Typed extractor for data tables. Uses Schema to map header row to case-class
  * fields.
  *

--- a/core/src/test/scala/zio/bdd/core/step/StepExpressionSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/step/StepExpressionSpec.scala
@@ -65,6 +65,32 @@ object StepExpressionSpec extends ZIOSpecDefault with DefaultTypedExtractor {
     }
   )
 
+  private val toPatternHelper = suite("StepExpression.toPattern")(
+    test("builds the same regex source the instance compiles internally") {
+      val parts   = List(Literal("age is "), Extractor(int))
+      val pattern = StepExpression.toPattern(parts)
+      assertTrue(pattern == "\\Qage is \\E(-?\\d+)")
+    },
+    test("matches the same inputs as extracting through a StepExpression instance") {
+      val parts   = List(Literal("count "), Extractor(double))
+      val pattern = StepExpression.toPattern(parts).r
+      val expr    = StepExpression[Tuple1[Double]](parts)
+      assertTrue(
+        pattern.matches("count 9.99"),
+        expr.extract(si("count 9.99")).isDefined
+      )
+    },
+    test("DefaultTypedExtractor.byName exposes the real built-in patterns, not a hand-copy") {
+      assertTrue(
+        DefaultTypedExtractor.byName("double").pattern == double.pattern,
+        DefaultTypedExtractor.byName("int").pattern == int.pattern,
+        DefaultTypedExtractor.byName("string").pattern == string.pattern,
+        DefaultTypedExtractor.byName("boolean").pattern == boolean.pattern,
+        DefaultTypedExtractor.byName("uuid").pattern == uuid.pattern
+      )
+    }
+  )
+
   private val regexCaching = suite("Regex is compiled once (lazy val)")(
     test("calling extract 1000 times completes without recompiling the regex") {
       val expr  = StepExpression[Tuple1[String]](List(Literal("step "), Extractor(string)))
@@ -210,6 +236,7 @@ object StepExpressionSpec extends ZIOSpecDefault with DefaultTypedExtractor {
 
   def spec: Spec[TestEnvironment & Scope, Any] = suite("StepExpression")(
     patternMatching,
+    toPatternHelper,
     regexCaching,
     stepDef,
     dslIntegration,


### PR DESCRIPTION
## Summary

Prerequisite for #93 (IDE/editor tooling RFC). External tooling — e.g. an LSP that statically scans `.scala` source for step definitions instead of running the compiled test suite — needs the *real* regex an extractor or step expression uses, rather than hand-copying it into its own table. A hand-copy can silently drift: reviewing a draft LSP implementation surfaced exactly this, where its `double` extractor regex didn't match `DefaultTypedExtractor.double`'s real pattern.

- `StepExpression.toPattern(parts: List[StepPart]): String` — pulls the regex-building logic already inlined in `compiledPattern` into a pure, public helper.
- `DefaultTypedExtractor.byName: Map[String, TypedExtractor[?]]` — exposes the built-in extractor instances keyed by the name they're referenced by in step-expression source (`int`, `string`, `double`, …), so callers can ask core for the real pattern instead of re-deriving it.

Both are additive; no MiMa filters required.

## Test plan

- [x] `sbt scalafmtCheckAll` — passes
- [x] `sbt mimaReportBinaryIssues` — no issues
- [x] `sbt test` — all passing, including new `StepExpressionSpec` cases asserting `toPattern`'s output and that `DefaultTypedExtractor.byName` patterns equal the real extractor `val`s