### PR TITLE
feat: MockFixtures feature/scenario Scoped layers + tag-driven @mock setup

### DIFF
--- a/core/src/main/scala/zio/bdd/mock/fixtures/MockFixtures.scala
+++ b/core/src/main/scala/zio/bdd/mock/fixtures/MockFixtures.scala
@@ -1,0 +1,83 @@
+package zio.bdd.mock.fixtures
+
+import zio.*
+import zio.bdd.gherkin.ScenarioMetadata
+import zio.bdd.mock.{MockControl, MockError, MockSource, MockSpace}
+
+/**
+ * The mock spaces a fixture scope provisioned, exposed to the suite's steps.
+ */
+final case class MockFixture(spaces: List[MockSpace])
+
+/**
+ * Parser for the `@mock(name, ...)` Gherkin tag. Tags arrive without the `@`.
+ */
+object MockTag:
+  private val pattern = """^mock\(([^)]*)\)$""".r
+
+  /**
+   * The catalog entry names in a single `@mock(...)` tag, or `None` if the tag
+   * is not a `@mock(...)` tag at all. An empty `@mock()` yields `Some(Nil)`.
+   */
+  def parse(tag: String): Option[List[String]] =
+    pattern.findFirstMatchIn(tag.trim.stripPrefix("@")).map { m =>
+      m.group(1).split(",").map(_.trim).filter(_.nonEmpty).toList
+    }
+
+  /**
+   * All `@mock(...)` names across the tags, in order,
+   * first-occurrence-deduplicated.
+   */
+  def extract(tags: List[String]): List[String] =
+    tags.flatMap(parse(_).getOrElse(Nil)).distinct
+
+object MockFixtures:
+
+  /**
+   * Feature-tier fixtures: provision `sources` once (the three-tier model
+   * memoizes this layer per feature). Heavy, read-only fixtures shared by all
+   * of a feature's scenarios.
+   */
+  def feature(sources: MockSource*): ZLayer[MockControl, Throwable, MockFixture] =
+    ZLayer.scoped(provisionScoped(sources.toList).mapError(asThrowable))
+
+  /**
+   * Scenario-tier fixtures: deploy the catalog entries named by the scenario's
+   * `@mock(...)` tags. Fresh per scenario (share-nothing, auto-port via the
+   * adapter); a name with no catalog entry fails the scenario at setup.
+   */
+  def scenario(meta: ScenarioMetadata, catalog: Map[String, MockSource]): ZLayer[MockControl, Throwable, MockFixture] =
+    ZLayer.scoped {
+      resolve(MockTag.extract(meta.tags), catalog).flatMap(provisionScoped).mapError(asThrowable)
+    }
+
+  // Provision each source as its own scoped acquisition, so a failure partway
+  // through still tears down the spaces already created (each registers its own
+  // finalizer in the scope). The scope destroys ONLY these spaces — never a
+  // global teardown (the §5.9 invariant). A teardown that fails is logged and
+  // skipped so one bad destroy can't strand its siblings.
+  private def provisionScoped(sources: List[MockSource]): ZIO[MockControl & Scope, MockError, MockFixture] =
+    ZIO.serviceWithZIO[MockControl] { control =>
+      ZIO
+        .foreach(sources) { source =>
+          ZIO.acquireRelease(control.provision(source))(spaces =>
+            ZIO.foreachDiscard(spaces)(space =>
+              control
+                .destroy(space)
+                .catchAllCause(cause =>
+                  ZIO.logWarningCause(s"mock fixture teardown failed for ${space.id.value}", cause)
+                )
+            )
+          )
+        }
+        .map(perSource => MockFixture(perSource.flatten))
+    }
+
+  private def resolve(names: List[String], catalog: Map[String, MockSource]): IO[MockError, List[MockSource]] =
+    ZIO.foreach(names) { name =>
+      ZIO
+        .fromOption(catalog.get(name))
+        .orElseFail(MockError.InvalidDefinition(s"@mock($name): no catalog entry named '$name'"))
+    }
+
+  private def asThrowable(e: MockError): Throwable = new RuntimeException(s"MockFixtures: $e")

--- a/core/src/test/scala/zio/bdd/mock/fixtures/MockFixturesSpec.scala
+++ b/core/src/test/scala/zio/bdd/mock/fixtures/MockFixturesSpec.scala
@@ -1,0 +1,183 @@
+package zio.bdd.mock.fixtures
+
+import zio.*
+import zio.bdd.gherkin.ScenarioMetadata
+import zio.bdd.mock.*
+import zio.test.*
+
+object MockFixturesSpec extends ZIOSpecDefault:
+
+  // A MockControl that provisions one fresh, uniquely-identified space per source
+  // and logs every destroy. It has no bulk delete — so "never a global teardown"
+  // is structural; the assertions check the finalizer destroyed exactly its own.
+  private final case class TState(nextId: Int, live: Set[String], destroyed: List[String], provisions: Int)
+  private object TState:
+    val init: TState = TState(0, Set.empty, Nil, 0)
+
+  private final class TestControl(
+    ref: Ref[TState],
+    failProvision: MockSource => Boolean = _ => false,
+    failDestroy: String => Boolean = _ => false
+  ) extends MockControl:
+    def backendName: String           = "test"
+    def capabilities: Set[Capability] = Set.empty
+
+    def provision(source: MockSource): IO[MockError, List[MockSpace]] =
+      if failProvision(source) then ZIO.fail(MockError.ProvisionFailed("boom"))
+      else
+        ref.modify { s =>
+          val id = s"sp${s.nextId}"
+          (
+            List(MockSpace(s"http://localhost/$id", identity, SpaceId(id))),
+            s.copy(nextId = s.nextId + 1, live = s.live + id, provisions = s.provisions + 1)
+          )
+        }
+
+    def destroy(space: MockSpace): IO[MockError, Unit] =
+      if failDestroy(space.id.value) then ZIO.fail(MockError.CommunicationError("teardown boom"))
+      else ref.update(s => s.copy(live = s.live - space.id.value, destroyed = s.destroyed :+ space.id.value))
+
+    def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+      ZIO.fail(MockError.InvalidDefinition("n/a"))
+    def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] = ZIO.succeed(RuleId("r"))
+    def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit]                        = ZIO.unit
+    def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit]           = ZIO.unit
+    def received(space: MockSpace): IO[MockError, List[RecordedRequest]]                     = ZIO.succeed(Nil)
+    def faults: IO[Unsupported, Faults]                                                      = ZIO.fail(Unsupported(Capability.Faults, backendName))
+    def scenarios: IO[Unsupported, StatefulScenarios]                                        = ZIO.fail(Unsupported(Capability.StatefulScenarios, backendName))
+    def stateInspection: IO[Unsupported, StateInspection] =
+      ZIO.fail(Unsupported(Capability.StateInspection, backendName))
+    def scripting: IO[Unsupported, Scripting]     = ZIO.fail(Unsupported(Capability.Scripting, backendName))
+    def proxyRecord: IO[Unsupported, ProxyRecord] = ZIO.fail(Unsupported(Capability.ProxyRecord, backendName))
+    def templating: IO[Unsupported, Templating]   = ZIO.fail(Unsupported(Capability.Templating, backendName))
+
+  private val srcA = MockSource.Json("""{"a":1}""")
+  private val srcB = MockSource.Json("""{"b":2}""")
+
+  private def meta(tags: String*): ScenarioMetadata = ScenarioMetadata("s", tags.toList, None, None)
+
+  private def control: UIO[(MockControl, Ref[TState])] =
+    Ref.make(TState.init).map(ref => (TestControl(ref), ref))
+
+  def spec = suite("MockFixtures")(
+    test("MockTag parses @mock(...) names and ignores unrelated tags") {
+      assertTrue(
+        MockTag.parse("mock(a, b)").contains(List("a", "b")),
+        MockTag.parse("@mock(x)").contains(List("x")),
+        MockTag.parse("mock()").contains(Nil),
+        MockTag.parse("flags(k=v)").isEmpty,
+        MockTag.parse("smoke").isEmpty,
+        MockTag.extract(List("mock(a)", "other", "mock(b, c)")) == List("a", "b", "c")
+      )
+    },
+    test("a feature fixture provisions its sources; the finalizer destroys exactly those spaces (§5.9)") {
+      for
+        cr        <- control
+        (ctl, ref) = cr
+        during <- ZIO.scoped {
+                    MockFixtures.feature(srcA, srcB).build.map(_.get[MockFixture]).flatMap(fx => ref.get.map((fx, _)))
+                  }.provideLayer(ZLayer.succeed(ctl))
+        after <- ref.get
+      yield
+        val (fx, mid) = during
+        assertTrue(
+          fx.spaces.size == 2,
+          mid.provisions == 2,
+          mid.live.size == 2,                                      // both live within the scope
+          after.live.isEmpty,                                      // both destroyed on release
+          after.destroyed.toSet == fx.spaces.map(_.id.value).toSet // exactly its own, nothing else
+        )
+    },
+    test(
+      "two scenario fixtures from the same source get independent spaces; one teardown leaves the other live (AC1)"
+    ) {
+      for
+        cr        <- control
+        (ctl, ref) = cr
+        catalog    = Map("svc" -> srcA)
+        res <- ZIO.scoped {
+                 MockFixtures.scenario(meta("mock(svc)"), catalog).build.map(_.get[MockFixture]).flatMap { fxA =>
+                   ZIO
+                     .scoped(MockFixtures.scenario(meta("mock(svc)"), catalog).build.map(_.get[MockFixture]))
+                     .flatMap(fxB => ref.get.map((fxA, fxB, _)))
+                 }
+               }.provideLayer(ZLayer.succeed(ctl))
+      yield
+        val (fxA, fxB, afterBClosed) = res
+        val aIds                     = fxA.spaces.map(_.id.value).toSet
+        val bIds                     = fxB.spaces.map(_.id.value).toSet
+        assertTrue(
+          aIds.nonEmpty && bIds.nonEmpty,
+          aIds.intersect(bIds).isEmpty,           // independent spaces
+          afterBClosed.destroyed.toSet == bIds,   // only B's teardown ran
+          aIds.forall(afterBClosed.live.contains) // A is untouched by B's teardown
+        )
+    },
+    test(
+      "a feature fixture provisions once per build; a second build gets fresh, disjoint spaces (isolation between features)"
+    ) {
+      for
+        cr      <- control
+        (ctl, _) = cr
+        f1      <- ZIO.scoped(MockFixtures.feature(srcA).build.map(_.get[MockFixture])).provideLayer(ZLayer.succeed(ctl))
+        f2      <- ZIO.scoped(MockFixtures.feature(srcA).build.map(_.get[MockFixture])).provideLayer(ZLayer.succeed(ctl))
+      yield assertTrue(
+        f1.spaces.nonEmpty,
+        f1.spaces.map(_.id.value).toSet.intersect(f2.spaces.map(_.id.value).toSet).isEmpty
+      )
+    },
+    test("@mock(...) deploys the named catalog entries; no @mock tag provisions nothing") {
+      for
+        cr      <- control
+        (ctl, _) = cr
+        catalog  = Map("payments" -> srcA, "inventory" -> srcB)
+        tagged <-
+          ZIO
+            .scoped(MockFixtures.scenario(meta("mock(payments, inventory)"), catalog).build.map(_.get[MockFixture]))
+            .provideLayer(ZLayer.succeed(ctl))
+        untagged <- ZIO
+                      .scoped(MockFixtures.scenario(meta("smoke"), catalog).build.map(_.get[MockFixture]))
+                      .provideLayer(ZLayer.succeed(ctl))
+      yield assertTrue(tagged.spaces.size == 2, untagged.spaces.isEmpty)
+    },
+    test("@mock(unknown) referencing a missing catalog entry fails loudly, naming the entry") {
+      for
+        cr      <- control
+        (ctl, _) = cr
+        res <- ZIO
+                 .scoped(MockFixtures.scenario(meta("mock(ghost)"), Map.empty).build)
+                 .provideLayer(ZLayer.succeed(ctl))
+                 .either
+      yield assertTrue(res.isLeft, res.swap.toOption.exists(_.getMessage.contains("ghost")))
+    },
+    test("a source that fails mid-provision does not leak the spaces already provisioned") {
+      for
+        ref             <- Ref.make(TState.init)
+        ctl: MockControl = TestControl(ref, failProvision = _ == srcB) // srcA succeeds, srcB fails
+        res <- ZIO
+                 .scoped(MockFixtures.feature(srcA, srcB).build)
+                 .provideLayer(ZLayer.succeed(ctl))
+                 .either
+        after <- ref.get
+      yield assertTrue(
+        res.isLeft,                     // build failed
+        after.provisions == 1,          // only srcA got provisioned
+        after.destroyed == List("sp0"), // and it was torn down on unwind — not leaked
+        after.live.isEmpty
+      )
+    },
+    test("a teardown failure for one space does not strand the others") {
+      for
+        ref             <- Ref.make(TState.init)
+        ctl: MockControl = TestControl(ref, failDestroy = _ == "sp0") // sp0's destroy fails
+        res <- ZIO
+                 .scoped(MockFixtures.feature(srcA, srcB).build.unit)
+                 .provideLayer(ZLayer.succeed(ctl))
+                 .either
+        after <- ref.get
+      yield assertTrue(
+        res.isRight,                    // the failing finalizer is logged, not propagated
+        after.destroyed.contains("sp1") // sp1 was still destroyed despite sp0's teardown failing
+      )
+    }
+  )


### PR DESCRIPTION
Maps mock provisioning onto zio-bdd's three-tier layer model (#115).

- **`MockFixtures.feature(sources*)`** — a `ZLayer.scoped` for heavy, read-only fixtures, provisioned once per feature (the three-tier model memoizes it) and shared across the feature's scenarios.
- **`MockFixtures.scenario(meta, catalog)`** — a fresh `ZLayer.scoped` per scenario that reads the scenario's `@mock(...)` tags and deploys the named catalog entries (share-nothing, auto-port). An unknown name fails with `InvalidDefinition` at setup.
- **`MockTag`** — parses the `@mock(payments, inventory)` Gherkin tag (modelled on the existing `FlagsTag`/`PropertyTag`).
- **§5.9 invariant**: each scope's finalizer destroys ONLY the spaces it created — never a global teardown (the SPI has no bulk delete). Each source is its own scoped acquisition, so a partial-provision failure still tears down the earlier spaces; a failing teardown is logged-and-skipped, not swallowed.

Lives in `core` (already depends on `mock` + `gherkin`).

## Testing
8 tests against a Ref-backed `MockControl` (unique spaces, destroy log, no bulk delete): AC1 (independent spaces; one teardown leaves the other live), AC2 (isolation between features), §5.9 (destroys exactly its own), `@mock` parse/deploy/unknown-name-fails, plus regressions for partial-provision cleanup and a teardown failure not stranding siblings.

Note: the cross-scenario/cross-feature memoization is the framework's three-tier model (tested separately); MockFixtures owns the scoped-layer contract, which the tests target directly.

Closes #115

Milestone: M1