### PR TITLE
feat: MockControl port + canonical model

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val mimaSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .aggregate(core, gherkin)
+  .aggregate(core, gherkin, mock)
   .settings(
     name                  := "zio-bdd-root",
     description           := "A ZIO-based BDD testing framework for Scala 3",
@@ -123,6 +123,17 @@ lazy val gherkin = (project in file("gherkin"))
     name := "zio-bdd-gherkin",
     libraryDependencies ++= commonDependencies,
     mimaSettings
+  )
+
+// Portable MockControl SPI (#110). Standalone, backend-neutral: no dependency on
+// any adapter (Rift, WireMock) — adapters depend on this module, never the reverse.
+lazy val mock = (project in file("mock"))
+  .settings(
+    name := "zio-bdd-mock",
+    libraryDependencies ++= commonDependencies,
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
+    mimaPreviousArtifacts := Set.empty
   )
 
 lazy val example = (project in file("example"))

--- a/mock/src/main/scala/zio/bdd/mock/Capability.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Capability.scala
@@ -1,0 +1,55 @@
+package zio.bdd.mock
+
+/**
+ * Optional capabilities an adapter MAY implement beyond the total core port. An
+ * adapter advertises a capability via [[MockControl.capabilities]]; for each
+ * advertised capability its typed accessor returns an instance, and for each
+ * un-advertised one the accessor fails fast with [[Unsupported]].
+ */
+enum Capability:
+  case Faults, StatefulScenarios, StateInspection, Scripting, ProxyRecord, Templating
+
+/**
+ * How a backend keeps mock spaces isolated under parallel features/scenarios.
+ *   - PerInstance: a unique base URI per space (e.g. Rift's own port).
+ *   - Correlated: a shared base URI partitioned by a correlation header (e.g.
+ *     WireMock).
+ *
+ * Marker type only at this stage; the per-adapter behaviour lands with the
+ * isolation model in M2 (#123).
+ */
+enum Isolation:
+  case PerInstance, Correlated
+
+// Capability interfaces returned by the typed accessors on [[MockControl]].
+// Empty markers here — their operations are fleshed out in M3 (#128/#129/#132).
+
+/**
+ * Fault injection (latency, errors, connection resets). Capability:
+ * [[Capability.Faults]].
+ */
+trait Faults
+
+/**
+ * Single-state-token FSM per scenario. Capability:
+ * [[Capability.StatefulScenarios]].
+ */
+trait StatefulScenarios
+
+/**
+ * Arrange/assert scenario state without driving requests. Capability:
+ * [[Capability.StateInspection]].
+ */
+trait StateInspection
+
+/** Backend scripting hooks. Capability: [[Capability.Scripting]]. */
+trait Scripting
+
+/**
+ * Proxy/record passthrough to a real upstream. Capability:
+ * [[Capability.ProxyRecord]].
+ */
+trait ProxyRecord
+
+/** Response templating. Capability: [[Capability.Templating]]. */
+trait Templating

--- a/mock/src/main/scala/zio/bdd/mock/MockControl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockControl.scala
@@ -1,0 +1,74 @@
+package zio.bdd.mock
+
+import zio.IO
+
+/**
+ * Where mock definitions come from. A placeholder marker at this stage — the
+ * DSL builders and raw/file/resource/dir entry points land in #111. Everything
+ * normalises to the canonical model before it reaches [[MockControl]].
+ */
+trait MockSource
+
+/**
+ * Type-level tag for a concrete backend, used to pin a [[NativeSpec]] to one
+ * provider. Concrete backends (Rift, WireMock) define their own marker; the
+ * native escape hatch is fleshed out in #119.
+ */
+trait Backend
+
+/**
+ * A backend-specific provisioning payload — the escape hatch that trades
+ * portability for full access to one backend. Fleshed out in #119.
+ */
+trait NativeSpec[B <: Backend]
+
+/**
+ * The total core port every adapter MUST implement. This is the hinge of the
+ * portable mocking feature (#109): steps, fixtures, overlays and the
+ * conformance suite all program against this interface, never against a
+ * concrete backend.
+ *
+ * Errors are values: the core operations fail with the typed [[MockError]] and
+ * the capability accessors with the typed [[Unsupported]] — no `Throwable`
+ * leaks into these signatures.
+ */
+trait MockControl:
+
+  /** The optional capabilities this adapter advertises. */
+  def capabilities: Set[Capability]
+
+  /** Stand up one or more mock spaces from a portable source. */
+  def provision(source: MockSource): IO[MockError, List[MockSpace]]
+
+  /**
+   * Stand up mock spaces from a backend-specific native spec (escape hatch).
+   */
+  def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]]
+
+  /**
+   * Add a rule to a space, returning its id. Overlay rules sit above base
+   * rules.
+   */
+  def addRule(space: MockSpace, rule: MockRule, priority: Priority = Priority.Overlay): IO[MockError, RuleId]
+
+  /** Remove a single rule from a space. */
+  def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit]
+
+  /** Replace all rules of a space with the given set. */
+  def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit]
+
+  /** Tear down exactly this space — never a global reset. */
+  def destroy(space: MockSpace): IO[MockError, Unit]
+
+  /** The requests this space recorded, for assertions. */
+  def received(space: MockSpace): IO[MockError, List[RecordedRequest]]
+
+  // Typed capability accessors. Each returns an instance when the capability is
+  // advertised, or fails fast with `Unsupported` (naming the gap and backend).
+
+  def faults: IO[Unsupported, Faults]
+  def scenarios: IO[Unsupported, StatefulScenarios]
+  def stateInspection: IO[Unsupported, StateInspection]
+  def scripting: IO[Unsupported, Scripting]
+  def proxyRecord: IO[Unsupported, ProxyRecord]
+  def templating: IO[Unsupported, Templating]

--- a/mock/src/main/scala/zio/bdd/mock/MockError.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockError.scala
@@ -1,0 +1,23 @@
+package zio.bdd.mock
+
+/**
+ * Typed failures of the MockControl core port. Deliberately *not* a `Throwable`
+ * subtype: the port keeps `Throwable` out of its public signatures, surfacing
+ * backend failures as values an adapter normalises a cause into (as text).
+ */
+enum MockError:
+  case ProvisionFailed(reason: String)
+  case SpaceNotFound(space: SpaceId)
+  case RuleNotFound(space: SpaceId, rule: RuleId)
+  case InvalidDefinition(reason: String)
+  case CommunicationError(reason: String)
+
+/**
+ * Typed failure of a capability accessor when the backend does not advertise
+ * the capability. Names both the gap and the backend. Not a `Throwable`: the
+ * capability accessors expose it as the narrow error channel `IO[Unsupported,
+ * _]`.
+ */
+final case class Unsupported(capability: Capability, backend: String):
+  def message: String =
+    s"Capability $capability is not supported by backend '$backend'"

--- a/mock/src/main/scala/zio/bdd/mock/model.scala
+++ b/mock/src/main/scala/zio/bdd/mock/model.scala
@@ -1,0 +1,124 @@
+package zio.bdd.mock
+
+import zio.Duration
+
+/**
+ * Backend-neutral canonical model for the portable MockControl SPI (#110).
+ *
+ * Every adapter (Rift, WireMock, …) normalises its own wire format to these
+ * types, so Gherkin steps, hooks, overlays and assertions stay backend-neutral.
+ * All types here are immutable value types — case classes and enums.
+ */
+
+/** HTTP method a rule matches or a recorded request used. */
+enum Method:
+  case Get, Post, Put, Delete, Patch, Head, Options, Trace, Connect
+
+/** How a request path is matched. The default is [[PathMatch.Any]]. */
+enum PathMatch:
+  case Any
+  case Exact(path: String)
+  case Regex(pattern: String)
+  case Template(template: String) // e.g. "/users/{id}"
+
+/** How a single scalar value (query param or header) is matched. */
+enum ValueMatch:
+  case Equals(value: String)
+  case Contains(value: String)
+  case Matches(regex: String)
+
+/** How a request body is matched. */
+enum BodyMatch:
+  case Equals(value: String)
+  case Contains(value: String)
+  case Matches(regex: String)
+  case JsonPath(path: String, expected: Option[String] = None)
+  case XPath(path: String, expected: Option[String] = None)
+
+/**
+ * A response body payload. Covers Text | Json | Base64 (plus the empty body).
+ */
+enum Body:
+  case Empty
+  case Text(value: String)
+  case Json(value: String)
+  case Base64(value: String)
+
+/** Ordering bucket for a rule: overlay rules sit above base rules. */
+enum Priority:
+  case Base, Overlay
+
+/** Opaque identifier for a rule within a [[MockSpace]]. */
+opaque type RuleId = String
+object RuleId:
+  def apply(value: String): RuleId         = value
+  extension (id: RuleId) def value: String = id
+
+/** Opaque identifier for a [[MockSpace]] (the unit of isolation). */
+opaque type SpaceId = String
+object SpaceId:
+  def apply(value: String): SpaceId         = value
+  extension (id: SpaceId) def value: String = id
+
+/**
+ * Portable HTTP request the SUT issues. [[MockSpace.inject]] decorates it (e.g.
+ * rewriting the base URI or adding a correlation header) so a mock space can be
+ * reached under share-nothing isolation. SUT-side wiring lands in #117.
+ */
+final case class HttpRequest(
+  method: Method,
+  uri: String,
+  headers: Map[String, String] = Map.empty,
+  body: Option[String] = None
+)
+
+/**
+ * A request the backend recorded, used to assert what the SUT actually sent.
+ */
+final case class RecordedRequest(
+  method: Method,
+  uri: String,
+  headers: Map[String, String] = Map.empty,
+  body: Option[String] = None
+)
+
+/**
+ * What to match on an incoming request. Every field is optional/permissive by
+ * default.
+ */
+final case class RequestMatch(
+  method: Option[Method] = None,
+  path: PathMatch = PathMatch.Any,
+  query: Map[String, ValueMatch] = Map.empty,
+  headers: Map[String, ValueMatch] = Map.empty,
+  body: Option[BodyMatch] = None
+)
+
+/** The response a matched rule serves. */
+final case class ResponseDef(
+  status: Int = 200,
+  headers: Map[String, String] = Map.empty,
+  body: Body = Body.Empty,
+  delay: Option[Duration] = None
+)
+
+/** A single stub: when a request matches, respond accordingly. */
+final case class MockRule(
+  `match`: RequestMatch,
+  respond: ResponseDef,
+  id: Option[RuleId] = None
+)
+
+/**
+ * The unit of isolation. Hides *how* isolation is achieved:
+ *   - PerInstance: a unique `baseUri` per space; `inject = identity`.
+ *   - Correlated: a shared `baseUri`; `inject` stamps a correlation header.
+ *
+ * The SUT must target `baseUri` AND apply `inject` so the correlation rides
+ * along. Isolation invariants and SUT wiring land in #117.
+ */
+final case class MockSpace(
+  baseUri: String,
+  inject: HttpRequest => HttpRequest,
+  id: SpaceId
+)

--- a/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
@@ -1,0 +1,137 @@
+package zio.bdd.mock
+
+import zio.*
+import zio.test.*
+
+object MockControlModelSpec extends ZIOSpecDefault:
+
+  // A minimal in-spec adapter that implements the *total* core port. Its mere
+  // existence proves `MockControl` is implementable end-to-end with no adapter
+  // dependency (AC1); it also exercises the capability fail-fast contract (AC4).
+  private final case class StubMockControl(backend: String, caps: Set[Capability]) extends MockControl:
+    def capabilities: Set[Capability] = caps
+
+    def provision(source: MockSource): IO[MockError, List[MockSpace]] =
+      ZIO.succeed(List(MockSpace("http://localhost:0", identity, SpaceId("s1"))))
+
+    def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+      ZIO.succeed(Nil)
+
+    def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+      ZIO.succeed(RuleId("r1"))
+
+    def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit]              = ZIO.unit
+    def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit] = ZIO.unit
+    def destroy(space: MockSpace): IO[MockError, Unit]                             = ZIO.unit
+    def received(space: MockSpace): IO[MockError, List[RecordedRequest]]           = ZIO.succeed(Nil)
+
+    private def cap[A](c: Capability)(a: => A): IO[Unsupported, A] =
+      if caps(c) then ZIO.succeed(a) else ZIO.fail(Unsupported(c, backend))
+
+    def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(new Faults {})
+    def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(new StatefulScenarios {})
+    def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(new StateInspection {})
+    def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(new Scripting {})
+    def proxyRecord: IO[Unsupported, ProxyRecord]         = cap(Capability.ProxyRecord)(new ProxyRecord {})
+    def templating: IO[Unsupported, Templating]           = cap(Capability.Templating)(new Templating {})
+
+  def spec = suite("MockControl port + canonical model")(
+    test("the total port is implementable by a stub adapter") {
+      val control: MockControl = StubMockControl("stub", Set.empty)
+      val rule = MockRule(
+        `match` = RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+        respond = ResponseDef(status = 200, body = Body.Text("pong"))
+      )
+      for
+        spaces <- control.provision(new MockSource {})
+        space  <- ZIO.fromOption(spaces.headOption).orElseFail(MockError.ProvisionFailed("stub returned no space"))
+        id     <- control.addRule(space, rule)
+        _      <- control.replaceRules(space, List(rule))
+        _      <- control.removeRule(space, id)
+        recs   <- control.received(space)
+        _      <- control.destroy(space)
+      yield
+        val req = HttpRequest(Method.Get, "http://x/")
+        assertTrue(
+          spaces.nonEmpty,
+          id == RuleId("r1"),
+          recs.isEmpty,
+          space.inject(req) == req // stub isolation is identity
+        )
+    },
+    test("Body covers Text | Json | Base64 (plus Empty)") {
+      val bodies: List[Body] = List(Body.Text("a"), Body.Json("{}"), Body.Base64("YQ=="), Body.Empty)
+      val shapes = bodies.map {
+        case Body.Text(_)   => "text"
+        case Body.Json(_)   => "json"
+        case Body.Base64(_) => "base64"
+        case Body.Empty     => "empty"
+      }
+      assertTrue(shapes == List("text", "json", "base64", "empty"))
+    },
+    test("PathMatch covers Exact | Regex | Template (plus Any)") {
+      val paths: List[PathMatch] =
+        List(PathMatch.Exact("/u"), PathMatch.Regex("/u/.*"), PathMatch.Template("/u/{id}"), PathMatch.Any)
+      val shapes = paths.map {
+        case PathMatch.Exact(_)    => "exact"
+        case PathMatch.Regex(_)    => "regex"
+        case PathMatch.Template(_) => "template"
+        case PathMatch.Any         => "any"
+      }
+      assertTrue(shapes == List("exact", "regex", "template", "any"))
+    },
+    test("MockError and Unsupported are typed, not Throwable") {
+      val err: MockError   = MockError.SpaceNotFound(SpaceId("s1"))
+      val uns: Unsupported = Unsupported(Capability.Faults, "stub")
+      assertTrue(
+        !err.isInstanceOf[Throwable],
+        !uns.isInstanceOf[Throwable],
+        uns.message.contains("Faults"),
+        uns.message.contains("stub")
+      )
+    },
+    test("every capability accessor fails fast with its own Unsupported when not advertised") {
+      // Each accessor must name *its own* capability — the likeliest copy-paste bug in adapters.
+      val accessors: List[(Capability, MockControl => IO[Unsupported, Any])] = List(
+        Capability.Faults            -> (_.faults),
+        Capability.StatefulScenarios -> (_.scenarios),
+        Capability.StateInspection   -> (_.stateInspection),
+        Capability.Scripting         -> (_.scripting),
+        Capability.ProxyRecord       -> (_.proxyRecord),
+        Capability.Templating        -> (_.templating)
+      )
+      val none: MockControl = StubMockControl("stub", Set.empty)
+      val all: MockControl  = StubMockControl("stub", Capability.values.toSet)
+      ZIO
+        .foreach(accessors) { (cap, access) =>
+          for
+            unsupported <- access(none).either
+            supported   <- access(all).either
+          yield assertTrue(
+            unsupported == Left(Unsupported(cap, "stub")),
+            supported.isRight
+          )
+        }
+        .map(_.reduce(_ && _))
+    },
+    test("Isolation enum has both isolation modes") {
+      assertTrue(Isolation.values.toSet == Set(Isolation.PerInstance, Isolation.Correlated))
+    },
+    test("model types are immutable value types (case-class semantics)") {
+      val r1 = ResponseDef(status = 200, body = Body.Json("{}"))
+      val r2 = r1.copy(status = 404)
+      assertTrue(
+        r1 == ResponseDef(status = 200, body = Body.Json("{}")),
+        r1.status == 200, // original unchanged by copy
+        r2.status == 404,
+        r2.body == Body.Json("{}")
+      )
+    },
+    test("RuleId and SpaceId are zero-cost newtypes carrying their value") {
+      assertTrue(
+        RuleId("r1") == RuleId("r1"),
+        RuleId("r1").value == "r1",
+        SpaceId("s1").value == "s1"
+      )
+    }
+  )


### PR DESCRIPTION
Defines the total **MockControl** core port and the backend-neutral canonical model (rules, matches, responses, mock spaces, recorded requests, typed errors, capability/isolation enums) as a new standalone `zio-bdd-mock` module with no adapter dependency.

This is the hinge of the portable mocking SPI (#109): adapters, steps, fixtures and the conformance harness all program against this port. `MockSource`/`Backend`/`NativeSpec` are minimal placeholders fleshed out in #111/#119; capability marker traits are filled in M3.

Closes #110
Milestone: M1