### PR TITLE
feat: native escape hatch provisionNative[B]

### DIFF
--- a/mock/src/main/scala/zio/bdd/mock/MockControl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockControl.scala
@@ -3,17 +3,31 @@ package zio.bdd.mock
 import zio.{IO, ZIO}
 
 /**
- * Type-level tag for a concrete backend, used to pin a [[NativeSpec]] to one
- * provider. Concrete backends (Rift, WireMock) define their own marker; the
- * native escape hatch is fleshed out in #119.
+ * Phantom tag pinning a [[NativeSpec]] — and the test that uses it — to one
+ * concrete backend, so the escape hatch is honest about the portability it
+ * trades away. A `NativeSpec[Backend.Rift]` can only be provisioned by a Rift
+ * adapter; a backend that does not recognise the spec rejects it.
  */
-trait Backend
+sealed trait Backend
+object Backend:
+  sealed trait Rift     extends Backend
+  sealed trait WireMock extends Backend
 
 /**
  * A backend-specific provisioning payload — the escape hatch that trades
- * portability for full access to one backend. Fleshed out in #119.
+ * portability for full access to one backend (#119). A natively-provisioned
+ * [[MockSpace]] still participates in destroy/received/overlays/isolation
+ * exactly like a portable one; only its *definition* is backend-pinned.
+ *
+ * The WireMock Java-builder variant lands with the WireMock adapter (M2, #122):
+ * it needs that library's types, which the neutral SPI must not depend on.
  */
-trait NativeSpec[B <: Backend]
+enum NativeSpec[B <: Backend]:
+  /** A raw Rift/Mountebank imposter document; may carry `_rift` extensions. */
+  case Rift(imposterJson: String) extends NativeSpec[Backend.Rift]
+
+  /** A raw WireMock stub-mapping document. */
+  case WireMock(stubMappingJson: String) extends NativeSpec[Backend.WireMock]
 
 /**
  * The total core port every adapter MUST implement. This is the hinge of the

--- a/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
@@ -118,6 +118,17 @@ object MockControlModelSpec extends ZIOSpecDefault:
     test("Isolation enum has both isolation modes") {
       assertTrue(Isolation.values.toSet == Set(Isolation.PerInstance, Isolation.Correlated))
     },
+    test("NativeSpec is backend-tagged and carries its raw payload") {
+      // The type ascriptions are the real assertion: they only compile because
+      // each case is pinned to its backend tag (Rift / WireMock).
+      val rift: NativeSpec[Backend.Rift]     = NativeSpec.Rift("""{"stubs":[]}""")
+      val wire: NativeSpec[Backend.WireMock] = NativeSpec.WireMock("""{"mappings":[]}""")
+      assertTrue(
+        rift.isInstanceOf[NativeSpec.Rift],
+        wire.isInstanceOf[NativeSpec.WireMock],
+        (rift match { case NativeSpec.Rift(j) => j; case _ => "" }) == """{"stubs":[]}"""
+      )
+    },
     test("model types are immutable value types (case-class semantics)") {
       val r1 = ResponseDef(status = 200, body = Body.Json("{}"))
       val r2 = r1.copy(status = 404)

--- a/mock/src/test/scala/zio/bdd/mock/RawSourceNoDslSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/RawSourceNoDslSpec.scala
@@ -113,7 +113,7 @@ object RawSourceNoDslSpec extends ZIOSpecDefault:
       yield assertTrue(res == Left(MockError.InvalidDefinition("resource not found: mocks/does-not-exist.json")))
     },
     test("provisionNative escape hatch stands up a space without a portable source") {
-      val nativeSpec = new NativeSpec[Backend] {}
+      val nativeSpec = NativeSpec.Rift("""{"stubs":[]}""")
       for
         mc     <- control
         spaces <- mc.provisionNative(nativeSpec)

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -49,7 +49,15 @@ private[rift] final case class RiftMockControl(
     yield spaces
 
   def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
-    ZIO.fail(MockError.InvalidDefinition("the Rift adapter does not support native specs yet (#119)"))
+    spec match
+      // A native Rift imposter goes through the same serveSpace machinery as a
+      // portable Raw source (pool port, `_rift`/stub passthrough, tracking), so
+      // the resulting space participates in destroy/received/overlays/isolation
+      // exactly like a portable one.
+      case NativeSpec.Rift(imposterJson) =>
+        serveSpace(NormalizedSource("native", SourcePayload.Raw(imposterJson), None)).map(List(_))
+      case NativeSpec.WireMock(_) =>
+        ZIO.fail(MockError.InvalidDefinition("the Rift adapter cannot provision a WireMock native spec"))
 
   def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
     withImposter(space) { imp =>

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
@@ -18,6 +18,10 @@ object RiftContainerSpec extends ZIOSpecDefault:
   )
   private val pingSource = MockSource.Dsl(MockSpec(List(pingRule)))
 
+  // A backend-native Rift imposter document for the escape hatch (#119).
+  private val nativeImposter =
+    """{"port":9999,"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/native"}}],"responses":[{"is":{"statusCode":200,"body":"native!"}}]}]}"""
+
   // Imposter binds slightly after provision returns; retry the first hit briefly.
   private val upWithin: Schedule[Any, Any, Any] = Schedule.recurs(20) && Schedule.spaced(100.millis)
 
@@ -65,6 +69,22 @@ object RiftContainerSpec extends ZIOSpecDefault:
         gone    <- waitUntilGone(a.baseUri)
         bAfter  <- httpGet(b.baseUri, "/ping") // B must still serve after A is destroyed
       yield assertTrue(gone, bAfter == (200, "pong"))
+    },
+    test("a natively-provisioned space serves, records, and is space-local on destroy") {
+      for
+        control  <- ZIO.service[MockControl]
+        spaces   <- control.provisionNative(NativeSpec.Rift(nativeImposter))
+        space     = spaces.head
+        served   <- httpGet(space.baseUri, "/native").retry(upWithin)
+        recorded <- control.received(space)
+        _        <- control.destroy(space)
+        gone     <- waitUntilGone(space.baseUri)
+      yield assertTrue(
+        spaces.size == 1,
+        served == (200, "native!"),                                         // serves
+        recorded.exists(r => r.method == Method.Get && r.uri == "/native"), // records
+        gone                                                                // space-local destroy
+      )
     }
   ).provideSome[Client](Provisioning.live, riftBackend) @@ TestAspect.sequential @@ TestAspect.withLiveClock
 

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -13,6 +13,14 @@ object RiftMockControlSpec extends ZIOSpecDefault:
   )
   private val pingSource = MockSource.Dsl(MockSpec(List(pingRule)))
 
+  // A full Rift imposter document with backend-specific `_rift` extensions — the
+  // kind of full-fidelity spec the native escape hatch exists for.
+  private val nativeImposter =
+    """{"port":9999,"protocol":"http",
+      | "stubs":[{"predicates":[{"equals":{"path":"/native"}}],
+      |           "responses":[{"is":{"statusCode":200,"body":"native!"}}]}],
+      | "_rift":{"script":{"engine":"rhai","code":"200"}}}""".stripMargin
+
   private def portOf(baseUri: String): Int = baseUri.substring(baseUri.lastIndexOf(':') + 1).toInt
 
   /**
@@ -169,19 +177,108 @@ object RiftMockControlSpec extends ZIOSpecDefault:
         )
       }
     },
-    test("advertises no capabilities; accessors fail fast; native specs unsupported") {
+    test("advertises no capabilities; every accessor fails fast") {
       withAdapter { (control, _) =>
-        for
-          faultsE <- control.faults.either
-          nativeE <- control.provisionNative(new NativeSpec[Backend] {}).either
+        for faultsE <- control.faults.either
         yield assertTrue(
           control.capabilities.isEmpty,
-          faultsE == Left(Unsupported(Capability.Faults, "rift")),
-          nativeE.swap.toOption.exists {
-            case MockError.InvalidDefinition(_) => true
-            case _                              => false
-          }
+          faultsE == Left(Unsupported(Capability.Faults, "rift"))
         )
+      }
+    },
+    test("provisionNative(Rift) stands up a full-fidelity space (stubs + _rift) on our pooled port") {
+      withAdapter { (control, fake) =>
+        for
+          sE     <- control.provisionNative(NativeSpec.Rift(nativeImposter)).either
+          posted <- fake.posted.get
+        yield
+          val space = sE.toOption.get.head
+          val body  = posted.headOption.getOrElse("")
+          val req   = HttpRequest(Method.Get, "http://sut/")
+          assertTrue(
+            sE.isRight,
+            body.contains("\"_rift\""),                            // full-fidelity: _rift extensions preserved
+            body.contains("/native"),                              // the native stub preserved
+            body.contains("\"recordRequests\":true"),              // forced on so received() works
+            FakeRift.portOf(body).contains(portOf(space.baseUri)), // our pool port, not the spec's 9999
+            !body.contains("9999"),
+            space.inject(req) == req // isolation: identity inject like a portable space
+          )
+      }
+    },
+    test("a natively-provisioned space participates in received and is space-local on destroy") {
+      withAdapter { (control, fake) =>
+        for
+          sE  <- control.provisionNative(NativeSpec.Rift(nativeImposter)).either
+          s    = sE.toOption.get.head
+          port = portOf(s.baseUri)
+          _ <- fake.setView(
+                 port,
+                 s"""{"port":$port,"requests":[{"method":"GET","path":"/native","headers":{},"body":null}]}"""
+               )
+          recvE    <- control.received(s).either
+          destroyE <- control.destroy(s).either
+          deleted  <- fake.deletedPorts.get
+          globals  <- fake.globalDeletes.get
+        yield assertTrue(
+          recvE == Right(List(RecordedRequest(Method.Get, "/native", Map.empty, None))),
+          destroyE.isRight,
+          deleted == Chunk(port), // space-local: only this imposter
+          globals == 0            // never the global reset
+        )
+      }
+    },
+    test("native spaces isolate: two get distinct ports; destroy(A) leaves B") {
+      withAdapter { (control, _) =>
+        for
+          aE    <- control.provisionNative(NativeSpec.Rift(nativeImposter)).either
+          bE    <- control.provisionNative(NativeSpec.Rift(nativeImposter)).either
+          a      = aE.toOption.get.head
+          b      = bE.toOption.get.head
+          _     <- control.destroy(a).either
+          recvB <- control.received(b).either
+          recvA <- control.received(a).either
+        yield assertTrue(
+          a.baseUri != b.baseUri,
+          recvB.isRight,
+          recvA == Left(MockError.SpaceNotFound(a.id))
+        )
+      }
+    },
+    test("provisionNative rejects a non-Rift (WireMock) spec with InvalidDefinition") {
+      withAdapter { (control, _) =>
+        for e <- control.provisionNative(NativeSpec.WireMock("{}")).either
+        yield assertTrue(e.swap.toOption.exists {
+          case MockError.InvalidDefinition(_) => true
+          case _                              => false
+        })
+      }
+    },
+    test("a native space participates in overlays with stable rule ids (native stub is counted)") {
+      withAdapter { (control, fake) =>
+        for
+          sE    <- control.provisionNative(NativeSpec.Rift(nativeImposter)).either       // native stub -> [r1]
+          s      = sE.toOption.get.head
+          port   = portOf(s.baseUri)
+          baseE <- control.addRule(s, pingRule, Priority.Base).either                    // r2 -> index 1 -> [r1, r2]
+          ovE   <- control.addRule(s, pingRule, Priority.Overlay).either                 // r3 -> index 0 -> [r3, r1, r2]
+          rmE   <- ZIO.fromEither(baseE).flatMap(id => control.removeRule(s, id)).either // remove r2
+          calls <- fake.stubCalls.get
+        yield assertTrue(
+          baseE == Right(RuleId("r2")), // only holds if the native imposter's 1 stub was counted
+          ovE == Right(RuleId("r3")),
+          rmE.isRight,
+          calls.contains(s"DELETE $port/2") // r2 shifted to index 2 by the overlay insert
+        )
+      }
+    },
+    test("provisionNative(Rift) with malformed JSON fails with InvalidDefinition") {
+      withAdapter { (control, _) =>
+        for e <- control.provisionNative(NativeSpec.Rift("not json")).either
+        yield assertTrue(e.swap.toOption.exists {
+          case MockError.InvalidDefinition(_) => true
+          case _                              => false
+        })
       }
     },
     test("a raw JSON source is provisioned with our port + recordRequests forced; malformed raw is InvalidDefinition") {


### PR DESCRIPTION
Implements the native escape hatch (#119): backend-typed full-fidelity specs that still honor lifecycle + isolation.

- `NativeSpec` becomes a GADT `enum NativeSpec[B <: Backend]` — `Rift(imposterJson)` (`NativeSpec[Backend.Rift]`) and `WireMock(stubMappingJson)` (`NativeSpec[Backend.WireMock]`), so the escape hatch is type-tagged and honest about pinning a test to one backend.
- The Rift adapter's `provisionNative` routes a `NativeSpec.Rift` through the same `serveSpace` path as a portable raw source: the native imposter (stubs + `_rift` scripting/faults/flow-state) is passed through verbatim, only port + `recordRequests` forced. The resulting `MockSpace` participates in `destroy`, `received`, overlays (`addRule`), and isolation exactly like a portable space. A non-Rift spec → typed `InvalidDefinition`.

## Testing
- Unit (adapter vs in-process fake admin server): full-fidelity passthrough, received + space-local destroy (never the global reset), isolation, overlays/`addRule` stability on a native space, cross-backend rejection, malformed-JSON → `InvalidDefinition`, plus a compile-time `NativeSpec` type-tag test.
- Real-container IT (`RIFT_IT`): a natively-provisioned space serves, records, and is space-local on destroy — green against `zainalpour/rift-proxy:v0.2.0`.

The WireMock Java-builder variant is deferred to the WireMock adapter (M2, #122), which carries the dependency the neutral SPI must not take.

Closes #119

Milestone: M1