### PR TITLE
fix: surface corrupt/unreadable property-failure records instead of swallowing them

### DIFF
--- a/core/src/main/scala/zio/bdd/core/property/PropertyFailureStore.scala
+++ b/core/src/main/scala/zio/bdd/core/property/PropertyFailureStore.scala
@@ -3,7 +3,7 @@ package zio.bdd.core.property
 import zio.*
 import zio.bdd.gherkin.Scenario
 
-import java.io.{File, PrintWriter}
+import java.io.{File, IOException, PrintWriter}
 import java.nio.file.{Files, Path, Paths}
 import java.time.Instant
 
@@ -179,27 +179,46 @@ object PropertyFailureStore:
     }
   }
 
+  // The three outcomes of reading a record's file, so a present-but-broken record is
+  // distinguished from a genuinely absent one rather than both collapsing to None.
+  private enum ReadOutcome:
+    case Absent
+    case Parsed(rec: FailureRecord)
+    case Corrupt(reason: String)
+
   def read(scenario: Scenario): UIO[Option[FailureRecord]] =
+    import ReadOutcome.*
     baseDir.get.flatMap { base =>
       ZIO.attemptBlocking {
         val f = fileIn(base, scenario)
-        if (!f.exists()) None
+        if (!f.exists()) Absent
         else {
           val json = scala.util.Using.resource(scala.io.Source.fromFile(f))(_.mkString)
-          decodeJson(json)
+          decodeJson(json) match {
+            case Some(rec) => Parsed(rec)
+            case None      => Corrupt(s"could not parse ${f.getName}")
+          }
         }
       }
-        .orElse(ZIO.none)
+        // Only I/O failures are "corrupt record" — a defect anywhere else (parser bug, etc.)
+        // must die, not be relabelled and swallowed as a warning.
+        .refineToOrDie[IOException]
+        .catchAll(e => ZIO.succeed(Corrupt(Option(e.getMessage).getOrElse(e.toString))))
         .flatMap {
-          case Some(rec) if rec.bodyHash == bodyHash(scenario) => ZIO.some(rec)
-          case Some(_)                                         =>
+          case Absent          => ZIO.none
+          case Corrupt(reason) =>
+            // A record exists but can't be read/parsed (interrupted write, hand-edit, disk
+            // issue). Replay is best-effort so we still fall back to a fresh run — but surface
+            // it, so a broken store isn't silently mistaken for "no failure recorded". See #140.
+            ZIO.logWarning(s"Unreadable property-failure record for '${scenario.name}': $reason").as(None)
+          case Parsed(rec) if rec.bodyHash == bodyHash(scenario) => ZIO.some(rec)
+          case Parsed(_)                                         =>
             // The scenario's step list changed since this failure was recorded — the stored
             // counterexample no longer corresponds to the current scenario body. Discard it
             // rather than replaying a test that no longer exists in this form.
             ZIO.logWarning(
               s"Discarding stale property-failure record for '${scenario.name}' — scenario body changed since it was recorded."
             ) *> clear(scenario).as(None)
-          case None => ZIO.none
         }
     }
 

--- a/core/src/test/scala/zio/bdd/core/property/PropertyFailureStoreSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/property/PropertyFailureStoreSpec.scala
@@ -42,7 +42,69 @@ object PropertyFailureStoreSpec extends ZIOSpecDefault {
       .acquireRelease(ZIO.attempt(Files.createTempDirectory("zio-bdd-failures-spec")).orDie)(deleteRecursively)
       .flatMap(dir => PropertyFailureStore.withBaseDir(dir)(use(dir)))
 
+  private def recordFile(dir: Path, sc: Scenario): Path =
+    dir.resolve(PropertyFailureStore.slug(sc) + ".json")
+
+  // A read of `sc` warned that its record is unreadable — bound to the scenario name so a
+  // warning about a different record can't satisfy it.
+  private def warnedUnreadable(logs: Chunk[ZTestLogger.LogEntry], sc: Scenario): Boolean =
+    logs.exists { e =>
+      e.logLevel == LogLevel.Warning &&
+      e.message().contains("Unreadable property-failure record") &&
+      e.message().contains(sc.name)
+    }
+
+  // Install `fixture` (a present-but-unreadable record), read `sc`, and assert the read falls
+  // back to None while warning about the unreadable record. Runs under ZTestLogger so the
+  // warning is captured rather than printed.
+  private def assertReadWarnsUnreadable(sc: Scenario)(fixture: UIO[Any]): UIO[TestResult] =
+    (for {
+      _      <- fixture
+      result <- PropertyFailureStore.read(sc)
+      logs   <- ZTestLogger.logOutput
+    } yield assertTrue(result.isEmpty, warnedUnreadable(logs, sc))).provideLayer(ZTestLogger.default)
+
   def spec: Spec[TestEnvironment & Scope, Any] = suite("PropertyFailureStoreSpec")(
+    test("a present-but-corrupt record is logged as a warning and read falls back to None (#140)") {
+      withIsolatedStore { dir =>
+        val sc = scenario("corrupt content")
+        assertReadWarnsUnreadable(sc) {
+          ZIO.attempt(Files.writeString(recordFile(dir, sc), "this is not valid json {{{")).orDie
+        }
+      }
+    },
+    test("a present-but-empty record is logged as a warning and read falls back to None (#140)") {
+      withIsolatedStore { dir =>
+        // A 0-byte file is the realistic interrupted-write shape: present but unparseable.
+        val sc = scenario("empty file")
+        assertReadWarnsUnreadable(sc) {
+          ZIO.attempt(Files.writeString(recordFile(dir, sc), "")).orDie
+        }
+      }
+    },
+    test("an unreadable record (I/O error) is logged as a warning and read falls back to None (#140)") {
+      withIsolatedStore { dir =>
+        // A directory where a file is expected: it `exists()`, but opening it as a file throws,
+        // exercising the I/O-exception path (the original `.orElse(ZIO.none)` silent swallow).
+        val sc = scenario("io error")
+        assertReadWarnsUnreadable(sc) {
+          ZIO.attempt(Files.createDirectory(recordFile(dir, sc))).orDie
+        }
+      }
+    },
+    test("a genuinely absent record returns None with no warning (#140)") {
+      withIsolatedStore { _ =>
+        // The common path must stay quiet — no file written, no warning of any kind.
+        val sc = scenario("absent record")
+        (for {
+          result <- PropertyFailureStore.read(sc)
+          logs   <- ZTestLogger.logOutput
+        } yield assertTrue(
+          result.isEmpty,
+          !logs.exists(_.logLevel == LogLevel.Warning)
+        )).provideLayer(ZTestLogger.default)
+      }
+    },
     test("the default base directory is the production .zio-bdd/failures layout (#138)") {
       // Every other test overrides the base dir, so this pins the un-overridden default that
       // production (and external tooling reading the files) relies on — a rename would


### PR DESCRIPTION
Fixes the silent swallow in `PropertyFailureStore.read` (#140): a corrupt or
unreadable `.zio-bdd/failures/<slug>.json` was coerced into `None` with no log,
so a broken store was indistinguishable from "no failure recorded" and replay
was silently skipped.

- `read` now classifies the file over a private `enum ReadOutcome { Absent,
  Parsed, Corrupt }`. A present-but-broken record (I/O error **or** `decodeJson`
  returning None) becomes `Corrupt`, which logs
  `ZIO.logWarning("Unreadable property-failure record for '<scenario>': …")` and
  falls back to None. A genuinely absent record stays a quiet None. The
  stale-bodyHash discard branch (warn + clear) is preserved.
- The catch is narrowed with `.refineToOrDie[IOException]` so only I/O failures
  are treated as "corrupt" — a genuine defect (parser bug, NPE) dies as a defect
  rather than being mislabelled and downgraded to a warning (per the project's
  `refineOrDie`-over-`catchAll(Throwable)` rule).

Tests (capture logs via `ZTestLogger`): corrupt content, empty file
(interrupted-write shape), and I/O error (directory-at-path → IOException) each
assert read → None **and** a Warning bound to the scenario name; the absent-record
test asserts None with no Warning-level log at all.

Verified: `scalafmtCheckAll` clean; core 503 + gherkin 141 tests pass.

Closes #140
