### PR TITLE
feat: Rift adapter (container/subprocess) implementing MockControl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val mimaSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .aggregate(core, gherkin, mock)
+  .aggregate(core, gherkin, mock, rift)
   .settings(
     name                  := "zio-bdd-root",
     description           := "A ZIO-based BDD testing framework for Scala 3",
@@ -131,6 +131,25 @@ lazy val mock = (project in file("mock"))
   .settings(
     name := "zio-bdd-mock",
     libraryDependencies ++= commonDependencies,
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
+    mimaPreviousArtifacts := Set.empty
+  )
+
+// Rift adapter (#113): implements the portable MockControl SPI over the Rift
+// (Mountebank-compatible) backend. Drives the admin API via zio-http and can
+// stand up the published image via testcontainers. Depends on `mock`, never the
+// reverse.
+lazy val rift = (project in file("rift"))
+  .dependsOn(mock)
+  .settings(
+    name := "zio-bdd-rift",
+    libraryDependencies ++= commonDependencies,
+    libraryDependencies ++= Seq(
+      "dev.zio"      %% "zio-http"                   % "3.2.0",
+      "dev.zio"      %% "zio-json"                   % "0.7.3",
+      "com.dimafeng" %% "testcontainers-scala-core"  % "0.41.4"
+    ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
     mimaPreviousArtifacts := Set.empty

--- a/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
@@ -1,0 +1,82 @@
+package zio.bdd.mock.rift
+
+import zio.*
+import zio.bdd.mock.{MockControl, MockError, Provisioning}
+import zio.http.Client
+import com.dimafeng.testcontainers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+
+/**
+ * Entry points for the Rift adapter — the default, zero-native-artifact
+ * provider of the portable mocking SPI (#113).
+ *
+ *   - [[connect]] targets an already-running Rift admin endpoint with a known
+ *     imposter port pool (used by tests and when Rift runs out-of-band).
+ *   - [[managed]] stands up the published Rift image via testcontainers and
+ *     stops it with the layer's scope finalizer.
+ */
+object Rift:
+
+  // Pinned to v0.2.0: the first release where DELETE /imposters/:port tears down
+  // existing keep-alive connections, so a destroyed imposter stops serving even
+  // a pooled client (EtaCassiopeia/rift#207).
+  val DefaultImage: String     = "zainalpour/rift-proxy:v0.2.0"
+  val DefaultAdminPort: Int    = 2525
+  val DefaultImposterBase: Int = 4545
+  val DefaultPoolSize: Int     = 16
+
+  /**
+   * Adapter over an already-running Rift: `adminBase` is the admin URL,
+   * `imposterPorts` the pool of ports imposters may bind, and `hostFor` maps an
+   * imposter port to its SUT-reachable base URI (the identity under host
+   * networking).
+   */
+  def connect(
+    adminBase: String,
+    imposterPorts: List[Int]
+  )(hostFor: Int => String): URLayer[Client & Provisioning, MockControl] =
+    ZLayer {
+      RiftEndpoint.pooled(adminBase, imposterPorts)(hostFor).flatMap(RiftMockControl.make)
+    }
+
+  /**
+   * Start the Rift image via testcontainers, exposing the admin port plus a
+   * pool of imposter ports, and expose a [[MockControl]] bound to it. The
+   * container is stopped when the layer's scope closes.
+   *
+   * Container port-mapping wrinkle: testcontainers maps each exposed imposter
+   * port to an arbitrary host port, so each [[zio.bdd.mock.MockSpace]]
+   * `baseUri` is built from the *host-mapped* port. On CI you may instead run
+   * Rift with host networking and a pre-mapped port pool, where the mapping is
+   * identity.
+   */
+  def managed(
+    image: String = DefaultImage,
+    poolSize: Int = DefaultPoolSize,
+    adminPort: Int = DefaultAdminPort,
+    imposterBasePort: Int = DefaultImposterBase
+  ): ZLayer[Client & Provisioning, MockError, MockControl] =
+    ZLayer.scoped {
+      val imposterPorts = (0 until poolSize).map(imposterBasePort + _).toList
+      for
+        container <- ZIO.acquireRelease(
+                       ZIO.attemptBlocking {
+                         val c = GenericContainer(
+                           dockerImage = image,
+                           exposedPorts = adminPort :: imposterPorts,
+                           waitStrategy = Wait.forHttp("/imposters").forPort(adminPort)
+                         )
+                         c.start()
+                         c
+                       }
+                         .mapError(t => MockError.ProvisionFailed(s"starting Rift container '$image': ${message(t)}"))
+                     )(c => ZIO.attemptBlocking(c.stop()).orDie)
+        host      = container.host
+        admin     = s"http://$host:${container.mappedPort(adminPort)}"
+        endpoint <- RiftEndpoint.pooled(admin, imposterPorts)(p => s"http://$host:${container.mappedPort(p)}")
+        control  <- RiftMockControl.make(endpoint)
+      yield control
+    }
+
+  private def message(t: Throwable): String =
+    Option(t.getMessage).getOrElse(t.getClass.getSimpleName)

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftEndpoint.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftEndpoint.scala
@@ -1,0 +1,50 @@
+package zio.bdd.mock.rift
+
+import zio.*
+import zio.bdd.mock.MockError
+
+/**
+ * Where Rift's admin API lives and how an imposter's port maps to a URI the SUT
+ * can actually reach — the seam that isolates the container port-mapping
+ * wrinkle from the protocol logic.
+ *
+ * With a container, imposters bind ports *inside* the container that
+ * testcontainers maps to arbitrary host ports, so the adapter cannot pick a
+ * host port up front (the way [[zio.bdd.mock.Provisioning]] does for in-process
+ * backends). Instead it draws an imposter port from a pre-exposed pool and asks
+ * the endpoint for the reachable base URI. Under host networking the mapping is
+ * the identity; the pooled implementation below covers both.
+ */
+private[rift] trait RiftEndpoint:
+  /** Base URL of the admin API, e.g. `http://localhost:2525`. */
+  def adminBase: String
+
+  /** Take an imposter port from the pool, or fail if the pool is exhausted. */
+  def acquirePort: IO[MockError, Int]
+
+  /** Return a port to the pool after an imposter is destroyed. */
+  def releasePort(port: Int): UIO[Unit]
+
+  /** The SUT-reachable base URI for an imposter bound to `imposterPort`. */
+  def baseUriFor(imposterPort: Int): String
+
+private[rift] object RiftEndpoint:
+
+  /**
+   * A fixed pool of imposter ports plus a caller-supplied mapping from an
+   * imposter port to its reachable URI (identity under host networking; the
+   * container's host-mapped port otherwise).
+   */
+  def pooled(admin: String, ports: List[Int])(hostFor: Int => String): UIO[RiftEndpoint] =
+    Ref.make(ports).map(free => Pooled(admin, free, hostFor))
+
+  private final case class Pooled(adminBase: String, free: Ref[List[Int]], hostFor: Int => String) extends RiftEndpoint:
+    def acquirePort: IO[MockError, Int] =
+      free.modify {
+        case head :: tail => (ZIO.succeed(head), tail)
+        case Nil          => (ZIO.fail(MockError.ProvisionFailed("Rift imposter port pool exhausted")), Nil)
+      }.flatten
+
+    def releasePort(port: Int): UIO[Unit] = free.update(port :: _)
+
+    def baseUriFor(imposterPort: Int): String = hostFor(imposterPort)

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -1,0 +1,209 @@
+package zio.bdd.mock.rift
+
+import zio.*
+import zio.bdd.mock.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.http.{Body, Client, Header, MediaType, Request, URL, Method as HttpMethod}
+
+/**
+ * The Rift adapter: implements the portable [[MockControl]] core port by
+ * driving Rift's Mountebank-compatible admin API over zio-http.
+ *
+ * PerInstance isolation: each [[MockSpace]] is one imposter on its own port and
+ * `inject == identity`. `destroy` deletes exactly that imposter (`DELETE
+ * /imposters/:port`) — never the global `DELETE /imposters` reset, so tearing
+ * down one space never touches another (#113 AC2).
+ *
+ * Rule identity: Mountebank addresses stubs by positional index, which shifts
+ * as stubs are inserted/removed. The adapter therefore hands out stable opaque
+ * [[RuleId]]s and tracks their current order per imposter, translating an id to
+ * its live index on removal — so a [[RuleId]] never silently points at the
+ * wrong stub after an overlay insert.
+ *
+ * Capabilities are intentionally empty here: the optional capability
+ * *interfaces* (faults, scenarios, …) are fleshed out in M3, so this adapter
+ * advertises none and every accessor fails fast with [[Unsupported]].
+ */
+private[rift] final case class RiftMockControl(
+  endpoint: RiftEndpoint,
+  client: Client,
+  provisioning: Provisioning,
+  spaces: Ref[Map[SpaceId, RiftMockControl.Imposter]],
+  ids: Ref[Int]
+) extends MockControl:
+
+  def backendName: String           = "rift"
+  def capabilities: Set[Capability] = Set.empty
+
+  def provision(source: MockSource): IO[MockError, List[MockSpace]] =
+    for
+      sources <- provisioning.normalize(source)
+      created <- Ref.make(List.empty[MockSpace])
+      // Provision atomically: tear down any spaces already stood up if a later
+      // space in the same source fails, so a partial batch never orphans
+      // imposters/ports the caller can't reach.
+      spaces <- ZIO
+                  .foreach(sources)(src => serveSpace(src).tap(s => created.update(s :: _)))
+                  .onError(_ => created.get.flatMap(ZIO.foreachDiscard(_)(s => destroy(s).ignore)))
+    yield spaces
+
+  def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+    ZIO.fail(MockError.InvalidDefinition("the Rift adapter does not support native specs yet (#119)"))
+
+  def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+    withImposter(space) { imp =>
+      for
+        ruleId <- freshId
+        // First match wins in Mountebank, so an overlay rule goes on top
+        // (index 0) and a base rule is appended after the existing stubs.
+        index <- priority match
+                   case Priority.Overlay => ZIO.succeed(0)
+                   case Priority.Base    => imp.stubs.get.map(_.size)
+        u   <- url(s"/imposters/${imp.port}/stubs")
+        res <- send(jsonRequest(HttpMethod.POST, u, RiftProtocol.addStubBody(index, rule)))
+        _   <- expectSuccess(s"add rule to imposter ${imp.port}", res)
+        _   <- imp.stubs.update(v => if priority == Priority.Overlay then ruleId +: v else v :+ ruleId)
+      yield ruleId
+    }
+
+  def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit] =
+    withImposter(space) { imp =>
+      imp.stubs.get.flatMap { ordered =>
+        ordered.indexOf(id) match
+          case -1 => ZIO.fail(MockError.RuleNotFound(space.id, id))
+          case idx =>
+            for
+              u   <- url(s"/imposters/${imp.port}/stubs/$idx")
+              res <- send(Request(method = HttpMethod.DELETE, url = u))
+              _   <- expectSuccess(s"remove rule from imposter ${imp.port}", res)
+              _   <- imp.stubs.update(_.patch(idx, Nil, 1))
+            yield ()
+      }
+    }
+
+  def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit] =
+    withImposter(space) { imp =>
+      for
+        ruleIds <- freshIds(rules.size)
+        u       <- url(s"/imposters/${imp.port}/stubs")
+        res     <- send(jsonRequest(HttpMethod.PUT, u, RiftProtocol.replaceStubsBody(rules)))
+        _       <- expectSuccess(s"replace rules on imposter ${imp.port}", res)
+        _       <- imp.stubs.set(ruleIds)
+      yield ()
+    }
+
+  def destroy(space: MockSpace): IO[MockError, Unit] =
+    withImposter(space) { imp =>
+      for
+        u   <- url(s"/imposters/${imp.port}")
+        res <- send(Request(method = HttpMethod.DELETE, url = u))
+        // A 404 means the imposter is already gone — destroy is idempotent.
+        _ <- ZIO.unless(res._1 == 404)(expectSuccess(s"destroy imposter ${imp.port}", res))
+        _ <- endpoint.releasePort(imp.port)
+        _ <- spaces.update(_ - space.id)
+      yield ()
+    }
+
+  def received(space: MockSpace): IO[MockError, List[RecordedRequest]] =
+    withImposter(space) { imp =>
+      for
+        u    <- url(s"/imposters/${imp.port}")
+        res  <- send(Request(method = HttpMethod.GET, url = u))
+        body <- expectSuccess(s"read imposter ${imp.port}", res)
+        // A malformed view is a backend/protocol fault, not a bad user definition.
+        recs <- ZIO.fromEither(RiftProtocol.parseRecorded(body)).mapError(MockError.CommunicationError(_))
+      yield recs
+    }
+
+  def faults: IO[Unsupported, Faults]                   = unsupported(Capability.Faults)
+  def scenarios: IO[Unsupported, StatefulScenarios]     = unsupported(Capability.StatefulScenarios)
+  def stateInspection: IO[Unsupported, StateInspection] = unsupported(Capability.StateInspection)
+  def scripting: IO[Unsupported, Scripting]             = unsupported(Capability.Scripting)
+  def proxyRecord: IO[Unsupported, ProxyRecord]         = unsupported(Capability.ProxyRecord)
+  def templating: IO[Unsupported, Templating]           = unsupported(Capability.Templating)
+
+  // ---------------------------------------------------------------------------
+
+  private def serveSpace(src: NormalizedSource): IO[MockError, MockSpace] =
+    endpoint.acquirePort.flatMap { port =>
+      val stand =
+        for
+          bodyAndCount <- imposterBody(port, src)
+          (body, count) = bodyAndCount
+          _            <- postImposter(port, body)
+          ruleIds      <- freshIds(count)
+          stubs        <- Ref.make(ruleIds)
+          id            = SpaceId(s"${src.name}-$port")
+          space         = MockSpace(endpoint.baseUriFor(port), identity, id)
+          _            <- spaces.update(_.updated(id, RiftMockControl.Imposter(port, stubs)))
+        yield space
+      // Release the port back to the pool on *any* failure after acquiring it
+      // (malformed source, POST rejected, …) so a bad provision can't leak slots.
+      stand.onError(_ => endpoint.releasePort(port))
+    }
+
+  private def imposterBody(port: Int, src: NormalizedSource): IO[MockError, (Json, Int)] =
+    src.payload match
+      case SourcePayload.Rules(rules) =>
+        ZIO.succeed((RiftProtocol.imposter(port, src.name, rules), rules.length))
+      case SourcePayload.Raw(text) =>
+        ZIO.fromEither(RiftProtocol.imposterFromRaw(port, src.name, text)).mapError(MockError.InvalidDefinition(_))
+
+  private def postImposter(port: Int, body: Json): IO[MockError, Unit] =
+    for
+      u   <- url("/imposters")
+      res <- send(jsonRequest(HttpMethod.POST, u, body))
+      _   <- expectSuccess(s"create imposter on port $port", res)
+    yield ()
+
+  private def freshId: UIO[RuleId] = ids.updateAndGet(_ + 1).map(n => RuleId(s"r$n"))
+
+  private def freshIds(n: Int): UIO[Vector[RuleId]] = ZIO.foreach(0 until n)(_ => freshId).map(_.toVector)
+
+  private def withImposter[A](space: MockSpace)(f: RiftMockControl.Imposter => IO[MockError, A]): IO[MockError, A] =
+    spaces.get.flatMap(_.get(space.id) match
+      case Some(imp) => f(imp)
+      case None      => ZIO.fail(MockError.SpaceNotFound(space.id))
+    )
+
+  private def unsupported[A](c: Capability): IO[Unsupported, A] = ZIO.fail(Unsupported(c, backendName))
+
+  private def url(path: String): IO[MockError, URL] =
+    ZIO
+      .fromEither(URL.decode(endpoint.adminBase + path))
+      .mapError(e => MockError.CommunicationError(s"invalid admin URL ${endpoint.adminBase}$path: ${e.getMessage}"))
+
+  private def jsonRequest(method: HttpMethod, u: URL, body: Json): Request =
+    Request(method = method, url = u, body = Body.fromString(body.toJson))
+      .addHeader(Header.ContentType(MediaType.application.json))
+
+  private def send(req: Request): IO[MockError, (Int, String)] =
+    Client
+      .batched(req)
+      .flatMap(resp => resp.body.asString.map(body => (resp.status.code, body)))
+      .provideEnvironment(ZEnvironment(client))
+      .mapError { t =>
+        val msg = Option(t.getMessage).filter(_.nonEmpty).fold("")(m => s": $m")
+        MockError.CommunicationError(s"${t.getClass.getSimpleName}$msg")
+      }
+
+  private def expectSuccess(action: String, res: (Int, String)): IO[MockError, String] =
+    val (code, body) = res
+    if code >= 200 && code < 300 then ZIO.succeed(body)
+    else ZIO.fail(MockError.CommunicationError(s"$action: Rift returned HTTP $code: ${body.take(1000)}"))
+
+private[rift] object RiftMockControl:
+  final case class Imposter(port: Int, stubs: Ref[Vector[RuleId]])
+
+  /**
+   * Build an adapter against an endpoint, taking the zio-http [[Client]] and
+   * [[Provisioning]] from the environment.
+   */
+  def make(endpoint: RiftEndpoint): URIO[Client & Provisioning, MockControl] =
+    for
+      client <- ZIO.service[Client]
+      prov   <- ZIO.service[Provisioning]
+      spaces <- Ref.make(Map.empty[SpaceId, Imposter])
+      ids    <- Ref.make(0)
+    yield RiftMockControl(endpoint, client, prov, spaces, ids)

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -1,0 +1,161 @@
+package zio.bdd.mock.rift
+
+import zio.bdd.mock.*
+import zio.json.*
+import zio.json.ast.Json
+
+/**
+ * Pure translation between the canonical mock model and Rift's
+ * Mountebank-compatible wire JSON. No effects, no I/O — every function is a
+ * total mapping over value types, so the protocol is unit-testable without a
+ * backend.
+ */
+private[rift] object RiftProtocol:
+
+  // ---------------------------------------------------------------------------
+  // Canonical model -> Mountebank wire JSON
+  // ---------------------------------------------------------------------------
+
+  /**
+   * A full `POST /imposters` body for one space: one imposter, recording on.
+   */
+  def imposter(port: Int, name: String, rules: List[MockRule]): Json =
+    Json.Obj(
+      "port"           -> Json.Num(port),
+      "protocol"       -> Json.Str("http"),
+      "name"           -> Json.Str(name),
+      "recordRequests" -> Json.Bool(true),
+      "stubs"          -> Json.Arr(rules.map(stub)*)
+    )
+
+  /** A single Mountebank stub: predicates (ANDed) + one response. */
+  def stub(rule: MockRule): Json =
+    val idField = rule.id.map(id => "id" -> Json.Str(id.value)).toList
+    Json.Obj(
+      (idField ++ List(
+        "predicates" -> Json.Arr(predicates(rule.`match`)*),
+        "responses"  -> Json.Arr(response(rule.respond))
+      ))*
+    )
+
+  /** The `{stubs: [...]}` body for `PUT /imposters/:port/stubs`. */
+  def replaceStubsBody(rules: List[MockRule]): Json =
+    Json.Obj("stubs" -> Json.Arr(rules.map(stub)*))
+
+  /** The `{index, stub}` body for `POST /imposters/:port/stubs`. */
+  def addStubBody(index: Int, rule: MockRule): Json =
+    Json.Obj("index" -> Json.Num(index), "stub" -> stub(rule))
+
+  def predicates(m: RequestMatch): List[Json] =
+    val methodPred = m.method.map(meth => equalsObj("method" -> Json.Str(methodName(meth))))
+    val pathPred = m.path match
+      case PathMatch.Any         => None
+      case PathMatch.Exact(p)    => Some(equalsObj("path" -> Json.Str(p)))
+      case PathMatch.Regex(r)    => Some(matchesObj("path" -> Json.Str(r)))
+      case PathMatch.Template(t) => Some(matchesObj("path" -> Json.Str(templateToRegex(t))))
+    val queryPreds  = m.query.toList.map((k, vm) => valuePred("query", k, vm))
+    val headerPreds = m.headers.toList.map((k, vm) => valuePred("headers", k, vm))
+    val bodyPred    = m.body.map(bodyPredicate)
+    methodPred.toList ++ pathPred.toList ++ queryPreds ++ headerPreds ++ bodyPred.toList
+
+  def response(r: ResponseDef): Json =
+    val headers =
+      if r.headers.isEmpty then Nil
+      else List("headers" -> Json.Obj(r.headers.toList.map((k, v) => k -> Json.Str(v))*))
+    val body = r.body match
+      case Body.Empty     => Nil
+      case Body.Text(v)   => List("body" -> Json.Str(v))
+      case Body.Json(v)   => List("body" -> Json.Str(v))
+      case Body.Base64(v) => List("body" -> Json.Str(v), "_mode" -> Json.Str("binary"))
+    val isObj = Json.Obj((("statusCode" -> Json.Num(r.status)) :: headers ++ body)*)
+    val behaviors =
+      r.delay.map(d => "_behaviors" -> Json.Obj("wait" -> Json.Num(d.toMillis.toInt))).toList
+    Json.Obj((("is" -> isObj) :: behaviors)*)
+
+  /** Rebuild a raw imposter doc, forcing our pool port and recording on. */
+  def imposterFromRaw(port: Int, name: String, raw: String): Either[String, (Json, Int)] =
+    raw.fromJson[Json].flatMap {
+      case obj: Json.Obj =>
+        val fields    = obj.fields.toMap
+        val stubCount = fields.get("stubs").collect { case Json.Arr(es) => es.length }.getOrElse(0)
+        val forced = upsert(
+          obj,
+          "port"           -> Json.Num(port),
+          "protocol"       -> fields.getOrElse("protocol", Json.Str("http")),
+          "name"           -> fields.getOrElse("name", Json.Str(name)),
+          "recordRequests" -> Json.Bool(true)
+        )
+        Right((forced, stubCount))
+      case _ => Left("raw Rift source must be a JSON object (an imposter document)")
+    }
+
+  // ---------------------------------------------------------------------------
+  // Mountebank wire JSON -> canonical model (recorded requests)
+  // ---------------------------------------------------------------------------
+
+  private case class WireReq(
+    method: String,
+    path: String,
+    headers: Option[Map[String, String]] = None,
+    body: Option[String] = None
+  ) derives JsonDecoder
+  private case class WireView(requests: Option[List[WireReq]] = None) derives JsonDecoder
+
+  /** Parse the `requests[]` of a `GET /imposters/:port` view. */
+  def parseRecorded(viewJson: String): Either[String, List[RecordedRequest]] =
+    viewJson.fromJson[WireView].map { v =>
+      v.requests.getOrElse(Nil).map { r =>
+        RecordedRequest(
+          method = methodFromWire(r.method),
+          uri = r.path,
+          headers = r.headers.getOrElse(Map.empty),
+          body = r.body
+        )
+      }
+    }
+
+  // ---------------------------------------------------------------------------
+  // helpers
+  // ---------------------------------------------------------------------------
+
+  def methodName(m: Method): String = m.toString.toUpperCase
+
+  // Rift records standard, upper-case HTTP method names; an unrecognized token
+  // (never produced by Rift) falls back to GET rather than failing a read.
+  def methodFromWire(s: String): Method =
+    Method.values.find(_.toString.equalsIgnoreCase(s)).getOrElse(Method.Get)
+
+  // "/users/{id}" -> anchored regex "^/users/[^/]+$" (Mountebank has no template).
+  def templateToRegex(t: String): String =
+    "^" + t.replaceAll("\\{[^/}]+\\}", "[^/]+") + "$"
+
+  private def equalsObj(fields: (String, Json)*): Json  = Json.Obj("equals" -> Json.Obj(fields*))
+  private def matchesObj(fields: (String, Json)*): Json = Json.Obj("matches" -> Json.Obj(fields*))
+
+  private def valuePred(selector: String, key: String, vm: ValueMatch): Json =
+    val (op, value) = vm match
+      case ValueMatch.Equals(v)   => ("equals", v)
+      case ValueMatch.Contains(v) => ("contains", v)
+      case ValueMatch.Matches(r)  => ("matches", r)
+    Json.Obj(op -> Json.Obj(selector -> Json.Obj(key -> Json.Str(value))))
+
+  private def bodyPredicate(bm: BodyMatch): Json =
+    bm match
+      case BodyMatch.Equals(v)   => Json.Obj("equals" -> Json.Obj("body" -> Json.Str(v)))
+      case BodyMatch.Contains(v) => Json.Obj("contains" -> Json.Obj("body" -> Json.Str(v)))
+      case BodyMatch.Matches(r)  => Json.Obj("matches" -> Json.Obj("body" -> Json.Str(r)))
+      case BodyMatch.JsonPath(path, expected) =>
+        selectorPred("jsonpath", path, expected)
+      case BodyMatch.XPath(path, expected) =>
+        selectorPred("xpath", path, expected)
+
+  private def selectorPred(kind: String, path: String, expected: Option[String]): Json =
+    val sel = kind -> Json.Obj("selector" -> Json.Str(path))
+    expected match
+      case Some(e) => Json.Obj(sel, "equals" -> Json.Obj("body" -> Json.Str(e)))
+      case None    => Json.Obj(sel, "exists" -> Json.Obj("body" -> Json.Bool(true)))
+
+  private def upsert(obj: Json.Obj, overrides: (String, Json)*): Json.Obj =
+    val overrideKeys = overrides.map(_._1).toSet
+    val kept         = obj.fields.filterNot((k, _) => overrideKeys(k))
+    Json.Obj(kept ++ overrides)

--- a/rift/src/test/scala/zio/bdd/mock/rift/FakeRift.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/FakeRift.scala
@@ -1,0 +1,94 @@
+package zio.bdd.mock.rift
+
+import zio.*
+import zio.http.*
+import zio.json.ast.Json
+
+/**
+ * An in-process stand-in for Rift's admin API: it records the admin calls the
+ * adapter makes and serves canned imposter views, so the adapter's protocol and
+ * isolation behaviour can be unit-tested with no Docker and no real backend.
+ *
+ * It deliberately does NOT serve imposter traffic — "serving" is the real
+ * container's job, proven by the tagged [[RiftContainerSpec]].
+ */
+final case class FakeRift(
+  posted: Ref[Chunk[String]],
+  deletedPorts: Ref[Chunk[Int]],
+  globalDeletes: Ref[Int],
+  stubCalls: Ref[Chunk[String]],
+  views: Ref[Map[Int, String]],
+  failProvision: Ref[Boolean]
+):
+  /**
+   * Preset the `GET /imposters/:port` view (e.g. to inject recorded requests).
+   */
+  def setView(port: Int, json: String): UIO[Unit] = views.update(_.updated(port, json))
+
+  val routes: Routes[Any, Response] =
+    Routes(
+      Method.POST / "imposters" -> handler { (req: Request) =>
+        req.body.asString.orDie.flatMap { body =>
+          val port = FakeRift.portOf(body).getOrElse(0)
+          failProvision.get.flatMap {
+            case true =>
+              ZIO.succeed(
+                Response(status = Status.BadRequest, body = Body.fromString("""{"errors":[{"code":"400"}]}"""))
+              )
+            case false =>
+              posted.update(_ :+ body) *>
+                views.update(m => if m.contains(port) then m else m.updated(port, FakeRift.emptyView(port))) *>
+                ZIO.succeed(Response(status = Status.Created, body = Body.fromString(s"""{"port":$port}""")))
+          }
+        }
+      },
+      Method.GET / "imposters" / int("port") -> handler { (port: Int, _: Request) =>
+        views.get.map(m => Response(body = Body.fromString(m.getOrElse(port, FakeRift.emptyView(port)))))
+      },
+      Method.DELETE / "imposters" / int("port") -> handler { (port: Int, _: Request) =>
+        (deletedPorts.update(_ :+ port) *> views.update(_ - port)).as(Response.ok)
+      },
+      Method.DELETE / "imposters" -> handler { (_: Request) =>
+        globalDeletes.update(_ + 1).as(Response.ok)
+      },
+      Method.POST / "imposters" / int("port") / "stubs" -> handler { (port: Int, req: Request) =>
+        req.body.asString.orDie.flatMap(b => stubCalls.update(_ :+ s"POST $port $b")).as(Response.ok)
+      },
+      Method.PUT / "imposters" / int("port") / "stubs" -> handler { (port: Int, req: Request) =>
+        req.body.asString.orDie.flatMap(b => stubCalls.update(_ :+ s"PUT $port $b")).as(Response.ok)
+      },
+      Method.DELETE / "imposters" / int("port") / "stubs" / int("index") -> handler {
+        (port: Int, index: Int, _: Request) =>
+          stubCalls.update(_ :+ s"DELETE $port/$index").as(Response.ok)
+      }
+    )
+
+object FakeRift:
+  private def emptyView(port: Int): String = s"""{"port":$port,"requests":[]}"""
+
+  def make: UIO[FakeRift] =
+    for
+      a <- Ref.make(Chunk.empty[String])
+      b <- Ref.make(Chunk.empty[Int])
+      c <- Ref.make(0)
+      d <- Ref.make(Chunk.empty[String])
+      e <- Ref.make(Map.empty[Int, String])
+      f <- Ref.make(false)
+    yield FakeRift(a, b, c, d, e, f)
+
+  def portOf(body: String): Option[Int] =
+    import zio.json.*
+    body.fromJson[Json].toOption.flatMap {
+      case o: Json.Obj => o.fields.toMap.get("port").collect { case Json.Num(n) => n.intValue }
+      case _           => None
+    }
+
+  /** Stand a fresh fake up on an ephemeral port inside the current scope. */
+  def started: ZIO[Scope, Throwable, (String, FakeRift)] =
+    for
+      fake  <- make
+      env   <- Server.defaultWithPort(0).build
+      server = env.get[Server]
+      _     <- server.install(fake.routes)
+      port  <- server.port
+    yield (s"http://localhost:$port", fake)

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
@@ -1,0 +1,83 @@
+package zio.bdd.mock.rift
+
+import zio.*
+import zio.bdd.mock.*
+import zio.http.{Client, Request, URL}
+import zio.test.*
+
+/**
+ * End-to-end acceptance against a REAL Rift container (#113 AC1/AC2). Opt-in:
+ * runs only when `RIFT_IT` is set, so the default `sbt test` stays hermetic and
+ * Docker-free. Run it with `RIFT_IT=1 sbt rift/test`.
+ */
+object RiftContainerSpec extends ZIOSpecDefault:
+
+  private val pingRule = MockRule(
+    `match` = RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+    respond = ResponseDef(status = 200, body = Body.Text("pong"))
+  )
+  private val pingSource = MockSource.Dsl(MockSpec(List(pingRule)))
+
+  // Imposter binds slightly after provision returns; retry the first hit briefly.
+  private val upWithin: Schedule[Any, Any, Any] = Schedule.recurs(20) && Schedule.spaced(100.millis)
+
+  private def httpGet(base: String, path: String): ZIO[Client, Throwable, (Int, String)] =
+    for
+      url  <- ZIO.fromEither(URL.decode(base + path))
+      resp <- Client.batched(Request.get(url))
+      body <- resp.body.asString
+    yield (resp.status.code, body)
+
+  // Teardown is observed even through the client's pooled keep-alive connection:
+  // as of Rift v0.2.0 (rift#207) DELETE /imposters/:port closes existing
+  // connections, so a destroyed imposter stops serving. Poll briefly since the
+  // socket close races the DELETE response.
+  private def waitUntilGone(base: String): ZIO[Client, Nothing, Boolean] =
+    (ZIO.sleep(100.millis) *> httpGet(base, "/ping").either.map(_.isLeft))
+      .repeatUntilEquals(true)
+      .timeoutTo(false)(identity)(5.seconds)
+
+  private val realSuite = suite("RiftContainerSpec (real Rift container)")(
+    test("provisions, serves, records, and destroys a space") {
+      for
+        control  <- ZIO.service[MockControl]
+        spaces   <- control.provision(pingSource)
+        space     = spaces.head
+        served   <- httpGet(space.baseUri, "/ping").retry(upWithin)
+        recorded <- control.received(space)
+        _        <- control.destroy(space)
+        gone     <- waitUntilGone(space.baseUri)
+      yield assertTrue(
+        spaces.size == 1,
+        served == (200, "pong"),                                          // serves
+        recorded.exists(r => r.method == Method.Get && r.uri == "/ping"), // records
+        gone                                                              // destroyed
+      )
+    },
+    test("destroy(A) leaves B intact (never a global reset)") {
+      for
+        control <- ZIO.service[MockControl]
+        a       <- control.provision(pingSource).map(_.head)
+        b       <- control.provision(pingSource).map(_.head)
+        _       <- httpGet(a.baseUri, "/ping").retry(upWithin)
+        _       <- httpGet(b.baseUri, "/ping").retry(upWithin)
+        _       <- control.destroy(a)
+        gone    <- waitUntilGone(a.baseUri)
+        bAfter  <- httpGet(b.baseUri, "/ping") // B must still serve after A is destroyed
+      yield assertTrue(gone, bAfter == (200, "pong"))
+    }
+  ).provideSome[Client](Provisioning.live, riftBackend) @@ TestAspect.sequential @@ TestAspect.withLiveClock
+
+  // Two ways to reach a real Rift: testcontainers spins one up (default), or —
+  // when RIFT_ADMIN points at an already-running Rift admin URL whose imposter
+  // ports are mapped 1:1 to localhost — connect to it directly. The latter
+  // exercises the same adapter without depending on the host's testcontainers
+  // Docker discovery.
+  private def riftBackend: ZLayer[Client & Provisioning, MockError, MockControl] =
+    sys.env.get("RIFT_ADMIN") match
+      case Some(admin) => Rift.connect(admin, (4545 until 4561).toList)(p => s"http://localhost:$p")
+      case None        => Rift.managed()
+
+  def spec =
+    if sys.env.contains("RIFT_IT") then realSuite.provideShared(Client.default)
+    else suite("RiftContainerSpec (skipped — set RIFT_IT=1 to run against a real Rift container)")()

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -1,0 +1,236 @@
+package zio.bdd.mock.rift
+
+import zio.*
+import zio.bdd.mock.*
+import zio.http.Client
+import zio.test.*
+
+object RiftMockControlSpec extends ZIOSpecDefault:
+
+  private val pingRule = MockRule(
+    `match` = RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+    respond = ResponseDef(status = 200, body = Body.Text("pong"))
+  )
+  private val pingSource = MockSource.Dsl(MockSpec(List(pingRule)))
+
+  private def portOf(baseUri: String): Int = baseUri.substring(baseUri.lastIndexOf(':') + 1).toInt
+
+  /**
+   * Set up a fresh fake admin server + a Rift adapter (with the given imposter
+   * port pool) bound to it, in a scope.
+   */
+  private def withAdapterPool(ports: List[Int])(
+    use: (MockControl, FakeRift) => UIO[TestResult]
+  ): ZIO[Client & Provisioning, Throwable, TestResult] =
+    ZIO.scoped {
+      for
+        adminAndFake <- FakeRift.started
+        (admin, fake) = adminAndFake
+        endpoint     <- RiftEndpoint.pooled(admin, ports)(p => s"http://localhost:$p")
+        control      <- RiftMockControl.make(endpoint)
+        result       <- use(control, fake)
+      yield result
+    }
+
+  private def withAdapter(
+    use: (MockControl, FakeRift) => UIO[TestResult]
+  ): ZIO[Client & Provisioning, Throwable, TestResult] =
+    withAdapterPool((4545 until 4600).toList)(use)
+
+  def spec = suite("RiftMockControl (adapter vs fake admin API)")(
+    test("provision creates one recording imposter per space; baseUri reflects its port; inject is identity") {
+      withAdapter { (control, fake) =>
+        for
+          spacesE <- control.provision(pingSource).either
+          posted  <- fake.posted.get
+        yield
+          val spaces = spacesE.toOption.toList.flatten
+          val space  = spaces.head
+          val req    = HttpRequest(Method.Get, "http://sut/")
+          assertTrue(
+            spacesE.isRight,
+            spaces.size == 1,
+            posted.size == 1,
+            posted.head.contains("\"recordRequests\":true"),
+            FakeRift.portOf(posted.head).contains(portOf(space.baseUri)),
+            space.baseUri == s"http://localhost:${portOf(space.baseUri)}",
+            space.inject(req) == req
+          )
+      }
+    },
+    test("destroy(A) deletes only A's imposter — never the global reset — and leaves B intact") {
+      withAdapter { (control, fake) =>
+        for
+          aE       <- control.provision(pingSource).either
+          bE       <- control.provision(pingSource).either
+          a         = aE.toOption.get.head
+          b         = bE.toOption.get.head
+          destroyE <- control.destroy(a).either
+          deleted  <- fake.deletedPorts.get
+          globals  <- fake.globalDeletes.get
+          recvBE   <- control.received(b).either
+          recvAE   <- control.received(a).either
+        yield assertTrue(
+          aE.isRight && bE.isRight,
+          a.baseUri != b.baseUri,
+          destroyE.isRight,
+          globals == 0,                        // never DELETE /imposters
+          deleted == Chunk(portOf(a.baseUri)), // exactly A's port, once
+          !deleted.contains(portOf(b.baseUri)),
+          recvBE.isRight,                               // B still addressable
+          recvAE == Left(MockError.SpaceNotFound(a.id)) // A is gone from the adapter
+        )
+      }
+    },
+    test("received parses the recorded requests from the imposter view") {
+      withAdapter { (control, fake) =>
+        for
+          sE  <- control.provision(pingSource).either
+          s    = sE.toOption.get.head
+          port = portOf(s.baseUri)
+          _ <- fake.setView(
+                 port,
+                 s"""{"port":$port,"requests":[{"method":"GET","path":"/ping","headers":{},"body":null}]}"""
+               )
+          recvE <- control.received(s).either
+        yield assertTrue(recvE == Right(List(RecordedRequest(Method.Get, "/ping", Map.empty, None))))
+      }
+    },
+    test("addRule/replaceRules/removeRule hit the stubs sub-resource endpoints") {
+      withAdapter { (control, fake) =>
+        for
+          sE    <- control.provision(pingSource).either
+          s      = sE.toOption.get.head
+          port   = portOf(s.baseUri)
+          addE  <- control.addRule(s, pingRule, Priority.Base).either                   // r2 -> index 1
+          rmE   <- ZIO.fromEither(addE).flatMap(id => control.removeRule(s, id)).either // remove r2 (index 1)
+          _     <- control.replaceRules(s, List(pingRule)).either                       // PUT all stubs
+          calls <- fake.stubCalls.get
+        yield assertTrue(
+          addE == Right(RuleId("r2")), // r1 is the provisioned stub; r2 appended at index 1
+          rmE.isRight,
+          calls.exists(_.startsWith(s"POST $port")),
+          calls.exists(_.startsWith(s"PUT $port")),
+          calls.contains(s"DELETE $port/1")
+        )
+      }
+    },
+    test("rule ids stay stable: an overlay insert does not misroute a later removal") {
+      withAdapter { (control, fake) =>
+        for
+          sE    <- control.provision(pingSource).either                                  // r1 at index 0
+          s      = sE.toOption.get.head
+          port   = portOf(s.baseUri)
+          baseE <- control.addRule(s, pingRule, Priority.Base).either                    // r2 -> index 1 -> [r1, r2]
+          ovE   <- control.addRule(s, pingRule, Priority.Overlay).either                 // r3 -> index 0 -> [r3, r1, r2]
+          rmE   <- ZIO.fromEither(baseE).flatMap(id => control.removeRule(s, id)).either // remove r2
+          calls <- fake.stubCalls.get
+        yield assertTrue(
+          baseE == Right(RuleId("r2")),
+          ovE == Right(RuleId("r3")),
+          rmE.isRight,
+          calls.contains(s"DELETE $port/2") // r2 shifted to index 2 by the overlay insert
+        )
+      }
+    },
+    test("removeRule of an unknown id fails with RuleNotFound") {
+      withAdapter { (control, _) =>
+        for
+          sE  <- control.provision(pingSource).either
+          s    = sE.toOption.get.head
+          rmE <- control.removeRule(s, RuleId("ghost")).either
+        yield assertTrue(rmE == Left(MockError.RuleNotFound(s.id, RuleId("ghost"))))
+      }
+    },
+    test("a failed provision releases the imposter port — no pool leak") {
+      withAdapterPool(List(4545)) { (control, fake) =>
+        for
+          _    <- fake.failProvision.set(true)
+          fail <- control.provision(pingSource).either // POST 400 -> fails; port must be released
+          _    <- fake.failProvision.set(false)
+          ok   <- control.provision(pingSource).either // would be "pool exhausted" if the port leaked
+        yield assertTrue(
+          fail.isLeft,
+          ok.isRight,
+          ok.toOption.get.head.baseUri == "http://localhost:4545"
+        )
+      }
+    },
+    test("an exhausted imposter port pool fails with a typed ProvisionFailed") {
+      withAdapterPool(List(4545)) { (control, _) =>
+        for
+          _    <- control.provision(pingSource).either // takes 4545
+          next <- control.provision(pingSource).either // pool empty
+        yield assertTrue(
+          next.swap.toOption.exists {
+            case MockError.ProvisionFailed(m) => m.contains("exhausted")
+            case _                            => false
+          }
+        )
+      }
+    },
+    test("advertises no capabilities; accessors fail fast; native specs unsupported") {
+      withAdapter { (control, _) =>
+        for
+          faultsE <- control.faults.either
+          nativeE <- control.provisionNative(new NativeSpec[Backend] {}).either
+        yield assertTrue(
+          control.capabilities.isEmpty,
+          faultsE == Left(Unsupported(Capability.Faults, "rift")),
+          nativeE.swap.toOption.exists {
+            case MockError.InvalidDefinition(_) => true
+            case _                              => false
+          }
+        )
+      }
+    },
+    test("a raw JSON source is provisioned with our port + recordRequests forced; malformed raw is InvalidDefinition") {
+      withAdapter { (control, fake) =>
+        val raw =
+          """{"port":9999,"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/x"}}],"responses":[{"is":{"statusCode":204}}]}]}"""
+        for
+          sE        <- control.provision(MockSource.Json(raw)).either
+          posted    <- fake.posted.get
+          malformed <- control.provision(MockSource.Json("not json")).either
+        yield
+          val body = posted.headOption.getOrElse("")
+          assertTrue(
+            sE.isRight,
+            body.contains("\"recordRequests\":true"),
+            FakeRift.portOf(body).contains(portOf(sE.toOption.get.head.baseUri)),
+            !body.contains("9999"), // advisory port overridden by the pool port
+            malformed.swap.toOption.exists {
+              case MockError.InvalidDefinition(_) => true
+              case _                              => false
+            }
+          )
+      }
+    },
+    test("received surfaces a malformed imposter view as a CommunicationError") {
+      withAdapter { (control, fake) =>
+        for
+          sE   <- control.provision(pingSource).either
+          s     = sE.toOption.get.head
+          _    <- fake.setView(portOf(s.baseUri), "this is not json")
+          recv <- control.received(s).either
+        yield assertTrue(recv.swap.toOption.exists {
+          case MockError.CommunicationError(_) => true
+          case _                               => false
+        })
+      }
+    },
+    test("a non-2xx admin response surfaces as a typed CommunicationError, not a swallowed success") {
+      withAdapter { (control, fake) =>
+        for
+          _ <- fake.failProvision.set(true)
+          e <- control.provision(pingSource).either
+        yield assertTrue(
+          e.isLeft,
+          e.swap.toOption.exists {
+            case MockError.CommunicationError(msg) => msg.contains("400")
+            case _                                 => false
+          }
+        )
+      }
+    }
+  ).provide(Client.default, Provisioning.live) @@ TestAspect.withLiveClock

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
@@ -1,0 +1,135 @@
+package zio.bdd.mock.rift
+
+import zio.bdd.mock.*
+import zio.json.ast.Json
+import zio.test.*
+
+object RiftProtocolSpec extends ZIOSpecDefault:
+
+  private def field(j: Json, k: String): Option[Json] = j match
+    case o: Json.Obj => o.fields.toMap.get(k)
+    case _           => None
+
+  extension (j: Json) private def /(k: String): Json = field(j, k).getOrElse(Json.Null)
+  private def arr(j: Json): List[Json] = j match
+    case Json.Arr(es) => es.toList
+    case _            => Nil
+
+  private val pingRule = MockRule(
+    `match` = RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+    respond = ResponseDef(status = 200, headers = Map("Content-Type" -> "text/plain"), body = Body.Text("pong"))
+  )
+
+  def spec = suite("RiftProtocol (canonical <-> Mountebank)")(
+    test("imposter carries port, http protocol, recordRequests, and one stub per rule") {
+      val j = RiftProtocol.imposter(4545, "ping", List(pingRule))
+      assertTrue(
+        j / "port" == Json.Num(4545),
+        j / "protocol" == Json.Str("http"),
+        j / "recordRequests" == Json.Bool(true),
+        arr(j / "stubs").size == 1
+      )
+    },
+    test("an exact path + method rule becomes equals predicates and an `is` response") {
+      val stub       = RiftProtocol.stub(pingRule)
+      val preds      = arr(stub / "predicates")
+      val methodPred = preds.find(p => (p / "equals" / "method") != Json.Null)
+      val pathPred   = preds.find(p => (p / "equals" / "path") != Json.Null)
+      val isResp     = arr(stub / "responses").head / "is"
+      assertTrue(
+        methodPred.exists(_ / "equals" / "method" == Json.Str("GET")),
+        pathPred.exists(_ / "equals" / "path" == Json.Str("/ping")),
+        isResp / "statusCode" == Json.Num(200),
+        isResp / "body" == Json.Str("pong"),
+        isResp / "headers" / "Content-Type" == Json.Str("text/plain")
+      )
+    },
+    test("a regex path becomes a matches predicate; a template path is anchored regex") {
+      val regex = RiftProtocol.stub(pingRule.copy(`match` = RequestMatch(path = PathMatch.Regex("/u/.*"))))
+      val tmpl  = RiftProtocol.stub(pingRule.copy(`match` = RequestMatch(path = PathMatch.Template("/users/{id}"))))
+      assertTrue(
+        arr(regex / "predicates").head / "matches" / "path" == Json.Str("/u/.*"),
+        arr(tmpl / "predicates").head / "matches" / "path" == Json.Str("^/users/[^/]+$")
+      )
+    },
+    test("a response delay becomes a _behaviors.wait in milliseconds") {
+      import zio.*
+      val withDelay = RiftProtocol.response(ResponseDef(status = 201, delay = Some(50.millis)))
+      assertTrue(
+        withDelay / "is" / "statusCode" == Json.Num(201),
+        withDelay / "_behaviors" / "wait" == Json.Num(50)
+      )
+    },
+    test("PathMatch.Any emits no path predicate") {
+      val stub = RiftProtocol.stub(pingRule.copy(`match` = RequestMatch(method = Some(Method.Post))))
+      val keys =
+        arr(stub / "predicates").map(p => p match { case o: Json.Obj => o.fields.map(_._1).toSet; case _ => Set.empty })
+      assertTrue(arr(stub / "predicates").size == 1, keys.head == Set("equals"))
+    },
+    test("parseRecorded reads the requests[] of a GET imposter view") {
+      val view =
+        """{"port":4545,"requests":[
+          |  {"method":"GET","path":"/ping","headers":{"Host":"x"},"body":null},
+          |  {"method":"POST","path":"/echo","body":"hi"}
+          |]}""".stripMargin
+      val parsed = RiftProtocol.parseRecorded(view)
+      assertTrue(
+        parsed == Right(
+          List(
+            RecordedRequest(Method.Get, "/ping", Map("Host" -> "x"), None),
+            RecordedRequest(Method.Post, "/echo", Map.empty, Some("hi"))
+          )
+        )
+      )
+    },
+    test("response body kinds: Empty omits body; Json sets body; Base64 sets _mode binary") {
+      val empty = RiftProtocol.response(ResponseDef(body = Body.Empty))
+      val json  = RiftProtocol.response(ResponseDef(body = Body.Json("""{"a":1}""")))
+      val b64   = RiftProtocol.response(ResponseDef(body = Body.Base64("YQ==")))
+      assertTrue(
+        field(empty / "is", "body").isEmpty,
+        json / "is" / "body" == Json.Str("""{"a":1}"""),
+        b64 / "is" / "body" == Json.Str("YQ=="),
+        b64 / "is" / "_mode" == Json.Str("binary")
+      )
+    },
+    test("query/header/body matchers map to their Mountebank operators") {
+      val rule = MockRule(
+        `match` = RequestMatch(
+          query = Map("q" -> ValueMatch.Equals("1")),
+          headers = Map("H" -> ValueMatch.Contains("x")),
+          body = Some(BodyMatch.Matches("ab.*"))
+        ),
+        respond = ResponseDef()
+      )
+      val preds = arr(RiftProtocol.stub(rule) / "predicates")
+      assertTrue(
+        preds.exists(p => p / "equals" / "query" / "q" == Json.Str("1")),
+        preds.exists(p => p / "contains" / "headers" / "H" == Json.Str("x")),
+        preds.exists(p => p / "matches" / "body" == Json.Str("ab.*"))
+      )
+    },
+    test("a JsonPath body matcher emits a jsonpath selector with an equals body") {
+      val rule = MockRule(RequestMatch(body = Some(BodyMatch.JsonPath("$.id", Some("7")))), ResponseDef())
+      val pred = arr(RiftProtocol.stub(rule) / "predicates").head
+      assertTrue(
+        pred / "jsonpath" / "selector" == Json.Str("$.id"),
+        pred / "equals" / "body" == Json.Str("7")
+      )
+    },
+    test("parseRecorded fails on malformed JSON; imposterFromRaw rejects a non-object document") {
+      assertTrue(
+        RiftProtocol.parseRecorded("not json").isLeft,
+        RiftProtocol.imposterFromRaw(1, "x", "[1,2,3]").isLeft
+      )
+    },
+    test("imposterFromRaw forces our port and recordRequests while keeping stubs") {
+      val raw           = """{"port":9999,"protocol":"http","stubs":[{"predicates":[],"responses":[]}]}"""
+      val Right((j, n)) = RiftProtocol.imposterFromRaw(4600, "json", raw): @unchecked
+      assertTrue(
+        j / "port" == Json.Num(4600),
+        j / "recordRequests" == Json.Bool(true),
+        n == 1
+      )
+    }
+  )


### PR DESCRIPTION
Adds the `rift` adapter module implementing the portable `MockControl` SPI over Rift, the Mountebank-compatible mock server — the default, zero-native-artifact provider (#109).

- Drives Rift's admin API (`POST`/`DELETE /imposters`, stubs sub-resource, recorded requests) over **zio-http**, with a pure canonical-model ⇄ Mountebank wire-JSON translation layer.
- **PerInstance isolation**: one imposter per `MockSpace` on its own pooled port, `inject = identity`. `destroy` deletes exactly that imposter — never the global `DELETE /imposters` reset (AC2).
- Stable opaque `RuleId`s tracked per imposter (correct across Mountebank's positional index shifts); atomic provisioning; idempotent `destroy`; port released on any failure.
- `Rift.connect` (already-running Rift) and `Rift.managed` (testcontainers, Scoped finalizer stops the container). Documents the container port-mapping wrinkle.

## Testing
- Always-on gate: adapter vs an in-process fake admin server + pure protocol specs (23 rift tests).
- Tagged real-container IT (`RIFT_IT`) proves provision/serve/record/destroy against a real Rift container — validated green against `zainalpour/rift-proxy:v0.2.0`.
- Found and reported a Rift keep-alive teardown bug (EtaCassiopeia/rift#207); fixed in v0.2.0, which the adapter now pins.

Closes #113

Milestone: M1