### PR TITLE
build: run the Rift real-container IT in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,27 @@ jobs:
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - run: sbt scalafmtCheckAll mimaReportBinaryIssues test
+
+  # The Rift adapter's real-container acceptance test (#113) is gated by RIFT_IT
+  # so the hermetic `build` job above stays Docker-free. ubuntu-latest ships a
+  # running Docker daemon at /var/run/docker.sock that testcontainers resolves
+  # natively, so Rift.managed() can stand up the published image here. (Docker
+  # Desktop on macOS is not auto-resolvable, which is why this can't run as part
+  # of the default unit gate.)
+  rift-it:
+    name: Rift integration test (real container)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+      - name: RiftContainerSpec against a real Rift container (testcontainers)
+        env:
+          RIFT_IT: "1"
+        run: sbt "rift/testOnly zio.bdd.mock.rift.RiftContainerSpec"


### PR DESCRIPTION
Runs the Rift adapter's real-container acceptance test (`RiftContainerSpec`, #113) in CI.

- Adds a parallel `rift-it` job on `ubuntu-latest` that runs `sbt "rift/testOnly *RiftContainerSpec"` with `RIFT_IT=1`. The runner's Docker daemon is testcontainers-resolvable, so `Rift.managed()` stands up `zainalpour/rift-proxy:v0.2.0` and the provision/serve/record/destroy path runs for real.
- The existing `build` job stays hermetic (Docker-free) — the unit gate and the container IT are separated.

Note: testcontainers' `managed` path runs for the first time on CI (Docker Desktop on macOS isn't auto-resolvable, so it couldn't be validated locally); the adapter logic itself is already covered by the always-on unit gate and was validated end-to-end against a real Rift via connect-mode.

Milestone: M1