### PR TITLE
fix: isolate property failure store per fiber to end flaky replay tests

### DIFF
--- a/core/src/main/scala/zio/bdd/core/property/PropertyFailureStore.scala
+++ b/core/src/main/scala/zio/bdd/core/property/PropertyFailureStore.scala
@@ -30,7 +30,26 @@ object PropertyFailureStore:
     timestamp: String
   )
 
-  private val dir: Path = Paths.get(".zio-bdd", "failures")
+  /**
+   * The production on-disk location, used whenever no `withBaseDir` override is
+   * in effect.
+   */
+  private[property] val defaultBaseDir: Path = Paths.get(".zio-bdd", "failures")
+
+  // The active base directory for per-scenario failure records. A FiberRef (not a constant)
+  // so a caller can redirect it for the duration of an effect via `withBaseDir`, scoped to
+  // its own fiber and children — concurrent scenarios never observe one another's override.
+  // Nothing overrides it in normal runs, so the on-disk layout is unchanged; tests use it to
+  // isolate the store and stop racing on a single shared directory — see #138.
+  private val baseDir: FiberRef[Path] =
+    Unsafe.unsafe(implicit unsafe => FiberRef.unsafe.make(defaultBaseDir))
+
+  /**
+   * Run `zio` with the failure store redirected to `dir` (for this fiber and
+   * its children).
+   */
+  def withBaseDir[R, E, A](dir: Path)(zio: => ZIO[R, E, A]): ZIO[R, E, A] =
+    baseDir.locally(dir)(zio)
 
   private[property] def slug(scenario: Scenario): String =
     val feature = scenario.file.getOrElse("unknown").replaceAll(""".*[/\\]""", "").stripSuffix(".feature")
@@ -41,8 +60,8 @@ object PropertyFailureStore:
     val content = scenario.steps.map(s => s"${s.stepType}:${s.pattern}").mkString("|")
     Integer.toHexString(content.hashCode)
 
-  private def file(scenario: Scenario): File =
-    dir.resolve(slug(scenario) + ".json").toFile
+  private def fileIn(base: Path, scenario: Scenario): File =
+    base.resolve(slug(scenario) + ".json").toFile
 
   // ── Minimal JSON encode/decode (avoids adding a library dependency) ───────
   // We control the output format: keys are known identifiers, values are
@@ -161,26 +180,28 @@ object PropertyFailureStore:
   }
 
   def read(scenario: Scenario): UIO[Option[FailureRecord]] =
-    ZIO.attemptBlocking {
-      val f = file(scenario)
-      if (!f.exists()) None
-      else {
-        val json = scala.util.Using.resource(scala.io.Source.fromFile(f))(_.mkString)
-        decodeJson(json)
+    baseDir.get.flatMap { base =>
+      ZIO.attemptBlocking {
+        val f = fileIn(base, scenario)
+        if (!f.exists()) None
+        else {
+          val json = scala.util.Using.resource(scala.io.Source.fromFile(f))(_.mkString)
+          decodeJson(json)
+        }
       }
+        .orElse(ZIO.none)
+        .flatMap {
+          case Some(rec) if rec.bodyHash == bodyHash(scenario) => ZIO.some(rec)
+          case Some(_)                                         =>
+            // The scenario's step list changed since this failure was recorded — the stored
+            // counterexample no longer corresponds to the current scenario body. Discard it
+            // rather than replaying a test that no longer exists in this form.
+            ZIO.logWarning(
+              s"Discarding stale property-failure record for '${scenario.name}' — scenario body changed since it was recorded."
+            ) *> clear(scenario).as(None)
+          case None => ZIO.none
+        }
     }
-      .orElse(ZIO.none)
-      .flatMap {
-        case Some(rec) if rec.bodyHash == bodyHash(scenario) => ZIO.some(rec)
-        case Some(_)                                         =>
-          // The scenario's step list changed since this failure was recorded — the stored
-          // counterexample no longer corresponds to the current scenario body. Discard it
-          // rather than replaying a test that no longer exists in this form.
-          ZIO.logWarning(
-            s"Discarding stale property-failure record for '${scenario.name}' — scenario body changed since it was recorded."
-          ) *> clear(scenario).as(None)
-        case None => ZIO.none
-      }
 
   def write(
     scenario: Scenario,
@@ -189,19 +210,21 @@ object PropertyFailureStore:
     shrunkValues: Map[String, String],
     generatorLabels: Map[String, String]
   ): UIO[Unit] =
-    ZIO.attemptBlocking {
-      Files.createDirectories(dir)
-      val rec = FailureRecord(
-        scenarioId = slug(scenario),
-        bodyHash = bodyHash(scenario),
-        seed = seed,
-        sampleIndex = sampleIndex,
-        shrunkValues = shrunkValues,
-        generatorLabels = generatorLabels,
-        timestamp = Instant.now().toString
-      )
-      scala.util.Using.resource(new PrintWriter(file(scenario)))(_.write(encodeJson(rec)))
-    }.orDie
+    baseDir.get.flatMap { base =>
+      ZIO.attemptBlocking {
+        Files.createDirectories(base)
+        val rec = FailureRecord(
+          scenarioId = slug(scenario),
+          bodyHash = bodyHash(scenario),
+          seed = seed,
+          sampleIndex = sampleIndex,
+          shrunkValues = shrunkValues,
+          generatorLabels = generatorLabels,
+          timestamp = Instant.now().toString
+        )
+        scala.util.Using.resource(new PrintWriter(fileIn(base, scenario)))(_.write(encodeJson(rec)))
+      }.orDie
+    }
 
   def clear(scenario: Scenario): UIO[Unit] =
-    ZIO.attemptBlocking { val _ = file(scenario).delete() }.orDie
+    baseDir.get.flatMap(base => ZIO.attemptBlocking { val _ = fileIn(base, scenario).delete() }.orDie)

--- a/core/src/test/scala/zio/bdd/core/PropertyExecutorSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/PropertyExecutorSpec.scala
@@ -3,10 +3,12 @@ package zio.bdd.core
 import zio.*
 import zio.test.*
 import zio.test.Assertion.*
-import zio.bdd.core.property.{ColumnGenLookup, HasGen}
+import zio.bdd.core.property.{ColumnGenLookup, HasGen, PropertyFailureStore}
 import zio.bdd.core.step.{State, TypedExtractor, ZIOSteps}
 import zio.bdd.gherkin.GherkinParser
 import zio.test.Gen
+
+import java.nio.file.{Files, Path}
 
 /**
  * End-to-end tests for Mode P (property-based testing) execution.
@@ -39,6 +41,27 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
           case _                                 => None
       FeatureExecutor.executeFeatures[Any, S](List(f), steps.getSteps, steps, genLookup = lookup)
     }
+
+  private def deleteRecursively(dir: Path): UIO[Unit] =
+    ZIO.attempt {
+      import scala.jdk.CollectionConverters.*
+      if (Files.exists(dir)) {
+        val walk = Files.walk(dir)
+        try walk.iterator().asScala.toList.sortBy(_.toString).reverse.foreach(Files.deleteIfExists(_))
+        finally walk.close()
+      }
+    }.orDie
+
+  // Redirect the property failure store to a fresh, scoped temp directory so the replay
+  // tests never read, write, or bulk-delete the process-global `.zio-bdd/failures` dir —
+  // which other tests touch concurrently (#138). `use` receives that directory.
+  private def withIsolatedStore[R, E, A](use: Path => ZIO[R, E, A]): ZIO[R & Scope, E, A] =
+    ZIO
+      .acquireRelease(ZIO.attempt(Files.createTempDirectory("zio-bdd-failures-exec")).orDie)(deleteRecursively)
+      .flatMap(dir => PropertyFailureStore.withBaseDir(dir)(use(dir)))
+
+  private def failureFiles(dir: Path): List[java.io.File] =
+    Option(dir.toFile.listFiles()).fold(List.empty[java.io.File])(_.filter(_.getName.endsWith(".json")).toList)
 
   def spec: Spec[TestEnvironment & Scope, Any] = suite("PropertyExecutorSpec")(
     passSuite,
@@ -742,46 +765,40 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
           FeatureExecutor.executeFeatures[Any, S](List(f), stepsFor().getSteps, stepsFor(), genLookup = lookup)
         }
 
-      val failuresDir = java.nio.file.Paths.get(".zio-bdd", "failures").toFile
-      def failureFiles(): List[java.io.File] =
-        Option(failuresDir.listFiles()).fold(List.empty[java.io.File])(_.filter(_.getName.endsWith(".json")).toList)
+      withIsolatedStore { dir =>
+        for {
+          // Run 1: always fails → failure file should be written.
+          firstResults   <- run()
+          firstScenario   = firstResults.head.scenarioResults.head
+          existsAfterRun1 = failureFiles(dir).nonEmpty
 
-      for {
-        _ <- ZIO.attempt(failureFiles().foreach(_.delete())).ignore
+          // Run 2: still fails, but replay should consult the stored seed first
+          // rather than burning a fresh batch of `samples` runs.
+          freshRunsBeforeRun2 = freshRuns.get()
+          secondResults      <- run()
+          secondScenario      = secondResults.head.scenarioResults.head
+          freshRunsDuringRun2 = freshRuns.get() - freshRunsBeforeRun2
 
-        // Run 1: always fails → failure file should be written.
-        firstResults   <- run()
-        firstScenario   = firstResults.head.scenarioResults.head
-        existsAfterRun1 = failureFiles().nonEmpty
-
-        // Run 2: still fails, but replay should consult the stored seed first
-        // rather than burning a fresh batch of `samples` runs.
-        freshRunsBeforeRun2 = freshRuns.get()
-        secondResults      <- run()
-        secondScenario      = secondResults.head.scenarioResults.head
-        freshRunsDuringRun2 = freshRuns.get() - freshRunsBeforeRun2
-
-        // Fix the bug, run again: replay should now pass.
-        _                  <- ZIO.succeed(shouldFail.set(false))
-        freshRunsBeforeRun3 = freshRuns.get()
-        thirdResults       <- run()
-        thirdScenario       = thirdResults.head.scenarioResults.head
-        freshRunsDuringRun3 = freshRuns.get() - freshRunsBeforeRun3
-        existsAfterRun3     = failureFiles().nonEmpty
-
-        _ <- ZIO.attempt(failureFiles().foreach(_.delete())).ignore
-      } yield assertTrue(
-        !firstScenario.isPassed,
-        existsAfterRun1,
-        !secondScenario.isPassed,
-        secondScenario.error.exists(_.getMessage.contains("replayed from failure store")),
-        // Replaying one stored sample should cost far fewer step invocations than a fresh 5-sample batch.
-        freshRunsDuringRun2 < 5,
-        thirdScenario.isPassed,
-        !existsAfterRun3,
-        // Once the replay passes, a full fresh batch of samples should still run.
-        freshRunsDuringRun3 >= 5
-      )
+          // Fix the bug, run again: replay should now pass.
+          _                  <- ZIO.succeed(shouldFail.set(false))
+          freshRunsBeforeRun3 = freshRuns.get()
+          thirdResults       <- run()
+          thirdScenario       = thirdResults.head.scenarioResults.head
+          freshRunsDuringRun3 = freshRuns.get() - freshRunsBeforeRun3
+          existsAfterRun3     = failureFiles(dir).nonEmpty
+        } yield assertTrue(
+          !firstScenario.isPassed,
+          existsAfterRun1,
+          !secondScenario.isPassed,
+          secondScenario.error.exists(_.getMessage.contains("replayed from failure store")),
+          // Replaying one stored sample should cost far fewer step invocations than a fresh 5-sample batch.
+          freshRunsDuringRun2 < 5,
+          thirdScenario.isPassed,
+          !existsAfterRun3,
+          // Once the replay passes, a full fresh batch of samples should still run.
+          freshRunsDuringRun3 >= 5
+        )
+      }
     },
     test("stale failure record (scenario body changed) is discarded, not replayed") {
       val freshRuns = new java.util.concurrent.atomic.AtomicInteger(0)
@@ -822,34 +839,34 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
           case "n" => Some(HasGen[Int])
           case _   => None
 
-      val failuresDir = java.nio.file.Paths.get(".zio-bdd", "failures").toFile
-      def failureFiles(): List[java.io.File] =
-        Option(failuresDir.listFiles()).fold(List.empty[java.io.File])(_.filter(_.getName.endsWith(".json")).toList)
+      withIsolatedStore { dir =>
+        for {
+          // Run 1: fails, writes a failure record keyed to this exact step body.
+          f1 <- GherkinParser.parseFeature(failingFeature, "stale-replay.feature")
+          _ <-
+            FeatureExecutor.executeFeatures[Any, S](List(f1), failingSteps.getSteps, failingSteps, genLookup = lookup)
+          recordedAfterRun1 = failureFiles(dir).nonEmpty
 
-      for {
-        _ <- ZIO.attempt(failureFiles().foreach(_.delete())).ignore
-
-        // Run 1: fails, writes a failure record keyed to this exact step body.
-        f1               <- GherkinParser.parseFeature(failingFeature, "stale-replay.feature")
-        _                <- FeatureExecutor.executeFeatures[Any, S](List(f1), failingSteps.getSteps, failingSteps, genLookup = lookup)
-        recordedAfterRun1 = failureFiles().nonEmpty
-
-        // Run 2: edited step body → bodyHash no longer matches. The stale record must be
-        // discarded (full fresh batch runs), not replayed as a single stored sample.
-        f2 <- GherkinParser.parseFeature(editedPassingFeature, "stale-replay.feature")
-        _ <- FeatureExecutor.executeFeatures[Any, S](
-               List(f2),
-               passingSteps().getSteps,
-               passingSteps(),
-               genLookup = lookup
-             )
-
-        _ <- ZIO.attempt(failureFiles().foreach(_.delete())).ignore
-      } yield assertTrue(
-        recordedAfterRun1,
-        // All 4 fresh samples ran — not a single-sample replay of the stale record.
-        freshRuns.get() == 4
-      )
+          // Run 2: edited step body → bodyHash no longer matches. The stale record must be
+          // discarded (full fresh batch runs), not replayed as a single stored sample.
+          f2 <- GherkinParser.parseFeature(editedPassingFeature, "stale-replay.feature")
+          _ <- FeatureExecutor.executeFeatures[Any, S](
+                 List(f2),
+                 passingSteps().getSteps,
+                 passingSteps(),
+                 genLookup = lookup
+               )
+          // The discard path actively clears the stale record. If the read had instead been
+          // silently swallowed to None, run 1's file would still be here — so this also fails
+          // a "4 fresh runs for the wrong reason" false green.
+          existsAfterRun2 = failureFiles(dir).nonEmpty
+        } yield assertTrue(
+          recordedAfterRun1,
+          !existsAfterRun2,
+          // All 4 fresh samples ran — not a single-sample replay of the stale record.
+          freshRuns.get() == 4
+        )
+      }
     }
   )
 

--- a/core/src/test/scala/zio/bdd/core/property/PropertyFailureStoreSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/property/PropertyFailureStoreSpec.scala
@@ -4,86 +4,149 @@ import zio.*
 import zio.test.*
 import zio.bdd.gherkin.{Scenario, Step, StepType}
 
-import java.nio.file.Paths
+import java.nio.file.{Files, Path, Paths}
 
 /**
  * Round-trip tests for `PropertyFailureStore`'s hand-rolled JSON encode/decode,
  * focused on value content that could break a naive (non-escape-aware) parser:
  * literal braces, quotes, backslashes, and non-ASCII text inside a sampled
  * column value.
+ *
+ * Every test runs against an isolated, auto-deleted base directory via
+ * `withIsolatedStore`, so the suite never touches (or races on) the
+ * process-global `.zio-bdd/failures` directory — see #138.
  */
 object PropertyFailureStoreSpec extends ZIOSpecDefault {
 
   private def scenario(name: String) =
     Scenario(name = name, steps = List(Step(StepType.GivenStep, "a step")), file = Some("failure-store-spec.feature"))
 
-  private val failuresDir = Paths.get(".zio-bdd", "failures").toFile
-
   private def cleanup(sc: Scenario) = PropertyFailureStore.clear(sc)
 
+  private def deleteRecursively(dir: Path): UIO[Unit] =
+    ZIO.attempt {
+      import scala.jdk.CollectionConverters.*
+      if (Files.exists(dir)) {
+        val walk = Files.walk(dir)
+        try walk.iterator().asScala.toList.sortBy(_.toString).reverse.foreach(Files.deleteIfExists(_))
+        finally walk.close()
+      }
+    }.orDie
+
+  /**
+   * Run `use` with the failure store redirected to a fresh, scoped temp
+   * directory.
+   */
+  private def withIsolatedStore[E, A](use: Path => ZIO[Any, E, A]): ZIO[Scope, E, A] =
+    ZIO
+      .acquireRelease(ZIO.attempt(Files.createTempDirectory("zio-bdd-failures-spec")).orDie)(deleteRecursively)
+      .flatMap(dir => PropertyFailureStore.withBaseDir(dir)(use(dir)))
+
   def spec: Spec[TestEnvironment & Scope, Any] = suite("PropertyFailureStoreSpec")(
+    test("the default base directory is the production .zio-bdd/failures layout (#138)") {
+      // Every other test overrides the base dir, so this pins the un-overridden default that
+      // production (and external tooling reading the files) relies on — a rename would
+      // otherwise pass the whole suite unnoticed.
+      assertTrue(PropertyFailureStore.defaultBaseDir == Paths.get(".zio-bdd", "failures"))
+    },
+    test("concurrent isolated stores never observe each other's records (parallel-safe, #138)") {
+      // Every fiber writes the SAME scenario slug. Under one shared global directory they
+      // would all collide on a single file (last-writer-wins) and most fibers would read a
+      // foreign seed. With a per-fiber `withBaseDir`, each must read back exactly its own.
+      val sc = scenario("contended slug")
+      ZIO
+        .foreachPar(1 to 32) { i =>
+          ZIO.scoped {
+            withIsolatedStore { dir =>
+              for {
+                _      <- PropertyFailureStore.write(sc, seed = i.toLong, sampleIndex = i, Map("n" -> i.toString), Map.empty)
+                rec    <- PropertyFailureStore.read(sc)
+                ourFile = dir.resolve(PropertyFailureStore.slug(sc) + ".json").toFile
+              } yield (i, rec, ourFile.exists())
+            }
+          }
+        }
+        .map { results =>
+          assertTrue(
+            results.size == 32,
+            results.forall { case (i, rec, wroteUnderOurDir) => rec.exists(_.seed == i.toLong) && wroteUnderOurDir }
+          )
+        }
+    } @@ TestAspect.nonFlaky,
     test("round-trips a value containing literal braces without truncating sibling keys") {
-      val sc              = scenario("braces in value")
-      val shrunkValues    = Map("col" -> """{"nested": "looks like json"}""")
-      val generatorLabels = Map("col" -> "HasGen[Custom]")
-      for {
-        _        <- cleanup(sc)
-        _        <- PropertyFailureStore.write(sc, seed = 1L, sampleIndex = 0, shrunkValues, generatorLabels)
-        readBack <- PropertyFailureStore.read(sc)
-        _        <- cleanup(sc)
-      } yield assertTrue(
-        readBack.isDefined,
-        readBack.get.shrunkValues == shrunkValues,
-        readBack.get.generatorLabels == generatorLabels
-      )
+      withIsolatedStore { _ =>
+        val sc              = scenario("braces in value")
+        val shrunkValues    = Map("col" -> """{"nested": "looks like json"}""")
+        val generatorLabels = Map("col" -> "HasGen[Custom]")
+        for {
+          _        <- cleanup(sc)
+          _        <- PropertyFailureStore.write(sc, seed = 1L, sampleIndex = 0, shrunkValues, generatorLabels)
+          readBack <- PropertyFailureStore.read(sc)
+          _        <- cleanup(sc)
+        } yield assertTrue(
+          readBack.isDefined,
+          readBack.get.shrunkValues == shrunkValues,
+          readBack.get.generatorLabels == generatorLabels
+        )
+      }
     },
     test("round-trips values containing quotes and backslashes") {
-      val sc           = scenario("quotes and backslashes")
-      val shrunkValues = Map("path" -> """C:\Users\test\"quoted"\file.txt""", "note" -> "she said \"hi\\bye\"")
-      for {
-        _        <- cleanup(sc)
-        _        <- PropertyFailureStore.write(sc, seed = 2L, sampleIndex = 0, shrunkValues, Map.empty)
-        readBack <- PropertyFailureStore.read(sc)
-        _        <- cleanup(sc)
-      } yield assertTrue(readBack.isDefined, readBack.get.shrunkValues == shrunkValues)
+      withIsolatedStore { _ =>
+        val sc           = scenario("quotes and backslashes")
+        val shrunkValues = Map("path" -> """C:\Users\test\"quoted"\file.txt""", "note" -> "she said \"hi\\bye\"")
+        for {
+          _        <- cleanup(sc)
+          _        <- PropertyFailureStore.write(sc, seed = 2L, sampleIndex = 0, shrunkValues, Map.empty)
+          readBack <- PropertyFailureStore.read(sc)
+          _        <- cleanup(sc)
+        } yield assertTrue(readBack.isDefined, readBack.get.shrunkValues == shrunkValues)
+      }
     },
     test("round-trips non-ASCII text") {
-      val sc           = scenario("unicode")
-      val shrunkValues = Map("name" -> "日本語 — café — emoji 🎉")
-      for {
-        _        <- cleanup(sc)
-        _        <- PropertyFailureStore.write(sc, seed = 3L, sampleIndex = 0, shrunkValues, Map.empty)
-        readBack <- PropertyFailureStore.read(sc)
-        _        <- cleanup(sc)
-      } yield assertTrue(readBack.isDefined, readBack.get.shrunkValues == shrunkValues)
+      withIsolatedStore { _ =>
+        val sc           = scenario("unicode")
+        val shrunkValues = Map("name" -> "日本語 — café — emoji 🎉")
+        for {
+          _        <- cleanup(sc)
+          _        <- PropertyFailureStore.write(sc, seed = 3L, sampleIndex = 0, shrunkValues, Map.empty)
+          readBack <- PropertyFailureStore.read(sc)
+          _        <- cleanup(sc)
+        } yield assertTrue(readBack.isDefined, readBack.get.shrunkValues == shrunkValues)
+      }
     },
     test("round-trips an empty shrunkValues/generatorLabels map") {
-      val sc = scenario("empty maps")
-      for {
-        _        <- cleanup(sc)
-        _        <- PropertyFailureStore.write(sc, seed = 4L, sampleIndex = 0, Map.empty, Map.empty)
-        readBack <- PropertyFailureStore.read(sc)
-        _        <- cleanup(sc)
-      } yield assertTrue(readBack.isDefined, readBack.get.shrunkValues.isEmpty, readBack.get.generatorLabels.isEmpty)
+      withIsolatedStore { _ =>
+        val sc = scenario("empty maps")
+        for {
+          _        <- cleanup(sc)
+          _        <- PropertyFailureStore.write(sc, seed = 4L, sampleIndex = 0, Map.empty, Map.empty)
+          readBack <- PropertyFailureStore.read(sc)
+          _        <- cleanup(sc)
+        } yield assertTrue(readBack.isDefined, readBack.get.shrunkValues.isEmpty, readBack.get.generatorLabels.isEmpty)
+      }
     },
     test("multiple columns each round-trip to their own value") {
-      val sc           = scenario("multi column")
-      val shrunkValues = Map("a" -> "1", "b" -> "two}", "c" -> """{"x"}""")
-      for {
-        _        <- cleanup(sc)
-        _        <- PropertyFailureStore.write(sc, seed = 5L, sampleIndex = 0, shrunkValues, Map.empty)
-        readBack <- PropertyFailureStore.read(sc)
-        _        <- cleanup(sc)
-      } yield assertTrue(readBack.isDefined, readBack.get.shrunkValues == shrunkValues)
+      withIsolatedStore { _ =>
+        val sc           = scenario("multi column")
+        val shrunkValues = Map("a" -> "1", "b" -> "two}", "c" -> """{"x"}""")
+        for {
+          _        <- cleanup(sc)
+          _        <- PropertyFailureStore.write(sc, seed = 5L, sampleIndex = 0, shrunkValues, Map.empty)
+          readBack <- PropertyFailureStore.read(sc)
+          _        <- cleanup(sc)
+        } yield assertTrue(readBack.isDefined, readBack.get.shrunkValues == shrunkValues)
+      }
     },
     test("clear deletes the file and read returns None afterwards") {
-      val sc = scenario("clear test")
-      for {
-        _               <- PropertyFailureStore.write(sc, seed = 6L, sampleIndex = 0, Map("n" -> "1"), Map.empty)
-        existsAfterWrite = Option(failuresDir.listFiles()).exists(_.nonEmpty)
-        _               <- PropertyFailureStore.clear(sc)
-        readBack        <- PropertyFailureStore.read(sc)
-      } yield assertTrue(existsAfterWrite, readBack.isEmpty)
+      withIsolatedStore { dir =>
+        val sc = scenario("clear test")
+        for {
+          _               <- PropertyFailureStore.write(sc, seed = 6L, sampleIndex = 0, Map("n" -> "1"), Map.empty)
+          existsAfterWrite = Option(dir.toFile.listFiles()).exists(_.nonEmpty)
+          _               <- PropertyFailureStore.clear(sc)
+          readBack        <- PropertyFailureStore.read(sc)
+        } yield assertTrue(existsAfterWrite, readBack.isEmpty)
+      }
     }
   )
 }


### PR DESCRIPTION
Fixes the intermittent `PropertyExecutorSpec` "Failure replay store" failures (#138).

Root cause: `PropertyFailureStore` used a process-global `.zio-bdd/failures`
directory; `PropertyExecutorSpec.replaySuite` and `PropertyFailureStoreSpec`
both write/read/bulk-delete it and run concurrently (zio-test is parallel by
default), racing on each other's files.

- Production: the base dir is now a per-fiber `FiberRef[Path]` (default
  `.zio-bdd/failures`, unchanged) with `withBaseDir(dir)(zio)` scoping an
  override via `FiberRef.locally`. `read`/`write`/`clear` resolve from it.
  `PropertyExecutor` is untouched; on-disk behaviour with no override is identical.
- Tests: every store-touching test now runs against a fresh, auto-deleted temp
  dir. New `concurrent isolated stores …` gate (32 fibers, one slug,
  `@@ TestAspect.nonFlaky`), a `defaultBaseDir` assertion, and the stale-discard
  test now asserts the record is cleared (closes a swallowed-read false-green).

Verified: `scalafmtCheckAll` clean; core 499 + gherkin 141 tests pass; the
isolation gate is green ×100 under parallelism.

Closes #138
