### PR TITLE
feat: MockSteps[R,S] mixin + recorded-request assertion steps

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,7 +103,7 @@ lazy val root = (project in file("."))
   .dependsOn(core, gherkin)
 
 lazy val core = (project in file("core"))
-  .dependsOn(gherkin)
+  .dependsOn(gherkin, mock)
   .settings(
     name := "zio-bdd",
     libraryDependencies ++= commonDependencies,

--- a/core/src/main/scala/zio/bdd/mock/steps/MockSteps.scala
+++ b/core/src/main/scala/zio/bdd/mock/steps/MockSteps.scala
@@ -1,0 +1,189 @@
+package zio.bdd.mock.steps
+
+import zio.*
+import zio.bdd.core.Assertions
+import zio.bdd.core.step.{Stage, ZIOSteps}
+import zio.bdd.mock.*
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest as JHttpRequest, HttpResponse as JHttpResponse}
+import scala.jdk.CollectionConverters.*
+
+/**
+ * The last response from sending a request through a mock space — staged per
+ * scenario so the response-assertion steps can read it.
+ */
+final case class MockResponse(status: Int, body: String, headers: Map[String, String])
+
+/**
+ * Mixin providing ready-made Gherkin steps for the portable mocking SPI,
+ * modelled on [[zio.bdd.http.HttpSteps]].
+ *
+ * Mix into any `ZIOSteps` suite whose environment provides a [[MockControl]] —
+ * the self-type `ZIOSteps[R & MockControl, S]` is the only wiring required (no
+ * lens, no extra given). The active [[MockSpace]] and the last response are
+ * kept in [[Stage]] (not scenario state) because a `MockSpace` carries a
+ * function and is not Schema-serialisable.
+ *
+ * ===Registered steps===
+ *   - `Given a mock space returning {int} {string} at {string}` — provision a
+ *     space
+ *   - `When the space overlays {int} {string} at {string}` — overlay a rule
+ *   - `When a {string} {string} is sent through the space` — send (honours
+ *     `inject`)
+ *   - `Then the space response status is {int}` / `… body contains {string}` /
+ *     `… header {string} is {string}` — assert the staged response
+ *   - `Then the space received {int} requests` — assert recorded count
+ *     (space-local)
+ *   - `Then a {string} request to {string} was recorded` — assert ≥1 match
+ *   - `Then exactly {int} {string} requests to {string} were recorded` — assert
+ *     exact count
+ *
+ * @tparam R
+ *   the suite environment (must provide `MockControl`)
+ * @tparam S
+ *   the suite scenario state (unused by these steps)
+ */
+trait MockSteps[R, S] { self: ZIOSteps[R & MockControl, S] =>
+
+  Given("a mock space returning " / int / " " / string / " at " / string) { (status: Int, body: String, path: String) =>
+    for
+      spaces <- mock(_.provision(MockSource.Dsl(MockSpec(List(ruleFor(status, body, path))))))
+      space  <- ZIO.fromOption(spaces.headOption).orElseFail(new IllegalStateException("provision returned no space"))
+      _      <- Stage.put(space)
+    yield ()
+  }
+
+  When("the space overlays " / int / " " / string / " at " / string) { (status: Int, body: String, path: String) =>
+    for
+      space <- activeSpace
+      _     <- mock(_.addRule(space, ruleFor(status, body, path), Priority.Overlay))
+    yield ()
+  }
+
+  When("a " / string / " " / string / " is sent through the space") { (method: String, path: String) =>
+    for
+      space <- activeSpace
+      resp  <- sendThrough(space, method, path)
+      _     <- Stage.put(resp)
+    yield ()
+  }
+
+  Then("the space response status is " / int) { (expected: Int) =>
+    stagedResponse.flatMap(r => Assertions.assertEquals(r.status, expected, "space response status mismatch"))
+  }
+
+  Then("the space response body contains " / string) { (expected: String) =>
+    stagedResponse.flatMap(r =>
+      Assertions.assertTrue(r.body.contains(expected), s"space response body '${r.body}' does not contain '$expected'")
+    )
+  }
+
+  Then("the space response header " / string / " is " / string) { (name: String, expected: String) =>
+    stagedResponse.flatMap { r =>
+      r.headers.get(name.toLowerCase) match
+        case Some(actual) => Assertions.assertEquals(actual, expected, s"response header '$name' mismatch")
+        case None =>
+          ZIO.fail(
+            new AssertionError(s"response header '$name' not present. Headers: ${r.headers.keys.mkString(", ")}")
+          )
+    }
+  }
+
+  Then("the space received " / int / " requests") { (expected: Int) =>
+    for
+      space <- activeSpace
+      reqs  <- mock(_.received(space))
+      _     <- Assertions.assertEquals(reqs.size, expected, s"recorded request count mismatch for space ${space.id.value}")
+    yield ()
+  }
+
+  Then("a " / string / " request to " / string / " was recorded") { (method: String, path: String) =>
+    for
+      space <- activeSpace
+      reqs  <- mock(_.received(space))
+      _ <- Assertions.assertTrue(
+             countMatching(reqs, method, path) >= 1,
+             s"no recorded $method request to $path. Recorded: ${reqs.map(r => s"${r.method} ${r.uri}").mkString(", ")}"
+           )
+    yield ()
+  }
+
+  Then("exactly " / int / " " / string / " requests to " / string / " were recorded") {
+    (expected: Int, method: String, path: String) =>
+      for
+        space <- activeSpace
+        reqs  <- mock(_.received(space))
+        _ <-
+          Assertions.assertEquals(countMatching(reqs, method, path), expected, s"recorded $method $path count mismatch")
+      yield ()
+  }
+
+  // ── helpers ─────────────────────────────────────────────────────────────
+
+  /**
+   * Run a MockControl operation, surfacing its typed error on the step's
+   * Throwable channel.
+   */
+  private def mock[A](f: MockControl => IO[MockError, A]): ZIO[R & MockControl, Throwable, A] =
+    ZIO.serviceWithZIO[MockControl](f).mapError(e => new RuntimeException(s"MockControl: ${describe(e)}"))
+
+  private val activeSpace: IO[Throwable, MockSpace] =
+    Stage
+      .get[MockSpace]
+      .mapError(e => new IllegalStateException(s"no active mock space — deploy one first (${e.message})"))
+
+  private val stagedResponse: IO[Throwable, MockResponse] =
+    Stage
+      .get[MockResponse]
+      .mapError(e => new IllegalStateException(s"no response staged — send a request first (${e.message})"))
+
+  private def ruleFor(status: Int, body: String, path: String): MockRule =
+    MockRule(RequestMatch(path = PathMatch.Exact(path)), ResponseDef(status = status, body = Body.Text(body)))
+
+  private def countMatching(reqs: List[RecordedRequest], method: String, path: String): Int =
+    reqs.count(r => r.method.toString.equalsIgnoreCase(method) && r.uri == path)
+
+  private def methodOf(name: String): IO[Throwable, Method] =
+    ZIO
+      .fromOption(Method.values.find(_.toString.equalsIgnoreCase(name)))
+      .orElseFail(
+        new IllegalArgumentException(
+          s"unknown HTTP method '$name'; expected one of ${Method.values.map(_.toString.toUpperCase).mkString(", ")}"
+        )
+      )
+
+  /**
+   * Send a request through the space: build the canonical request, apply the
+   * space's `inject` (the isolation decoration), then issue exactly the
+   * injected request — method included — with the JDK client.
+   */
+  private def sendThrough(space: MockSpace, method: String, path: String): IO[Throwable, MockResponse] =
+    methodOf(method).flatMap { m =>
+      val injected = space.inject(HttpRequest(m, space.baseUri + path))
+      ZIO.attemptBlocking {
+        val builder = injected.headers.foldLeft(JHttpRequest.newBuilder(URI.create(injected.uri))) { case (b, (k, v)) =>
+          b.header(k, v)
+        }
+        val publisher = injected.body match
+          case Some(body) => JHttpRequest.BodyPublishers.ofString(body)
+          case None       => JHttpRequest.BodyPublishers.noBody()
+        val request  = builder.method(injected.method.toString.toUpperCase, publisher).build()
+        val response = HttpClient.newHttpClient().send(request, JHttpResponse.BodyHandlers.ofString())
+        val headers = response
+          .headers()
+          .map()
+          .asScala
+          .collect { case (k, vs) if !vs.isEmpty => k.toLowerCase -> vs.asScala.mkString(", ") }
+          .toMap
+        MockResponse(response.statusCode, response.body, headers)
+      }
+    }
+
+  private def describe(e: MockError): String = e match
+    case MockError.ProvisionFailed(r)    => s"provision failed: $r"
+    case MockError.SpaceNotFound(s)      => s"space not found: ${s.value}"
+    case MockError.RuleNotFound(s, r)    => s"rule ${r.value} not found in space ${s.value}"
+    case MockError.InvalidDefinition(r)  => s"invalid definition: $r"
+    case MockError.CommunicationError(r) => s"communication error: $r"
+}

--- a/core/src/test/scala/zio/bdd/mock/steps/MockStepsSpec.scala
+++ b/core/src/test/scala/zio/bdd/mock/steps/MockStepsSpec.scala
@@ -1,0 +1,231 @@
+package zio.bdd.mock.steps
+
+import zio.*
+import zio.bdd.core.FeatureResult
+import zio.bdd.core.step.ZIOSteps
+import zio.bdd.gherkin.*
+import zio.bdd.mock.*
+import zio.schema.{DeriveSchema, Schema}
+import zio.test.*
+
+import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{ConcurrentHashMap, CopyOnWriteArrayList}
+import scala.jdk.CollectionConverters.*
+
+/**
+ * Tests for MockSteps — the pre-built mock step mixin. Drives the mixin against
+ * a real in-process HTTP backend (a tiny `com.sun.net.httpserver` server) that
+ * implements `MockControl` directly, partitioning spaces by an id path prefix
+ * so recordings are genuinely space-local.
+ */
+object MockStepsSpec extends ZIOSpecDefault:
+
+  final case class TestState()
+  object TestState:
+    given Schema[TestState] = DeriveSchema.gen[TestState]
+
+  // ── In-process MockControl backed by one HttpServer ─────────────────────────
+
+  private final class TestBackend(
+    server: HttpServer,
+    recordings: ConcurrentHashMap[String, CopyOnWriteArrayList[RecordedRequest]],
+    stubs: ConcurrentHashMap[String, (Int, String)],
+    counter: AtomicInteger
+  ) extends MockControl:
+    private val port                  = server.getAddress.getPort
+    def backendName: String           = "test"
+    def capabilities: Set[Capability] = Set.empty
+
+    def provision(source: MockSource): IO[MockError, List[MockSpace]] =
+      source match
+        case MockSource.Dsl(spec) =>
+          ZIO.succeed {
+            val id = "s" + counter.incrementAndGet()
+            recordings.put(id, new CopyOnWriteArrayList[RecordedRequest]())
+            spec.rules.foreach(registerStub(id, _))
+            List(MockSpace(s"http://localhost:$port/$id", identity, SpaceId(id)))
+          }
+        case _ => ZIO.fail(MockError.InvalidDefinition("test backend only supports Dsl sources"))
+
+    def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+      ZIO.succeed { registerStub(space.id.value, rule); RuleId("r") }
+
+    def received(space: MockSpace): IO[MockError, List[RecordedRequest]] =
+      ZIO.succeed(Option(recordings.get(space.id.value)).map(_.asScala.toList).getOrElse(Nil))
+
+    def destroy(space: MockSpace): IO[MockError, Unit] =
+      ZIO.succeed { recordings.remove(space.id.value); () }
+
+    def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+      ZIO.fail(MockError.InvalidDefinition("unsupported"))
+    def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit]              = ZIO.unit
+    def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit] = ZIO.unit
+    def faults: IO[Unsupported, Faults]                                            = ZIO.fail(Unsupported(Capability.Faults, backendName))
+    def scenarios: IO[Unsupported, StatefulScenarios]                              = ZIO.fail(Unsupported(Capability.StatefulScenarios, backendName))
+    def stateInspection: IO[Unsupported, StateInspection] =
+      ZIO.fail(Unsupported(Capability.StateInspection, backendName))
+    def scripting: IO[Unsupported, Scripting]     = ZIO.fail(Unsupported(Capability.Scripting, backendName))
+    def proxyRecord: IO[Unsupported, ProxyRecord] = ZIO.fail(Unsupported(Capability.ProxyRecord, backendName))
+    def templating: IO[Unsupported, Templating]   = ZIO.fail(Unsupported(Capability.Templating, backendName))
+
+    private def registerStub(spaceId: String, rule: MockRule): Unit =
+      val path = rule.`match`.path match
+        case PathMatch.Exact(p) => p
+        case _                  => "/"
+      val body = rule.respond.body match
+        case Body.Text(v) => v
+        case Body.Json(v) => v
+        case _            => ""
+      stubs.put(stubKey(spaceId, path), (rule.respond.status, body))
+
+  private def stubKey(spaceId: String, path: String): String = spaceId + " " + path
+
+  private def methodOf(name: String): Method =
+    Method.values.find(_.toString.equalsIgnoreCase(name)).getOrElse(Method.Get)
+
+  private val makeBackend: ZIO[Scope, Throwable, MockControl] =
+    ZIO
+      .acquireRelease(
+        ZIO.attempt {
+          val recordings = new ConcurrentHashMap[String, CopyOnWriteArrayList[RecordedRequest]]()
+          val stubs      = new ConcurrentHashMap[String, (Int, String)]()
+          val server     = HttpServer.create(new InetSocketAddress("localhost", 0), 0)
+          server.createContext(
+            "/",
+            new HttpHandler:
+              def handle(exchange: HttpExchange): Unit =
+                val segments = exchange.getRequestURI.getPath.stripPrefix("/").split("/", 2)
+                val spaceId  = segments(0)
+                val path     = "/" + (if segments.length > 1 then segments(1) else "")
+                val body     = new String(exchange.getRequestBody.readAllBytes())
+                Option(recordings.get(spaceId)).foreach { rec =>
+                  rec.add(
+                    RecordedRequest(
+                      methodOf(exchange.getRequestMethod),
+                      path,
+                      Map.empty,
+                      Option(body).filter(_.nonEmpty)
+                    )
+                  )
+                }
+                val (status, payload) = Option(stubs.get(stubKey(spaceId, path))).getOrElse((404, ""))
+                val bytes             = payload.getBytes
+                exchange.getResponseHeaders.set("X-Served-By", "test-mock")
+                exchange.sendResponseHeaders(status, if bytes.isEmpty then -1 else bytes.length.toLong)
+                val os = exchange.getResponseBody
+                os.write(bytes)
+                os.close()
+          )
+          server.start()
+          (server, new TestBackend(server, recordings, stubs, new AtomicInteger(0)): MockControl)
+        }
+      )((acquired) => ZIO.attempt(acquired._1.stop(0)).orDie)
+      .map(_._2)
+
+  // ── Suite mixing in MockSteps ───────────────────────────────────────────────
+
+  private class MockSuite(control: MockControl)
+      extends ZIOSteps[MockControl, TestState]
+      with MockSteps[MockControl, TestState]:
+    override def environment: ZLayer[Any, Throwable, MockControl] = ZLayer.succeed(control)
+
+  private val F = "mock-steps.feature"
+
+  private def run(steps: List[Step]): ZIO[Any, Throwable, FeatureResult] =
+    ZIO.scoped {
+      makeBackend.flatMap { backend =>
+        new MockSuite(backend)
+          .run(List(Feature("Mock", Nil, List(Scenario("s", Nil, steps, Some(F), Some(1))))))
+          .provideEnvironment(ZEnvironment(backend))
+          .map(_.head)
+      }
+    }
+
+  private def step(t: StepType, p: String) = Step(t, p, None, None, None)
+  private val G                            = StepType.GivenStep
+  private val W                            = StepType.WhenStep
+  private val T                            = StepType.ThenStep
+
+  def spec = suite("MockSteps")(
+    test("AC1: a suite mixing MockSteps deploys, sends, and asserts the response with only MockControl in R") {
+      run(
+        List(
+          step(G, """a mock space returning 200 "pong" at "/ping""""),
+          step(W, """a "GET" "/ping" is sent through the space"""),
+          step(T, "the space response status is 200"),
+          step(T, """the space response body contains "pong""""),
+          step(T, """the space response header "x-served-by" is "test-mock"""")
+        )
+      ).map(r => assertTrue(r.isPassed))
+    },
+    test("AC2: recorded-request assertions read received(space) and are space-local") {
+      run(
+        List(
+          step(G, """a mock space returning 200 "a" at "/x""""), // space A
+          step(W, """a "GET" "/x" is sent through the space"""),
+          step(W, """a "GET" "/x" is sent through the space"""),
+          step(T, "the space received 2 requests"), // A recorded 2
+          step(T, """a "GET" request to "/x" was recorded"""),
+          step(G, """a mock space returning 200 "b" at "/y""""), // space B becomes active
+          step(W, """a "GET" "/y" is sent through the space"""),
+          step(T, "the space received 1 requests") // B has 1, NOT 3 -> space-local
+        )
+      ).map(r => assertTrue(r.isPassed))
+    },
+    test("the recorded-count assertion fails when the active space's count differs (negative)") {
+      run(
+        List(
+          step(G, """a mock space returning 200 "pong" at "/ping""""),
+          step(W, """a "GET" "/ping" is sent through the space"""),
+          step(T, "the space received 5 requests") // actually 1
+        )
+      ).map(r => assertTrue(!r.isPassed, r.error.isDefined))
+    },
+    test("an overlay rule added to the active space is served") {
+      run(
+        List(
+          step(G, """a mock space returning 404 "" at "/over""""),
+          step(W, """the space overlays 200 "yes" at "/over""""),
+          step(W, """a "GET" "/over" is sent through the space"""),
+          step(T, "the space response status is 200"),
+          step(T, """the space response body contains "yes"""")
+        )
+      ).map(r => assertTrue(r.isPassed))
+    },
+    test("the exact-count assertion filters recorded requests by method (and covers non-GET sends)") {
+      run(
+        List(
+          step(G, """a mock space returning 200 "ok" at "/x""""),
+          step(W, """a "GET" "/x" is sent through the space"""),
+          step(W, """a "GET" "/x" is sent through the space"""),
+          step(W, """a "POST" "/x" is sent through the space"""),
+          step(T, """exactly 2 "GET" requests to "/x" were recorded"""), // POST excluded by the method filter
+          step(T, "the space received 3 requests")                       // but all 3 are recorded
+        )
+      ).map(r => assertTrue(r.isPassed))
+    },
+    test("a step used before deploying a space fails with a clear error") {
+      run(List(step(T, "the space received 0 requests")))
+        .map(r => assertTrue(!r.isPassed, r.error.isDefined))
+    },
+    test("asserting a response header that is absent fails") {
+      run(
+        List(
+          step(G, """a mock space returning 200 "ok" at "/h""""),
+          step(W, """a "GET" "/h" is sent through the space"""),
+          step(T, """the space response header "x-absent" is "nope"""")
+        )
+      ).map(r => assertTrue(!r.isPassed, r.error.isDefined))
+    },
+    test("a send to an unstubbed path returns 404 through the space") {
+      run(
+        List(
+          step(G, """a mock space returning 200 "ok" at "/known""""),
+          step(W, """a "GET" "/unknown" is sent through the space"""),
+          step(T, "the space response status is 404")
+        )
+      ).map(r => assertTrue(r.isPassed))
+    }
+  )


### PR DESCRIPTION
Adds a `MockSteps[R, S]` Gherkin step mixin for the portable mocking SPI (#114), modelled on the existing `HttpSteps`.

- **Steps**: deploy a mock space, overlay a rule, send a request through a space (built-in JDK `java.net.http.HttpClient`, honouring `MockSpace.inject`), assert the response (status/body/header), and assert recorded requests (`received`/`countMatching`) — space-local.
- **Wiring**: the only requirement is `MockControl` in the suite environment. The self-type `ZIOSteps[R & MockControl, S]` puts the service in the step env (a compile spike confirmed `HasService` is a phantom marker that can't extract a service from an abstract `R`; the self-type is the sound equivalent and keeps wiring to "include MockControl in R").
- The active `MockSpace` + last response live in `Stage` (a `MockSpace` carries a function, so it isn't Schema-serialisable). `MockError` surfaces on the step's Throwable channel.
- `core` now `.dependsOn(gherkin, mock)` — acyclic; `mock` stays standalone.

## Testing
8 scenarios drive the mixin against a real in-process `com.sun.net.httpserver` backend implementing `MockControl`, partitioned per space-id so recordings are genuinely space-local: AC1 (mixin wiring + send + response asserts), AC2 (space-local — 2 requests to A, deploy B, assert B==1 not 3), overlay, exact-count with method filtering (+ non-GET), and negatives (count mismatch, used-before-deploy, absent header, unstubbed 404).

Note: `inject` is exercised as identity (PerInstance); the non-identity case is Correlated isolation (M2, #123). `sendThrough` applies `inject` and uses the injected method authoritatively.

Closes #114

Milestone: M1