### PR TITLE
feat: MockSource + provision (dsl/json/resource/file/dir, auto-port)

### DIFF
--- a/mock/src/main/scala/zio/bdd/mock/MockControl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockControl.scala
@@ -3,13 +3,6 @@ package zio.bdd.mock
 import zio.IO
 
 /**
- * Where mock definitions come from. A placeholder marker at this stage — the
- * DSL builders and raw/file/resource/dir entry points land in #111. Everything
- * normalises to the canonical model before it reaches [[MockControl]].
- */
-trait MockSource
-
-/**
  * Type-level tag for a concrete backend, used to pin a [[NativeSpec]] to one
  * provider. Concrete backends (Rift, WireMock) define their own marker; the
  * native escape hatch is fleshed out in #119.

--- a/mock/src/main/scala/zio/bdd/mock/MockSource.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockSource.scala
@@ -1,0 +1,33 @@
+package zio.bdd.mock
+
+/**
+ * A minimal, portable spec a [[MockSource.Dsl]] carries: canonical rules plus
+ * an *advisory* port. The fluent builders that produce a `MockSpec` land in
+ * #112 — here it is just the neutral payload the DSL source wraps.
+ *
+ * `port` is advisory only: [[Provisioning]] always strips it and auto-assigns a
+ * fresh free port (see the fixed-port trap in #111). It is retained on the
+ * normalized form purely for diagnostics.
+ */
+final case class MockSpec(rules: List[MockRule], port: Option[Int] = None)
+
+/**
+ * Where mock definitions come from. Every case normalizes through the single
+ * [[Provisioning]] path to one [[NormalizedSource]] per space before reaching
+ * an adapter, so adapters never re-implement loading, memoization or auto-port.
+ *
+ *   - `Dsl` : already-canonical rules built in-code.
+ *   - `Json` : a raw backend wire document, inline.
+ *   - `Resource` : a classpath resource holding a raw wire document.
+ *   - `File` : a filesystem file holding a raw wire document.
+ *   - `Dir` : a filesystem directory; each regular file becomes one space.
+ *
+ * The raw cases stay un-parsed here: each adapter parses its own wire format
+ * (#113 Rift, #122 WireMock). This module owns only the neutral plumbing.
+ */
+enum MockSource:
+  case Dsl(spec: MockSpec)
+  case Json(raw: String)
+  case Resource(path: String)
+  case File(path: String)
+  case Dir(path: String)

--- a/mock/src/main/scala/zio/bdd/mock/Provisioning.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Provisioning.scala
@@ -1,0 +1,184 @@
+package zio.bdd.mock
+
+import zio.*
+
+import java.net.ServerSocket
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+
+/**
+ * The neutral, normalized form of a single mock space — the "wire config" every
+ * [[MockSource]] reduces to before an adapter consumes it.
+ *
+ *   - `name` : the space label (the file name for a [[MockSource.Dir]];
+ *     "dsl"/"json"/the resource or file base name otherwise).
+ *   - `payload` : canonical rules (from the DSL) or raw backend wire text (from
+ *     json/resource/file) the adapter parses itself.
+ *   - `authoredPort`: the advisory port the author requested, if any. Always
+ *     stripped on provision — kept only for diagnostics.
+ */
+final case class NormalizedSource(name: String, payload: SourcePayload, authoredPort: Option[Int])
+
+/** The two shapes a normalized source can take. */
+enum SourcePayload:
+  case Rules(rules: List[MockRule])
+  case Raw(text: String)
+
+private object MockIO:
+  /**
+   * Turn a JVM exception into a typed [[MockError.ProvisionFailed]] without
+   * losing the path/exception class, and without rendering a null message as
+   * the literal "null". `CommunicationError` is reserved for backend comms, so
+   * a source-read failure is *not* one.
+   */
+  def failed(action: String, e: Throwable): MockError =
+    val msg = Option(e.getMessage).getOrElse("<no message>")
+    MockError.ProvisionFailed(s"$action failed: ${e.getClass.getSimpleName}: $msg")
+
+/**
+ * Hands out localhost ports that are free at the moment of issue and distinct
+ * across the allocator's lifetime — the antidote to the fixed-port trap: an
+ * authored port is never honored, every space gets its own auto-assigned port.
+ *
+ * Allocation probes the OS (`ServerSocket(0)`) and closes the probe, so there
+ * is an inherent TOCTOU window before the caller binds the port; distinctness
+ * within the allocator removes the *self*-collision (provisioning the same
+ * fixed-port source twice), which is the trap this issue targets.
+ */
+trait PortAllocator:
+  def freePort: IO[MockError, Int]
+
+final case class PortAllocatorLive(issued: Ref[Set[Int]]) extends PortAllocator:
+  // Bound the dedup retry so a constrained ephemeral range surfaces as a typed
+  // failure instead of livelocking on probe→close→same-port forever.
+  private val maxAttempts = 100
+
+  private val probe: IO[MockError, Int] =
+    ZIO
+      .scoped(ZIO.fromAutoCloseable(ZIO.attempt(ServerSocket(0))).map(_.getLocalPort))
+      .mapError(MockIO.failed("allocating a free port", _))
+
+  def freePort: IO[MockError, Int] =
+    def go(attempt: Int): IO[MockError, Int] =
+      if attempt >= maxAttempts then
+        ZIO.fail(MockError.ProvisionFailed(s"could not obtain a distinct free port after $maxAttempts attempts"))
+      else
+        probe.flatMap { p =>
+          issued
+            .modify(s => if s(p) then (false, s) else (true, s + p))
+            .flatMap(added => if added then ZIO.succeed(p) else go(attempt + 1))
+        }
+    go(0)
+
+object PortAllocator:
+  val make: UIO[PortAllocator]     = Ref.make(Set.empty[Int]).map(PortAllocatorLive(_))
+  val layer: ULayer[PortAllocator] = ZLayer(make)
+
+/**
+ * The single provisioning entry point (#111). Normalizes any [[MockSource]] to
+ * one [[NormalizedSource]] per space — memoizing the parsed form so repeated
+ * provisioning of the same source is cheap — then for each space strips the
+ * authored port, auto-assigns a free one, asks the adapter to serve the
+ * payload, and assembles the resolved [[MockSpace]] whose `baseUri` reflects
+ * the auto-assigned port.
+ */
+final case class Provisioning(allocator: PortAllocator, cache: Ref[Map[MockSource, List[NormalizedSource]]]):
+
+  /** Resolve a source to one normalized form per space; memoized by source. */
+  def normalize(source: MockSource): IO[MockError, List[NormalizedSource]] =
+    cache.get.flatMap(_.get(source) match
+      case Some(cached) => ZIO.succeed(cached)
+      case None         => load(source).tap(ns => cache.update(_.updated(source, ns)))
+    )
+
+  /**
+   * Stand up one space per normalized source. `serve` is the adapter seam: it
+   * receives the normalized payload and the resolved [[MockSpace]] (whose
+   * `baseUri` already carries the auto-assigned port) and binds the backend.
+   */
+  def provision[E >: MockError](
+    source: MockSource
+  )(serve: (NormalizedSource, MockSpace) => IO[E, Unit]): IO[E, List[MockSpace]] =
+    normalize(source).flatMap { sources =>
+      ZIO.foreach(sources) { src =>
+        for
+          port <- allocator.freePort
+          space = MockSpace(s"http://localhost:$port", identity, SpaceId(s"${src.name}-$port"))
+          _    <- serve(src, space)
+        yield space
+      }
+    }
+
+  private def load(source: MockSource): IO[MockError, List[NormalizedSource]] =
+    source match
+      case MockSource.Dsl(spec) =>
+        ZIO.succeed(List(NormalizedSource("dsl", SourcePayload.Rules(spec.rules), spec.port)))
+      case MockSource.Json(raw) =>
+        ZIO.succeed(List(NormalizedSource("json", SourcePayload.Raw(raw), None)))
+      case MockSource.Resource(path) =>
+        readResource(path).map(t => List(NormalizedSource(baseName(path), SourcePayload.Raw(t), None)))
+      case MockSource.File(path) =>
+        readFile(path).map(t => List(NormalizedSource(baseName(path), SourcePayload.Raw(t), None)))
+      case MockSource.Dir(path) =>
+        readDir(path)
+
+  private def readResource(path: String): IO[MockError, String] =
+    val normalized = path.stripPrefix("/")
+    // Acquire the (possibly null) stream uninterruptibly and always close it, so
+    // an interrupt or read failure can never leak the handle.
+    ZIO.acquireReleaseWith(
+      ZIO
+        .attemptBlocking(Option(getClass.getClassLoader.getResourceAsStream(normalized)))
+        .mapError(MockIO.failed(s"opening resource $path", _))
+    )(opt => ZIO.foreachDiscard(opt)(s => ZIO.attempt(s.close()).ignore)) {
+      case None => ZIO.fail(MockError.InvalidDefinition(s"resource not found: $path"))
+      case Some(stream) =>
+        ZIO
+          .attemptBlocking(String(stream.readAllBytes(), StandardCharsets.UTF_8))
+          .mapError(MockIO.failed(s"reading resource $path", _))
+    }
+
+  private def readFile(path: String): IO[MockError, String] =
+    val p = Paths.get(path)
+    ZIO
+      .attemptBlocking(Files.isRegularFile(p))
+      .mapError(MockIO.failed(s"stat-ing file $path", _))
+      .flatMap { isFile =>
+        if !isFile then ZIO.fail(MockError.InvalidDefinition(s"file not found: $path"))
+        else
+          ZIO
+            .attemptBlocking(Files.readString(p, StandardCharsets.UTF_8))
+            .mapError(MockIO.failed(s"reading file $path", _))
+      }
+
+  private def readDir(path: String): IO[MockError, List[NormalizedSource]] =
+    val dir = Paths.get(path)
+    for
+      isDir <- ZIO
+                 .attemptBlocking(Files.isDirectory(dir))
+                 .mapError(MockIO.failed(s"stat-ing directory $path", _))
+      _ <- ZIO.unless(isDir)(ZIO.fail(MockError.InvalidDefinition(s"not a directory: $path")))
+      files <- ZIO.attemptBlocking {
+                 import scala.jdk.CollectionConverters.*
+                 val stream = Files.list(dir)
+                 try stream.iterator().asScala.filter(Files.isRegularFile(_)).toList.sortBy(_.getFileName.toString)
+                 finally stream.close()
+               }
+                 .mapError(MockIO.failed(s"listing directory $path", _))
+      out <- ZIO.foreach(files) { f =>
+               readFile(f.toString).map(t => NormalizedSource(f.getFileName.toString, SourcePayload.Raw(t), None))
+             }
+    yield out
+
+  private def baseName(path: String): String =
+    Option(Paths.get(path).getFileName).map(_.toString).getOrElse(path)
+
+object Provisioning:
+  private def from(allocator: PortAllocator): UIO[Provisioning] =
+    Ref.make(Map.empty[MockSource, List[NormalizedSource]]).map(Provisioning(allocator, _))
+
+  val make: UIO[Provisioning] = PortAllocator.make.flatMap(from)
+
+  val layer: URLayer[PortAllocator, Provisioning] = ZLayer(ZIO.serviceWithZIO[PortAllocator](from))
+
+  val live: ULayer[Provisioning] = PortAllocator.layer >>> layer

--- a/mock/src/test/resources/mocks/ping.json
+++ b/mock/src/test/resources/mocks/ping.json
@@ -1,0 +1,1 @@
+{ "rules": [ { "path": "/ping", "status": 200, "body": "pong" } ] }

--- a/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
@@ -43,7 +43,7 @@ object MockControlModelSpec extends ZIOSpecDefault:
         respond = ResponseDef(status = 200, body = Body.Text("pong"))
       )
       for
-        spaces <- control.provision(new MockSource {})
+        spaces <- control.provision(MockSource.Dsl(MockSpec(Nil)))
         space  <- ZIO.fromOption(spaces.headOption).orElseFail(MockError.ProvisionFailed("stub returned no space"))
         id     <- control.addRule(space, rule)
         _      <- control.replaceRules(space, List(rule))

--- a/mock/src/test/scala/zio/bdd/mock/ProvisioningSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/ProvisioningSpec.scala
@@ -1,0 +1,210 @@
+package zio.bdd.mock
+
+import zio.*
+import zio.test.*
+
+import java.net.{ServerSocket, URI}
+import java.nio.file.{Files, Path}
+
+object ProvisioningSpec extends ZIOSpecDefault:
+
+  // A canonical rule used wherever a DSL source needs content. Its shape is
+  // irrelevant to this issue — provisioning never inspects the rules, only
+  // routes them through normalisation and auto-port assignment.
+  private val pingRule =
+    MockRule(
+      `match` = RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+      respond = ResponseDef(status = 200, body = Body.Text("pong"))
+    )
+
+  /**
+   * A `serve` callback that records the (space, normalized source) it was asked
+   * to stand up, without binding anything.
+   */
+  private def recording(log: Ref[List[(MockSpace, NormalizedSource)]]): (NormalizedSource, MockSpace) => UIO[Unit] =
+    (src, space) => log.update(_ :+ (space, src))
+
+  private def portOf(space: MockSpace): Int = URI(space.baseUri).getPort
+
+  private def isInvalidDefinition(res: Either[MockError, Any]): Boolean =
+    res.left.exists(_.isInstanceOf[MockError.InvalidDefinition])
+
+  def spec = suite("Provisioning")(
+    test("provision resolves a classpath Resource to one space carrying its raw text") {
+      for
+        prov   <- Provisioning.make
+        log    <- Ref.make(List.empty[(MockSpace, NormalizedSource)])
+        spaces <- prov.provision(MockSource.Resource("mocks/ping.json"))(recording(log))
+        seen   <- log.get
+      yield
+        val (space, src) = seen.head
+        assertTrue(
+          spaces.size == 1,
+          seen.size == 1,
+          src.name == "ping.json",
+          src.payload match
+            case SourcePayload.Raw(t) => t.contains("\"/ping\"")
+            case _                    => false,
+          portOf(space) > 0
+        )
+    },
+    test("provision of a Dir yields one space per file, named by file") {
+      ZIO.scoped {
+        for
+          dir    <- tempDir
+          _      <- writeFile(dir.resolve("a.json"), """{"a":1}""")
+          _      <- writeFile(dir.resolve("b.json"), """{"b":2}""")
+          prov   <- Provisioning.make
+          log    <- Ref.make(List.empty[(MockSpace, NormalizedSource)])
+          spaces <- prov.provision(MockSource.Dir(dir.toString))(recording(log))
+          seen   <- log.get
+        yield assertTrue(
+          spaces.size == 2,
+          seen.map(_._2.name).sorted == List("a.json", "b.json"),
+          // every resolved space got its own auto-assigned port
+          spaces.map(portOf).distinct.size == 2
+        )
+      }
+    },
+    test("provisioning a fixed-port source twice gives two independently bindable spaces (fixed-port trap)") {
+      // The source authors a single fixed port; provisioning it twice must NOT
+      // try to bind that port twice. Each provision auto-assigns a distinct free
+      // port, so both `serve` calls can bind a real socket simultaneously.
+      val authored        = 18080
+      val fixedPortSource = MockSource.Dsl(MockSpec(List(pingRule), port = Some(authored)))
+
+      def bindServe(sockets: Ref[List[ServerSocket]]): (NormalizedSource, MockSpace) => IO[MockError, Unit] =
+        (_, space) =>
+          ZIO
+            .attempt(ServerSocket(portOf(space)))
+            .mapError(e => MockError.CommunicationError(e.getMessage))
+            .flatMap(s => sockets.update(_ :+ s))
+
+      ZIO.scoped {
+        for
+          prov    <- Provisioning.make
+          sockets <- Ref.make(List.empty[ServerSocket])
+          _       <- ZIO.addFinalizer(sockets.get.flatMap(ss => ZIO.foreachDiscard(ss)(s => ZIO.succeed(s.close()))))
+          first   <- prov.provision(fixedPortSource)(bindServe(sockets))
+          second  <- prov.provision(fixedPortSource)(bindServe(sockets))
+          bound   <- sockets.get
+        yield
+          val p1 = portOf(first.head)
+          val p2 = portOf(second.head)
+          assertTrue(
+            first.size == 1,
+            second.size == 1,
+            p1 != p2, // authored port was stripped + auto-assigned, twice
+            p1 != authored,
+            p2 != authored,
+            bound.size == 2, // both sockets bound at once -> no collision
+            bound.forall(_.isBound)
+          )
+      }
+    },
+    test("authored port is advisory: stripped from baseUri, auto-assigned port used instead") {
+      val authored = 19090
+      for
+        prov   <- Provisioning.make
+        log    <- Ref.make(List.empty[(MockSpace, NormalizedSource)])
+        spaces <- prov.provision(MockSource.Dsl(MockSpec(List(pingRule), port = Some(authored))))(recording(log))
+      yield
+        val space = spaces.head
+        assertTrue(
+          portOf(space) != authored,
+          portOf(space) > 0,
+          space.baseUri.startsWith("http://localhost:"),
+          space.inject(HttpRequest(Method.Get, "http://x/")) == HttpRequest(Method.Get, "http://x/")
+        )
+    },
+    test("normalize memoizes: a source deleted after first normalize still resolves from cache") {
+      ZIO.scoped {
+        for
+          dir   <- tempDir
+          file   = dir.resolve("once.json")
+          _     <- writeFile(file, """{"once":true}""")
+          prov  <- Provisioning.make
+          first <- prov.normalize(MockSource.File(file.toString))
+          _     <- ZIO.attempt(Files.delete(file)).orDie
+          again <- prov.normalize(MockSource.File(file.toString))
+        yield assertTrue(
+          first == again,
+          first.head.payload == SourcePayload.Raw("""{"once":true}""")
+        )
+      }
+    },
+    test("a Dsl source normalizes to canonical rules with its advisory port retained") {
+      for
+        prov <- Provisioning.make
+        norm <- prov.normalize(MockSource.Dsl(MockSpec(List(pingRule), port = Some(1234))))
+      yield assertTrue(
+        norm.size == 1,
+        norm.head.authoredPort.contains(1234),
+        norm.head.payload == SourcePayload.Rules(List(pingRule))
+      )
+    },
+    test("a Json source normalizes to a raw payload named \"json\" with no authored port") {
+      for
+        prov <- Provisioning.make
+        norm <- prov.normalize(MockSource.Json("""{"raw":true}"""))
+      yield assertTrue(
+        norm.size == 1,
+        norm.head.name == "json",
+        norm.head.authoredPort.isEmpty,
+        norm.head.payload == SourcePayload.Raw("""{"raw":true}""")
+      )
+    },
+    test("a File source normalizes to the file's raw contents, named by file") {
+      ZIO.scoped {
+        for
+          dir  <- tempDir
+          file  = dir.resolve("greeting.json")
+          _    <- writeFile(file, """{"hello":"world"}""")
+          prov <- Provisioning.make
+          norm <- prov.normalize(MockSource.File(file.toString))
+        yield assertTrue(
+          norm.size == 1,
+          norm.head.name == "greeting.json",
+          norm.head.payload == SourcePayload.Raw("""{"hello":"world"}""")
+        )
+      }
+    },
+    test("a missing Resource fails with InvalidDefinition") {
+      for
+        prov <- Provisioning.make
+        res  <- prov.normalize(MockSource.Resource("mocks/does-not-exist.json")).either
+      yield assertTrue(isInvalidDefinition(res))
+    },
+    test("a missing File fails with InvalidDefinition") {
+      for
+        prov <- Provisioning.make
+        res  <- prov.normalize(MockSource.File("/no/such/path/missing.json")).either
+      yield assertTrue(isInvalidDefinition(res))
+    },
+    test("a Dir pointing at a non-directory fails with InvalidDefinition") {
+      ZIO.scoped {
+        for
+          dir  <- tempDir
+          file  = dir.resolve("not-a-dir.json")
+          _    <- writeFile(file, "{}")
+          prov <- Provisioning.make
+          res  <- prov.normalize(MockSource.Dir(file.toString)).either
+        yield assertTrue(isInvalidDefinition(res))
+      }
+    }
+  )
+
+  // --- filesystem helpers (scoped temp dir, auto-deleted) -------------------
+
+  private val tempDir: ZIO[Scope, Throwable, Path] =
+    ZIO.acquireRelease(ZIO.attempt(Files.createTempDirectory("provisioning-spec"))) { dir =>
+      ZIO.attempt {
+        import scala.jdk.CollectionConverters.*
+        val walk = Files.walk(dir)
+        try walk.iterator().asScala.toList.sortBy(_.toString).reverse.foreach(Files.deleteIfExists(_))
+        finally walk.close()
+      }.orDie
+    }
+
+  private def writeFile(path: Path, content: String): ZIO[Any, Throwable, Unit] =
+    ZIO.attempt(Files.writeString(path, content)).unit


### PR DESCRIPTION
Evolve the #110 placeholder `MockSource` into a real ADT (`Dsl`/`Json`/`Resource`/`File`/`Dir`) and add a single `Provisioning` entry point that normalizes every source to one neutral `NormalizedSource` per space (memoized), strips the advisory authored port, auto-assigns a free localhost port, and returns resolved `MockSpace`s. A `Dir` yields one space per file; raw payloads stay un-parsed for each adapter to parse its own wire format (#113/#122).

The auto-port allocator defeats the fixed-port trap: provisioning the same fixed-port source twice yields two independently bindable spaces with no collision (verified by a test that binds two real sockets at once).

Closes #111
Milestone: M1