### PR TITLE
feat: portable mock DSL builders + raw/native escape hatches

### DIFF
--- a/mock/src/main/scala/zio/bdd/mock/Dsl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Dsl.scala
@@ -1,0 +1,121 @@
+package zio.bdd.mock
+
+import zio.Duration
+
+/**
+ * Portable fluent builders over the canonical mock model (#112).
+ *
+ * The DSL is pure convenience: every builder returns one of the canonical value
+ * types from `model.scala` (or composes them), so DSL output is *structurally
+ * identical* to the same model written by hand. Nothing here is required — a
+ * suite can be authored entirely from raw `.json` sources via [[MockSource]]
+ * and still drive every mutation/assertion on [[MockControl]]. Whatever the DSL
+ * produces normalises through the one [[Provisioning]] path to the same wire
+ * contract an adapter consumes.
+ *
+ * Import the whole object to use it: `import zio.bdd.mock.dsl.*`.
+ */
+object dsl:
+
+  /**
+   * A refinement applied to a [[RequestMatch]] — the value `header(..)`,
+   * `query(..)`, `jsonPath(..)` and the body matchers produce. Kept opaque so
+   * it reads as a first-class clause in signatures while remaining a plain
+   * model transform under the hood.
+   */
+  opaque type MatchClause = RequestMatch => RequestMatch
+
+  // --- request entry points -------------------------------------------------
+
+  /** Match `method` against the exact `path`. */
+  def request(method: Method, path: String): RequestMatch =
+    RequestMatch(method = Some(method), path = PathMatch.Exact(path))
+
+  def get(path: String): RequestMatch     = request(Method.Get, path)
+  def post(path: String): RequestMatch    = request(Method.Post, path)
+  def put(path: String): RequestMatch     = request(Method.Put, path)
+  def delete(path: String): RequestMatch  = request(Method.Delete, path)
+  def patch(path: String): RequestMatch   = request(Method.Patch, path)
+  def head(path: String): RequestMatch    = request(Method.Head, path)
+  def options(path: String): RequestMatch = request(Method.Options, path)
+
+  /** Match any request — no method, no path constraint. */
+  val anyRequest: RequestMatch = RequestMatch()
+
+  // --- value-match clause builders ------------------------------------------
+
+  /** A header/query clause: `header("Authorization").matches("Bearer .*")`. */
+  final class ValueClause private[dsl] (attach: ValueMatch => MatchClause):
+    def equalTo(value: String): MatchClause  = attach(ValueMatch.Equals(value))
+    def contains(value: String): MatchClause = attach(ValueMatch.Contains(value))
+    def matches(regex: String): MatchClause  = attach(ValueMatch.Matches(regex))
+
+  def header(name: String): ValueClause =
+    ValueClause(m => rm => rm.copy(headers = rm.headers.updated(name, m)))
+
+  def query(name: String): ValueClause =
+    ValueClause(m => rm => rm.copy(query = rm.query.updated(name, m)))
+
+  /** A JSON-path body clause: `jsonPath("$.a").exists`. */
+  final class JsonPathClause private[dsl] (path: String):
+    def exists: MatchClause                 = body(BodyMatch.JsonPath(path, None))
+    def equalTo(value: String): MatchClause = body(BodyMatch.JsonPath(path, Some(value)))
+
+  def jsonPath(path: String): JsonPathClause = JsonPathClause(path)
+
+  def bodyEquals(value: String): MatchClause   = body(BodyMatch.Equals(value))
+  def bodyContains(value: String): MatchClause = body(BodyMatch.Contains(value))
+  def bodyMatches(regex: String): MatchClause  = body(BodyMatch.Matches(regex))
+  def xPath(path: String): MatchClause         = body(BodyMatch.XPath(path, None))
+
+  private def body(m: BodyMatch): MatchClause = rm => rm.copy(body = Some(m))
+
+  // --- request refinement ---------------------------------------------------
+
+  extension (rm: RequestMatch)
+    /** Refine the match by folding the clauses on, left to right. */
+    def where(clauses: MatchClause*): RequestMatch =
+      clauses.foldLeft(rm)((acc, c) => c(acc))
+
+    /** Replace the path matcher (use for regex/template matching). */
+    def withPath(m: PathMatch): RequestMatch = rm.copy(path = m)
+
+    /** Pair this match with a response to form a rule. */
+    def respondWith(response: ResponseDef): MockRule = MockRule(rm, response)
+
+  // --- response entry points + refinement -----------------------------------
+
+  /** A 200 OK response with an empty body. */
+  val ok: ResponseDef = ResponseDef(status = 200)
+
+  /** A response with the given status and an empty body. */
+  def status(code: Int): ResponseDef = ResponseDef(status = code)
+
+  extension (r: ResponseDef)
+    def json(value: String): ResponseDef   = r.copy(body = Body.Json(value))
+    def text(value: String): ResponseDef   = r.copy(body = Body.Text(value))
+    def base64(value: String): ResponseDef = r.copy(body = Body.Base64(value))
+    def withBody(b: Body): ResponseDef     = r.copy(body = b)
+    def withStatus(code: Int): ResponseDef = r.copy(status = code)
+    def withHeader(name: String, value: String): ResponseDef =
+      r.copy(headers = r.headers.updated(name, value))
+    def withLatency(d: Duration): ResponseDef = r.copy(delay = Some(d))
+
+  // --- rule + spec assembly -------------------------------------------------
+
+  extension (rule: MockRule) def withId(id: String): MockRule = rule.copy(id = Some(RuleId(id)))
+
+  /** Assemble rules into a spec. */
+  def mock(rules: MockRule*): MockSpec = MockSpec(rules.toList)
+
+  extension (spec: MockSpec)
+    /**
+     * Set the advisory port (always stripped on provision — see [[MockSpec]]).
+     */
+    def onPort(port: Int): MockSpec = spec.copy(port = Some(port))
+
+    /** Wrap this spec as a DSL [[MockSource]]. */
+    def source: MockSource = MockSource.Dsl(spec)
+
+  /** Build a DSL [[MockSource]] straight from rules. */
+  def dslSource(rules: MockRule*): MockSource = mock(rules*).source

--- a/mock/src/test/scala/zio/bdd/mock/DslSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/DslSpec.scala
@@ -1,0 +1,187 @@
+package zio.bdd.mock
+
+import zio.*
+import zio.bdd.mock.dsl.*
+import zio.test.*
+
+/**
+ * AC2 gate: the DSL is a pure convenience over the canonical model. Every
+ * builder expression must equal the hand-written case class it stands for, and
+ * a full DSL spec must normalise through the real [[Provisioning]] path to
+ * exactly the canonical rules — i.e. DSL output IS the wire contract an adapter
+ * consumes. (Adapter-level "identical JSON behaviour" is verified by the
+ * conformance suite in #113/#122; no adapter parses JSON in this module.)
+ */
+object DslSpec extends ZIOSpecDefault:
+
+  def spec = suite("mock DSL builders")(
+    suite("request matchers equal the canonical RequestMatch")(
+      test("get/post/... set method + exact path") {
+        assertTrue(
+          get("/x") == RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/x")),
+          post("/x") == RequestMatch(method = Some(Method.Post), path = PathMatch.Exact("/x")),
+          put("/x") == RequestMatch(method = Some(Method.Put), path = PathMatch.Exact("/x")),
+          delete("/x") == RequestMatch(method = Some(Method.Delete), path = PathMatch.Exact("/x")),
+          patch("/x") == RequestMatch(method = Some(Method.Patch), path = PathMatch.Exact("/x")),
+          head("/x") == RequestMatch(method = Some(Method.Head), path = PathMatch.Exact("/x")),
+          options("/x") == RequestMatch(method = Some(Method.Options), path = PathMatch.Exact("/x")),
+          anyRequest == RequestMatch()
+        )
+      },
+      test("withPath replaces the path matcher with regex/template") {
+        assertTrue(
+          get("/ignored").withPath(PathMatch.Template("/users/{id}")) ==
+            RequestMatch(method = Some(Method.Get), path = PathMatch.Template("/users/{id}")),
+          get("/ignored").withPath(PathMatch.Regex("/u/.*")) ==
+            RequestMatch(method = Some(Method.Get), path = PathMatch.Regex("/u/.*"))
+        )
+      },
+      test("header(...).{equalTo,contains,matches} add a header value matcher") {
+        assertTrue(
+          get("/x").where(header("Authorization").matches("Bearer .*")) ==
+            RequestMatch(
+              method = Some(Method.Get),
+              path = PathMatch.Exact("/x"),
+              headers = Map("Authorization" -> ValueMatch.Matches("Bearer .*"))
+            ),
+          get("/x").where(header("X").equalTo("1")) ==
+            RequestMatch(Some(Method.Get), PathMatch.Exact("/x"), headers = Map("X" -> ValueMatch.Equals("1"))),
+          get("/x").where(header("X").contains("ab")) ==
+            RequestMatch(Some(Method.Get), PathMatch.Exact("/x"), headers = Map("X" -> ValueMatch.Contains("ab")))
+        )
+      },
+      test("query(...).{equalTo,contains,matches} add a query value matcher") {
+        assertTrue(
+          get("/x").where(query("page").equalTo("1")) ==
+            RequestMatch(Some(Method.Get), PathMatch.Exact("/x"), query = Map("page" -> ValueMatch.Equals("1"))),
+          get("/x").where(query("page").contains("1")).query == Map("page" -> ValueMatch.Contains("1")),
+          get("/x").where(query("page").matches("\\d+")).query == Map("page" -> ValueMatch.Matches("\\d+"))
+        )
+      },
+      test("jsonPath(...).exists / .equalTo set a JsonPath body matcher") {
+        assertTrue(
+          post("/x").where(jsonPath("$.a").exists).body.contains(BodyMatch.JsonPath("$.a", None)),
+          post("/x").where(jsonPath("$.a").equalTo("v")).body.contains(BodyMatch.JsonPath("$.a", Some("v")))
+        )
+      },
+      test("body matchers (equals/contains/matches/xPath) set the body matcher") {
+        assertTrue(
+          post("/x").where(bodyEquals("hi")).body.contains(BodyMatch.Equals("hi")),
+          post("/x").where(bodyContains("h")).body.contains(BodyMatch.Contains("h")),
+          post("/x").where(bodyMatches("h.")).body.contains(BodyMatch.Matches("h.")),
+          post("/x").where(xPath("/a/b")).body.contains(BodyMatch.XPath("/a/b", None))
+        )
+      },
+      test("clauses targeting the same slot are last-wins") {
+        assertTrue(
+          get("/x").where(bodyEquals("a"), bodyContains("b")).body.contains(BodyMatch.Contains("b")),
+          get("/x").where(header("X").equalTo("1"), header("X").matches("2")).headers ==
+            Map("X" -> ValueMatch.Matches("2"))
+        )
+      },
+      test("where folds multiple clauses onto one match") {
+        val rm = get("/x").where(
+          header("Authorization").matches("Bearer .*"),
+          query("page").equalTo("1"),
+          jsonPath("$.id").exists
+        )
+        assertTrue(
+          rm == RequestMatch(
+            method = Some(Method.Get),
+            path = PathMatch.Exact("/x"),
+            query = Map("page" -> ValueMatch.Equals("1")),
+            headers = Map("Authorization" -> ValueMatch.Matches("Bearer .*")),
+            body = Some(BodyMatch.JsonPath("$.id", None))
+          )
+        )
+      }
+    ),
+    suite("response builders equal the canonical ResponseDef")(
+      test("ok / status set the status with an empty body") {
+        assertTrue(
+          ok == ResponseDef(status = 200),
+          status(402) == ResponseDef(status = 402)
+        )
+      },
+      test("json/text/base64/withBody set the body") {
+        assertTrue(
+          ok.json("{}") == ResponseDef(status = 200, body = Body.Json("{}")),
+          ok.text("hi") == ResponseDef(status = 200, body = Body.Text("hi")),
+          ok.base64("YQ==") == ResponseDef(status = 200, body = Body.Base64("YQ==")),
+          status(402).withBody(Body.Text("nope")) == ResponseDef(status = 402, body = Body.Text("nope"))
+        )
+      },
+      test("withHeader / withStatus / withLatency refine the response") {
+        assertTrue(
+          ok.withHeader("Content-Type", "application/json") ==
+            ResponseDef(status = 200, headers = Map("Content-Type" -> "application/json")),
+          ok.withStatus(204) == ResponseDef(status = 204),
+          ok.json("{}").withLatency(50.millis) ==
+            ResponseDef(status = 200, body = Body.Json("{}"), delay = Some(50.millis))
+        )
+      }
+    ),
+    suite("rule + spec assembly")(
+      test("respondWith pairs a match and a response into a MockRule") {
+        assertTrue(
+          get("/ping").respondWith(ok.text("pong")) ==
+            MockRule(
+              `match` = RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+              respond = ResponseDef(status = 200, body = Body.Text("pong"))
+            )
+        )
+      },
+      test("withId stamps a rule id") {
+        assertTrue(
+          get("/ping").respondWith(ok).withId("r1").id.contains(RuleId("r1"))
+        )
+      },
+      test("a full DSL rule equals the hand-built canonical rule") {
+        val built = get("/ignored")
+          .withPath(PathMatch.Template("/users/{id}"))
+          .where(header("Authorization").matches("Bearer .*"), jsonPath("$.name").exists)
+          .respondWith(status(201).json("""{"ok":true}""").withHeader("Location", "/users/1").withLatency(10.millis))
+          .withId("create-user")
+
+        val canonical = MockRule(
+          `match` = RequestMatch(
+            method = Some(Method.Get),
+            path = PathMatch.Template("/users/{id}"),
+            headers = Map("Authorization" -> ValueMatch.Matches("Bearer .*")),
+            body = Some(BodyMatch.JsonPath("$.name", None))
+          ),
+          respond = ResponseDef(
+            status = 201,
+            headers = Map("Location" -> "/users/1"),
+            body = Body.Json("""{"ok":true}"""),
+            delay = Some(10.millis)
+          ),
+          id = Some(RuleId("create-user"))
+        )
+        assertTrue(built == canonical)
+      },
+      test("mock / onPort / source assemble a spec and a Dsl source") {
+        val r1 = get("/a").respondWith(ok)
+        val r2 = post("/b").respondWith(status(201))
+        assertTrue(
+          mock(r1, r2) == MockSpec(List(r1, r2)),
+          mock(r1).onPort(8080) == MockSpec(List(r1), port = Some(8080)),
+          mock(r1, r2).source == MockSource.Dsl(MockSpec(List(r1, r2))),
+          dslSource(r1, r2) == MockSource.Dsl(MockSpec(List(r1, r2)))
+        )
+      }
+    ),
+    test("a DSL spec normalizes through Provisioning to exactly its canonical rules") {
+      // Ties DSL output to the real wire contract: the same Provisioning path the
+      // raw sources use yields SourcePayload.Rules(handBuiltRules) for the DSL.
+      val r1 = get("/ping").respondWith(ok.text("pong"))
+      val r2 = post("/echo").where(jsonPath("$.msg").exists).respondWith(status(201))
+      for
+        prov <- Provisioning.make
+        norm <- prov.normalize(dslSource(r1, r2))
+      yield assertTrue(
+        norm.size == 1,
+        norm.head.payload == SourcePayload.Rules(List(r1, r2))
+      )
+    }
+  )

--- a/mock/src/test/scala/zio/bdd/mock/RawSourceNoDslSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/RawSourceNoDslSpec.scala
@@ -1,0 +1,127 @@
+package zio.bdd.mock
+
+import zio.*
+import zio.test.*
+
+/**
+ * AC1 gate: a suite authored entirely from raw `.json` sources (no DSL) must
+ * still drive every mutation and assertion on [[MockControl]]. This file
+ * deliberately does NOT `import zio.bdd.mock.dsl.*` — that it compiles and runs
+ * proves the DSL builders are pure convenience, never a requirement. Overlay
+ * rules are constructed from the bare canonical model, not the DSL.
+ */
+object RawSourceNoDslSpec extends ZIOSpecDefault:
+
+  // An in-memory adapter: rules and the loaded source payload live in Refs.
+  // `provision` runs through the real [[Provisioning]] path so a raw `.json`
+  // source is genuinely read (a missing resource fails the test), then records
+  // the normalized payload per space. Enough to exercise
+  // addRule/removeRule/replaceRules/received/destroy and the provisionNative
+  // escape hatch without any backend.
+  private final case class InMemoryControl(
+    prov: Provisioning,
+    rules: Ref[Map[SpaceId, List[(RuleId, MockRule)]]],
+    loaded: Ref[Map[SpaceId, SourcePayload]],
+    seq: Ref[Int]
+  ) extends MockControl:
+    def capabilities: Set[Capability] = Set.empty
+
+    def provision(source: MockSource): IO[MockError, List[MockSpace]] =
+      prov.provision(source) { (norm, space) =>
+        rules.update(_.updated(space.id, Nil)) *> loaded.update(_.updated(space.id, norm.payload))
+      }
+
+    def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+      val space = MockSpace("http://localhost:0", identity, SpaceId("native"))
+      rules.update(_.updated(space.id, Nil)).as(List(space))
+
+    def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+      seq.updateAndGet(_ + 1).map(n => RuleId(s"r$n")).flatMap { id =>
+        rules.update(m => m.updated(space.id, m.getOrElse(space.id, Nil) :+ (id, rule))).as(id)
+      }
+
+    def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit] =
+      rules.update(m => m.updated(space.id, m.getOrElse(space.id, Nil).filterNot(_._1 == id)))
+
+    def replaceRules(space: MockSpace, rs: List[MockRule]): IO[MockError, Unit] =
+      rules.update(m => m.updated(space.id, rs.map(r => (RuleId("replaced"), r))))
+
+    def destroy(space: MockSpace): IO[MockError, Unit] =
+      rules.update(_.removed(space.id))
+
+    def received(space: MockSpace): IO[MockError, List[RecordedRequest]] =
+      ZIO.succeed(Nil)
+
+    private def unsupported[A](c: Capability): IO[Unsupported, A] = ZIO.fail(Unsupported(c, "in-memory"))
+    def faults: IO[Unsupported, Faults]                           = unsupported(Capability.Faults)
+    def scenarios: IO[Unsupported, StatefulScenarios]             = unsupported(Capability.StatefulScenarios)
+    def stateInspection: IO[Unsupported, StateInspection]         = unsupported(Capability.StateInspection)
+    def scripting: IO[Unsupported, Scripting]                     = unsupported(Capability.Scripting)
+    def proxyRecord: IO[Unsupported, ProxyRecord]                 = unsupported(Capability.ProxyRecord)
+    def templating: IO[Unsupported, Templating]                   = unsupported(Capability.Templating)
+
+  private def control: UIO[InMemoryControl] =
+    for
+      prov   <- Provisioning.make
+      rules  <- Ref.make(Map.empty[SpaceId, List[(RuleId, MockRule)]])
+      loaded <- Ref.make(Map.empty[SpaceId, SourcePayload])
+      seq    <- Ref.make(0)
+    yield InMemoryControl(prov, rules, loaded, seq)
+
+  // A canonical overlay rule built WITHOUT the DSL — bare model constructors only.
+  private val overlay: MockRule =
+    MockRule(
+      `match` = RequestMatch(method = Some(Method.Post), path = PathMatch.Exact("/echo")),
+      respond = ResponseDef(status = 201, body = Body.Json("""{"ok":true}"""))
+    )
+
+  def spec = suite("raw .json source drives every mutation/assertion without the DSL")(
+    test("provision from a .json resource, then add/replace/remove/received/destroy") {
+      for
+        mc       <- control
+        spaces   <- mc.provision(MockSource.Resource("mocks/ping.json"))
+        space    <- ZIO.fromOption(spaces.headOption).orElseFail(MockError.ProvisionFailed("no space"))
+        payload  <- mc.loaded.get.map(_(space.id))
+        id       <- mc.addRule(space, overlay)
+        afterAdd <- mc.rules.get
+        _        <- mc.replaceRules(space, List(overlay))
+        afterRep <- mc.rules.get
+        _        <- mc.removeRule(space, RuleId("replaced"))
+        afterRem <- mc.rules.get
+        recs     <- mc.received(space)
+        _        <- mc.destroy(space)
+        afterDel <- mc.rules.get
+      yield assertTrue(
+        spaces.size == 1,
+        // the raw .json was genuinely read by the provisioning path
+        payload match
+          case SourcePayload.Raw(t) => t.contains("\"/ping\"")
+          case _                    => false,
+        id == RuleId("r1"),
+        afterAdd(space.id).map(_._2) == List(overlay),
+        afterRep(space.id).map(_._2) == List(overlay),
+        afterRem(space.id).isEmpty,
+        recs.isEmpty,
+        !afterDel.contains(space.id)
+      )
+    },
+    test("provisioning a missing .json resource fails — no DSL fallback hides it") {
+      for
+        mc  <- control
+        res <- mc.provision(MockSource.Resource("mocks/does-not-exist.json")).either
+      yield assertTrue(res == Left(MockError.InvalidDefinition("resource not found: mocks/does-not-exist.json")))
+    },
+    test("provisionNative escape hatch stands up a space without a portable source") {
+      val nativeSpec = new NativeSpec[Backend] {}
+      for
+        mc     <- control
+        spaces <- mc.provisionNative(nativeSpec)
+      yield assertTrue(spaces.map(_.id) == List(SpaceId("native")))
+    },
+    test("an unadvertised capability fails fast with typed Unsupported") {
+      for
+        mc  <- control
+        res <- mc.faults.either
+      yield assertTrue(res == Left(Unsupported(Capability.Faults, "in-memory")))
+    }
+  )


### PR DESCRIPTION
Adds portable fluent DSL builders over the canonical MockControl model
(RequestMatch/ResponseDef/MockRule/MockSpec), plus keeps the raw/native escape
hatches first-class so the DSL never blocks a developer.

- `object dsl`: request matchers (get/post/…, header/query/jsonPath/body clauses,
  `where`, `withPath`), response builders (ok, status, json/text/base64, withHeader/
  withStatus/withLatency), and rule/spec assembly (respondWith, withId, mock, onPort,
  source, dslSource).
- DSL output is structurally identical to the hand-written canonical model and
  normalizes through the single Provisioning path — verified in `DslSpec`.
- `RawSourceNoDslSpec` never imports the DSL: it provisions from a `.json` resource
  through the real Provisioning path and drives every mutation/assertion plus
  `provisionNative`, proving the DSL is convenience, not a requirement (AC1).

Adapter-level "equivalent raw JSON ⇒ identical behaviour" needs a JSON-parsing
adapter (none in this module) and is covered by the conformance suite in #113/#122.

Closes #112
Milestone: M1