### PR TITLE
Clarify generateStepRegistry/zioBddSnippets scope; no new sbt plugin needed (#104)

### DIFF
--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -181,9 +181,13 @@ Feature file:
 Given a post dated -7 days relative to current date
 ```
 
-If the step text already exists in the feature file, run `sbt zioBddSnippets` to get a
-skeleton. Run `sbt "testOnly MySuite -- --dry-run"` to confirm all feature file steps
-match registered definitions without executing them.
+If the step text already exists in the feature file, the
+[zio-bdd-tooling](https://github.com/EtaCassiopeia/zio-bdd-tooling) LSP/editor extensions
+surface a skeleton live as a completion item the moment you start typing inside a
+`Given`/`When`/`Then(...)` call. `sbt zioBddSnippets` does the same from the command line, but
+only inside this repository's own build (see `docs/running.md`). Run
+`sbt "testOnly MySuite -- --dry-run"` to confirm all feature file steps match registered
+definitions without executing them.
 
 ---
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -346,10 +346,32 @@ When("a very slow operation completes") {
 ---
 
 
-## IDE integration: generateStepRegistry
+## IDE integration
 
-The `generateStepRegistry` sbt task produces a `step-registry.json` file that IDE plugins
-can use to navigate from `.feature` file steps to their Scala definitions.
+**For a live editing experience** (go-to-definition, hover, autocomplete, real-time
+"no matching step" diagnostics with a closest-match hint, and a code lens to run a
+scenario/feature) — install the LSP server, VSCode extension, or IntelliJ plugin from
+[zio-bdd-tooling](https://github.com/EtaCassiopeia/zio-bdd-tooling). It scans `.scala`/
+`.feature` source text directly and needs no build step or registry file.
+
+The two sbt tasks below (`generateStepRegistry`, `zioBddSnippets`) predate that tooling and
+serve a narrower, different purpose — read on only if you specifically need one of them.
+
+### generateStepRegistry — interop with *other* Cucumber IDE plugins
+
+> **Scope note:** `generateStepRegistry` is defined by an sbt auto-plugin in *this
+> repository's own build* (`project/StepRegistryPlugin.scala`), not by the published
+> `io.github.etacassiopeia:zio-bdd` artifact. A project that only adds zio-bdd as a library
+> dependency does not get this task — running it fails with "not a valid command". It's
+> usable today if you're working inside a clone of this repository, or if you copy
+> `StepRegistryPlugin.scala` into your own `project/` directory. See
+> [zio-bdd#104](https://github.com/EtaCassiopeia/zio-bdd/issues/104) if you'd find a
+> published, `addSbtPlugin`-installable version of this task valuable.
+
+The `generateStepRegistry` sbt task produces a `step-registry.json` file that *generic*
+Cucumber-ecosystem IDE plugins (the VS Code Cucumber extension, IntelliJ's built-in Cucumber
+support) can use for step navigation — it is not consumed by zio-bdd-tooling's own LSP, which
+resolves steps itself from live source text and needs no intermediate file.
 
 ```sh
 sbt generateStepRegistry
@@ -397,6 +419,13 @@ Regenerate after adding or renaming step definitions to keep the registry curren
 ---
 
 ## zioBddSnippets task
+
+> **Scope note:** same caveat as `generateStepRegistry` above — `zioBddSnippets` is defined
+> in this repository's own build (`project/SnippetGeneratorPlugin.scala`), not published for
+> consumers of the library. If you're using zio-bdd-tooling's LSP/VSCode/IntelliJ extension,
+> you don't need this task at all: opening a step-definition `.scala` file and typing inside a
+> `Given`/`When`/`Then(...)` call already surfaces a completion item for any unmatched step
+> text found in your `.feature` files, live, with no command to run.
 
 The `zioBddSnippets` sbt task scans feature files for steps that do not appear to have a
 matching step definition and prints skeleton code to stdout.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -159,7 +159,12 @@ FAILED: Given a valid provision request dated -7 days
 4. The step definition uses an extractor pattern that does not match the actual text.
 
 **Fix:** Run `sbt "testOnly MySuite -- --dry-run"` to see all unmatched steps at once.
-Run `sbt zioBddSnippets` to generate skeleton definitions for unmatched steps.
+If you're working inside this repository (or have vendored `SnippetGeneratorPlugin.scala`
+into your own `project/` — see `docs/running.md`'s "zioBddSnippets task" for why it isn't
+available otherwise), `sbt zioBddSnippets` prints a skeleton for each unmatched step. With the
+[zio-bdd-tooling](https://github.com/EtaCassiopeia/zio-bdd-tooling) LSP/editor extensions
+installed, the same skeleton appears live as a completion item the moment you start typing
+inside a `Given`/`When`/`Then(...)` call.
 
 ---
 


### PR DESCRIPTION
## Summary

Addresses #104. Investigated whether zio-bdd-tooling's LSP needs `generateStepRegistry`/`zioBddSnippets` published as a real, `addSbtPlugin`-installable sbt plugin (issue's Option 1) to support live step discovery — confirmed it doesn't:

- `zio-bdd-tooling`'s LSP/VSCode/IntelliJ extensions resolve steps via their own real-time source-text scan (`StepExtractor`, `WorkspaceIndex`) — no `step-registry.json`, no sbt invocation, no coupling to either task at all.
- `generateStepRegistry`'s actual intended audience (per its own doc comment) is *other*, generic Cucumber-ecosystem IDE plugins (VS Code Cucumber extension, IntelliJ's built-in Cucumber support) — not our own tooling.
- `zioBddSnippets`'s skeleton-generation use case is already covered, live, by `CompletionHandler.unimplementedStepCompletion` in the LSP.

So there's no functional reason to invest in publishing a plugin (Option 1) — the actual problem is that the docs (and zio-bdd-tooling's diagnostic/command text) presented these as available to any zio-bdd consumer, when both are sbt auto-plugins defined in *this repository's own* `project/*.scala`, not part of the published library artifact. This PR implements Option 2: scope the docs accurately and point users at the actually-working live tooling.

- `docs/running.md`: rewrote the "IDE integration" section — recommends zio-bdd-tooling as the live-editing path, adds a scope note to both tasks explaining they're build-local to this repo, clarifies `generateStepRegistry`'s real audience.
- `docs/troubleshooting.md`, `docs/cookbook.md`: softened the "run `sbt zioBddSnippets`" advice with the same scope caveat and a pointer to the LSP's live completion alternative.

Companion change in [zio-bdd-tooling](https://github.com/EtaCassiopeia/zio-bdd-tooling) (separate PR): removes the `zio-bdd.generateRegistry` VSCode command (it shelled out to `sbt generateStepRegistry`, which fails outside this repo) and replaces `DiagnosticsHandler`'s "Run sbt zioBddSnippets" hint with a pointer to the LSP's own completion-based skeleton suggestion.

Also corrects a mischaracterization from when I originally filed #104: `StepGeneratorPlugin` (mentioned in the issue's Option 1 alongside the other two) is unrelated — it's purely internal codegen producing `GeneratedStepMethods`, which ships *already compiled* inside the published `zio-bdd` jar. Consumers get it automatically; it was never part of this gap. Left issue #104 open with a comment to that effect rather than re-editing the original report.

## Test plan

- [x] `sbt scalafmtCheckAll` — passes (docs-only change, no code touched)
- [x] `sbt test` — 497 passed, 0 failed