### PR TITLE
Expose allDefinitions on ZIOSteps for BSP class-loading

### DIFF
--- a/core/src/main/scala/zio/bdd/core/step/StepSummary.scala
+++ b/core/src/main/scala/zio/bdd/core/step/StepSummary.scala
@@ -12,6 +12,7 @@ package zio.bdd.core.step
  *   at runtime, so extractor types are correctly reflected (e.g. a `/ int /`
  *   extractor produces `\-?\d+` rather than the literal string "int").
  * @param displayText
- *   Human-readable representation for UI (e.g. `"the cart has " / int / " items"`).
+ *   Human-readable representation for UI (e.g. `"the cart has " / int / "
+ *   items"`).
  */
 case class StepSummary(keyword: String, pattern: String, displayText: String)

--- a/core/src/main/scala/zio/bdd/core/step/StepSummary.scala
+++ b/core/src/main/scala/zio/bdd/core/step/StepSummary.scala
@@ -1,0 +1,17 @@
+package zio.bdd.core.step
+
+/**
+ * A runtime-accurate summary of a registered step definition, produced by
+ * `ZIOSteps.allDefinitions`. Consumed by external tooling (LSP server, IntelliJ
+ * plugin) to populate accurate step indexes without static source scanning.
+ *
+ * @param keyword
+ *   BDD keyword (Given, When, Then, And, But)
+ * @param pattern
+ *   The full regex the step matches against — same pattern `StepRegistry` uses
+ *   at runtime, so extractor types are correctly reflected (e.g. a `/ int /`
+ *   extractor produces `\-?\d+` rather than the literal string "int").
+ * @param displayText
+ *   Human-readable representation for UI (e.g. `"the cart has " / int / " items"`).
+ */
+case class StepSummary(keyword: String, pattern: String, displayText: String)

--- a/core/src/main/scala/zio/bdd/core/step/ZIOSteps.scala
+++ b/core/src/main/scala/zio/bdd/core/step/ZIOSteps.scala
@@ -581,4 +581,28 @@ trait ZIOSteps[R: Tag, S: Tag: Default]
       dryRun,
       genLookup = columnGenLookup
     )
+
+  /**
+   * Returns a runtime-accurate summary of every registered step definition.
+   *
+   * Unlike `getSteps` this does NOT seal the registry or run ambiguity
+   * validation — it is safe to call from external tooling (e.g. the
+   * zio-bdd LSP server's BSP class-loader subprocess) at any point after
+   * the object initializer has run.
+   *
+   * The `pattern` field carries the exact regex used by `StepRegistry` at
+   * runtime, so extractor-based steps (e.g. `/ int /`, `/ string /`) are
+   * represented faithfully rather than as static-scan approximations.
+   */
+  def allDefinitions: List[StepSummary] =
+    steps.toList.collect { case s: StepDefImpl[?, ?, ?] =>
+      val keyword = s.stepType match {
+        case zio.bdd.gherkin.StepType.GivenStep => "Given"
+        case zio.bdd.gherkin.StepType.WhenStep  => "When"
+        case zio.bdd.gherkin.StepType.ThenStep  => "Then"
+        case zio.bdd.gherkin.StepType.AndStep   => "And"
+        case zio.bdd.gherkin.StepType.ButStep   => "But"
+      }
+      StepSummary(keyword, StepExpression.toPattern(s.stepExpr.parts), s.stepExpr.toString)
+    }
 }

--- a/core/src/main/scala/zio/bdd/core/step/ZIOSteps.scala
+++ b/core/src/main/scala/zio/bdd/core/step/ZIOSteps.scala
@@ -586,9 +586,9 @@ trait ZIOSteps[R: Tag, S: Tag: Default]
    * Returns a runtime-accurate summary of every registered step definition.
    *
    * Unlike `getSteps` this does NOT seal the registry or run ambiguity
-   * validation — it is safe to call from external tooling (e.g. the
-   * zio-bdd LSP server's BSP class-loader subprocess) at any point after
-   * the object initializer has run.
+   * validation — it is safe to call from external tooling (e.g. the zio-bdd LSP
+   * server's BSP class-loader subprocess) at any point after the object
+   * initializer has run.
    *
    * The `pattern` field carries the exact regex used by `StepRegistry` at
    * runtime, so extractor-based steps (e.g. `/ int /`, `/ string /`) are


### PR DESCRIPTION
## Summary

- Adds `StepSummary(keyword, pattern, displayText)` to the `step` package
- Adds `ZIOSteps.allDefinitions: List[StepSummary]` — reads directly from the mutable step buffer without sealing the registry or running ambiguity validation
- `pattern` carries the exact regex used by `StepRegistry` at runtime, so `/ int /` and other typed extractors are faithfully represented

## Why

`zio-bdd-tooling` issue #2 (BSP class-loading): the LSP server will launch a subprocess on the user's test classpath that finds `ZIOSteps` subclasses via ClassGraph, calls `allDefinitions` reflectively, and serialises the result to JSON. This replaces static-scan approximations (e.g. `<IntExtractor>`) with the actual regex patterns the runtime uses for matching.

## Test plan

- [x] `sbt core/compile` — no warnings
- [x] `sbt core/test` — all 497 tests pass, no regressions
