### PR TITLE
feat: MockSpace.inject + SUT base-URL injection + isolation invariant tests

### DIFF
--- a/core/src/test/scala/zio/bdd/mock/sut/SutInjectionSpec.scala
+++ b/core/src/test/scala/zio/bdd/mock/sut/SutInjectionSpec.scala
@@ -1,0 +1,104 @@
+package zio.bdd.mock.sut
+
+import zio.*
+import zio.bdd.core.step.ZIOSteps
+import zio.bdd.gherkin.*
+import zio.bdd.mock.*
+import zio.schema.{DeriveSchema, Schema}
+import zio.test.*
+
+import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
+import java.net.InetSocketAddress
+import java.util.concurrent.{ConcurrentHashMap, CopyOnWriteArrayList}
+import scala.jdk.CollectionConverters.*
+
+/**
+ * Integration proof of #117 AC1: a suite whose SUT reads its dependency URL
+ * from a per-scenario layer (`SutClient`, injected via `scenarioLayer`) runs
+ * under feature×scenario parallelism with no cross-talk — each scenario's
+ * dependency call lands in its own space.
+ */
+object SutInjectionSpec extends ZIOSpecDefault:
+
+  final case class TestState()
+  object TestState:
+    given Schema[TestState] = DeriveSchema.gen[TestState]
+
+  // A shared in-process dependency that records each request under its first path
+  // segment (the PerInstance space id baked into `space.baseUri`).
+  private final class TestDependency(port: Int, recordings: ConcurrentHashMap[String, CopyOnWriteArrayList[String]]):
+    def perInstanceSpace(id: String): MockSpace = MockSpace(s"http://localhost:$port/$id", identity, SpaceId(id))
+    def received(id: String): UIO[List[String]] =
+      ZIO.succeed(Option(recordings.get(id)).map(_.asScala.toList).getOrElse(Nil))
+    def recordedKeys: UIO[Set[String]] = ZIO.succeed(recordings.keySet.asScala.toSet)
+
+  private val dependency: ZIO[Scope, Throwable, TestDependency] =
+    ZIO
+      .acquireRelease(
+        ZIO.attempt {
+          val recordings = new ConcurrentHashMap[String, CopyOnWriteArrayList[String]]()
+          val server     = HttpServer.create(new InetSocketAddress("localhost", 0), 0)
+          server.createContext(
+            "/",
+            new HttpHandler:
+              def handle(exchange: HttpExchange): Unit =
+                val seg  = exchange.getRequestURI.getPath.stripPrefix("/").split("/", 2)
+                val key  = seg(0)
+                val path = "/" + (if seg.length > 1 then seg(1) else "")
+                recordings.computeIfAbsent(key, _ => new CopyOnWriteArrayList[String]()).add(path)
+                exchange.sendResponseHeaders(200, -1)
+                exchange.close()
+          )
+          server.start()
+          (server, new TestDependency(server.getAddress.getPort, recordings))
+        }
+      )(acquired => ZIO.attempt(acquired._1.stop(0)).orDie)
+      .map(_._2)
+
+  // The SUT's dependency client is provided per scenario, bound to a space named
+  // after the scenario — never a shared/global value.
+  private class SutSuite(dep: TestDependency) extends ZIOSteps[SutClient, TestState]:
+    override def scenarioLayer(meta: ScenarioMetadata): ZLayer[Any, Throwable, SutClient] =
+      SutClient.layer(dep.perInstanceSpace(meta.name))
+
+    When("the SUT calls its dependency at " / string) { (path: String) =>
+      ZIO.serviceWithZIO[SutClient](_.send(Method.Get, path)).unit
+    }
+
+  private def scenario(name: String, feature: String) =
+    Scenario(
+      name,
+      Nil,
+      List(Step(StepType.WhenStep, """the SUT calls its dependency at "/call"""", None, None, None)),
+      Some(s"$feature.feature"),
+      Some(1)
+    )
+
+  def spec = suite("SutInjection")(
+    test(
+      "a suite whose SUT reads its dep URL from the layer runs under feature×scenario parallelism with no cross-talk"
+    ) {
+      val featureSpecs = List(
+        "F1" -> List("F1-s1", "F1-s2", "F1-s3"),
+        "F2" -> List("F2-s1", "F2-s2", "F2-s3")
+      )
+      val allNames = featureSpecs.flatMap(_._2)
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          val suite    = new SutSuite(dep)
+          val features = featureSpecs.map((f, names) => Feature(f, Nil, names.map(scenario(_, f))))
+          for
+            results <- suite
+                         .run(features, featureParallelism = 2, scenarioParallelism = 3)
+                         .provideEnvironment(ZEnvironment[SutClient](SutClient.make(dep.perInstanceSpace("__outer__"))))
+            recs <- ZIO.foreach(allNames)(n => dep.received(n).map((n, _)))
+            keys <- dep.recordedKeys
+          yield assertTrue(
+            results.forall(_.isPassed),                // all scenarios passed under parallelism
+            recs.forall((_, r) => r == List("/call")), // each scenario's call landed in its OWN space, exactly once
+            keys == allNames.toSet                     // the server saw exactly these keys — no stray/foreign space
+          )
+        }
+      }
+    }
+  )

--- a/mock/src/main/scala/zio/bdd/mock/SutClient.scala
+++ b/mock/src/main/scala/zio/bdd/mock/SutClient.scala
@@ -1,0 +1,71 @@
+package zio.bdd.mock
+
+import zio.*
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest as JHttpRequest, HttpResponse as JHttpResponse}
+import scala.jdk.CollectionConverters.*
+
+/** A response the SUT received from its (mocked) dependency. */
+final case class SutResponse(status: Int, body: String, headers: Map[String, String])
+
+/**
+ * The SUT's dependency client, bound to one [[MockSpace]]. It derives the
+ * dependency base URL from `space.baseUri` and applies `space.inject` to every
+ * request, so the share-nothing isolation decoration (e.g. a Correlated
+ * backend's correlation header) rides along.
+ *
+ * Provide it per scenario via [[SutClient.layer]] — never a process-wide env
+ * var — so parallel scenarios each target their own space with no cross-talk.
+ */
+trait SutClient:
+  /**
+   * The base URL the SUT should treat as its dependency endpoint
+   * (`space.baseUri`).
+   */
+  def baseUrl: String
+
+  /**
+   * Issue a request to the bound space: `path` is resolved against [[baseUrl]]
+   * and the space's `inject` is applied before sending.
+   */
+  def send(
+    method: Method,
+    path: String,
+    headers: Map[String, String] = Map.empty,
+    body: Option[String] = None
+  ): IO[Throwable, SutResponse]
+
+object SutClient:
+  def make(space: MockSpace): SutClient = Live(space)
+
+  /** Per-scenario layer: bind the SUT's dependency client to `space`. */
+  def layer(space: MockSpace): ULayer[SutClient] = ZLayer.succeed(make(space))
+
+  private final case class Live(space: MockSpace) extends SutClient:
+    def baseUrl: String = space.baseUri
+
+    def send(
+      method: Method,
+      path: String,
+      headers: Map[String, String],
+      body: Option[String]
+    ): IO[Throwable, SutResponse] =
+      val injected = space.inject(HttpRequest(method, space.baseUri + path, headers, body))
+      ZIO.attemptBlocking {
+        val builder = injected.headers.foldLeft(JHttpRequest.newBuilder(URI.create(injected.uri))) { case (b, (k, v)) =>
+          b.header(k, v)
+        }
+        val publisher = injected.body match
+          case Some(content) => JHttpRequest.BodyPublishers.ofString(content)
+          case None          => JHttpRequest.BodyPublishers.noBody()
+        val request  = builder.method(injected.method.toString.toUpperCase, publisher).build()
+        val response = HttpClient.newHttpClient().send(request, JHttpResponse.BodyHandlers.ofString())
+        val respHeaders = response
+          .headers()
+          .map()
+          .asScala
+          .collect { case (k, vs) if !vs.isEmpty => k.toLowerCase -> vs.asScala.mkString(", ") }
+          .toMap
+        SutResponse(response.statusCode, response.body, respHeaders)
+      }

--- a/mock/src/test/scala/zio/bdd/mock/SutClientSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/SutClientSpec.scala
@@ -1,0 +1,173 @@
+package zio.bdd.mock
+
+import zio.*
+import zio.test.*
+
+import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
+import java.net.{InetSocketAddress, URI}
+import java.net.http.{HttpClient, HttpRequest as JHttpRequest, HttpResponse as JHttpResponse}
+import java.util.concurrent.{ConcurrentHashMap, CopyOnWriteArrayList}
+import scala.jdk.CollectionConverters.*
+
+object SutClientSpec extends ZIOSpecDefault:
+
+  // An in-process stand-in for the SUT's dependency. It records each request under
+  // a space key = the `x-correlation-id` header if present (Correlated isolation),
+  // else the first path segment (PerInstance isolation). A request that carries
+  // neither (e.g. inject was bypassed) lands under the wrong key, so a Correlated
+  // request without inject never reaches its space.
+  private final class TestDependency(
+    port: Int,
+    recordings: ConcurrentHashMap[String, CopyOnWriteArrayList[(String, String)]]
+  ):
+    def perInstanceSpace(id: String): MockSpace =
+      MockSpace(s"http://localhost:$port/$id", identity, SpaceId(id))
+
+    def correlatedSpace(id: String): MockSpace =
+      MockSpace(
+        s"http://localhost:$port",
+        req => req.copy(headers = req.headers + ("x-correlation-id" -> id)),
+        SpaceId(id)
+      )
+
+    def received(id: String): UIO[List[(String, String)]] =
+      ZIO.succeed(Option(recordings.get(id)).map(_.asScala.toList).getOrElse(Nil))
+
+  private val dependency: ZIO[Scope, Throwable, TestDependency] =
+    ZIO
+      .acquireRelease(
+        ZIO.attempt {
+          val recordings = new ConcurrentHashMap[String, CopyOnWriteArrayList[(String, String)]]()
+          val server     = HttpServer.create(new InetSocketAddress("localhost", 0), 0)
+          server.createContext(
+            "/",
+            new HttpHandler:
+              def handle(exchange: HttpExchange): Unit =
+                val full    = exchange.getRequestURI.getPath
+                val method  = exchange.getRequestMethod
+                val reqBody = new String(exchange.getRequestBody.readAllBytes())
+                val header  = Option(exchange.getRequestHeaders.getFirst("x-correlation-id"))
+                val (key, path) = header match
+                  case Some(h) => (h, full)
+                  case None =>
+                    val seg = full.stripPrefix("/").split("/", 2)
+                    (seg(0), "/" + (if seg.length > 1 then seg(1) else ""))
+                recordings.computeIfAbsent(key, _ => new CopyOnWriteArrayList[(String, String)]()).add((method, path))
+                // Echo the request body back, stamp a header, and fail /down — so a
+                // test can pin SutResponse status/body/header decoding and the
+                // non-2xx-is-a-value contract.
+                val status    = if path.endsWith("/down") then 503 else 200
+                val respBytes = reqBody.getBytes
+                exchange.getResponseHeaders.set("X-Served-By", "dep")
+                exchange.sendResponseHeaders(status, if respBytes.isEmpty then -1 else respBytes.length.toLong)
+                val os = exchange.getResponseBody
+                os.write(respBytes)
+                os.close()
+          )
+          server.start()
+          (server, new TestDependency(server.getAddress.getPort, recordings))
+        }
+      )(acquired => ZIO.attempt(acquired._1.stop(0)).orDie)
+      .map(_._2)
+
+  // Send a raw request with NO inject applied (bypasses SutClient).
+  private def rawGet(url: String): ZIO[Any, Throwable, Int] =
+    ZIO.attemptBlocking {
+      val req = JHttpRequest.newBuilder(URI.create(url)).GET().build()
+      HttpClient.newHttpClient().send(req, JHttpResponse.BodyHandlers.ofString()).statusCode
+    }
+
+  def spec = suite("SutClient")(
+    test("baseUrl derives from the space; PerInstance spaces target distinct endpoints (no fixed port)") {
+      ZIO.scoped {
+        dependency.map { dep =>
+          val a = SutClient.make(dep.perInstanceSpace("A"))
+          val b = SutClient.make(dep.perInstanceSpace("B"))
+          assertTrue(
+            a.baseUrl == dep.perInstanceSpace("A").baseUri, // derived from the space, not hardcoded
+            a.baseUrl.endsWith("/A"),
+            a.baseUrl != b.baseUrl // distinct per space
+          )
+        }
+      }
+    },
+    test("SutClient applies inject so Correlated requests reach their own space (no cross-talk)") {
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          for
+            _    <- SutClient.make(dep.correlatedSpace("A")).send(Method.Get, "/x")
+            _    <- SutClient.make(dep.correlatedSpace("B")).send(Method.Post, "/y")
+            recA <- dep.received("A")
+            recB <- dep.received("B")
+          yield assertTrue(recA == List(("GET", "/x")), recB == List(("POST", "/y")))
+        }
+      }
+    },
+    test("a Correlated request without inject does NOT reach its space (inject is load-bearing)") {
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          val spaceA = dep.correlatedSpace("A")
+          for
+            _        <- rawGet(spaceA.baseUri + "/x")                 // shared baseUri, no correlation header
+            withoutI <- dep.received("A")
+            _        <- SutClient.make(spaceA).send(Method.Get, "/x") // same, but via inject
+            withInj  <- dep.received("A")
+          yield assertTrue(
+            withoutI.isEmpty,              // not routed to A — inject was load-bearing
+            withInj == List(("GET", "/x")) // with inject it reaches A
+          )
+        }
+      }
+    },
+    test("concurrent SUT calls via per-space clients don't cross-talk (PerInstance)") {
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          val n = 25
+          for
+            _ <-
+              ZIO.foreachParDiscard(1 to n)(i => SutClient.make(dep.perInstanceSpace(s"s$i")).send(Method.Get, s"/p$i"))
+            recs <- ZIO.foreach((1 to n).toList)(i => dep.received(s"s$i").map((i, _)))
+          yield assertTrue(recs.forall((i, r) => r == List(("GET", s"/p$i"))))
+        }
+      }
+    },
+    test("concurrent SUT calls via per-space clients don't cross-talk (Correlated, shared base URL)") {
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          val n = 25
+          for
+            _ <-
+              ZIO.foreachParDiscard(1 to n)(i => SutClient.make(dep.correlatedSpace(s"c$i")).send(Method.Get, s"/q$i"))
+            recs <- ZIO.foreach((1 to n).toList)(i => dep.received(s"c$i").map((i, _)))
+          yield assertTrue(recs.forall((i, r) => r == List(("GET", s"/q$i"))))
+        }
+      }
+    },
+    test("send issues the inject-rewritten request URI, not the original (inject may rewrite the URI)") {
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          val rewriting = dep.perInstanceSpace("Z").copy(inject = req => req.copy(uri = req.uri + "-rewritten"))
+          for
+            _   <- SutClient.make(rewriting).send(Method.Get, "/orig")
+            rec <- dep.received("Z")
+          yield assertTrue(rec == List(("GET", "/orig-rewritten"))) // the inject's URI rewrite was honoured
+        }
+      }
+    },
+    test("send returns the decoded dependency response (status, body, headers); a non-2xx is a value, not an error") {
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          val client = SutClient.make(dep.perInstanceSpace("R"))
+          for
+            ok   <- client.send(Method.Post, "/echo", body = Some("hello"))
+            down <- client.send(Method.Get, "/down")
+          yield assertTrue(
+            ok.status == 200,
+            ok.body == "hello",                            // request body sent + response body decoded
+            ok.headers.get("x-served-by").contains("dep"), // header normalised to lower-case
+            down.status == 503                             // non-2xx surfaced as a SutResponse, not a failure
+          )
+        }
+      }
+    }
+  )


### PR DESCRIPTION
The SUT-side wiring for the portable mock SPI (#117): a dependency client that derives its base URL from the mock space and applies `space.inject`, injected per scenario via a layer.

- **`SutClient`** (mock module) — bound to one `MockSpace`. `baseUrl == space.baseUri`; `send(method, path, headers, body)` applies `space.inject` to the canonical request (so the correlation header / URI rewrite rides along) and issues it via the JDK `java.net.http.HttpClient` (zero new deps). Generalizes `MockSteps.sendThrough` (#114).
- **`SutClient.layer(space)`** — provides the client per scenario, never a process-wide env var, so parallel scenarios each target their own space.

## Tests — the three isolation invariants + both ACs
- AC1 (no cross-talk under feature×scenario parallelism): a `ZIOSteps` suite (2×3) whose `scenarioLayer` injects a per-scenario `SutClient`; asserts each scenario's dependency call lands only in its own space (recorded key-set == all scenario names). Plus mock-level `foreachPar` concurrency proofs for PerInstance and Correlated.
- AC2 (inject is load-bearing): a Correlated request sent **without** inject misses its space (no correlation header → routed elsewhere); **with** inject it reaches it.
- inv1 (no fixed port): `baseUrl` derives from the space, distinct per PerInstance space.
- inv2 (targets baseUri + applies inject): covered by the above + a test proving an `inject` that rewrites the URI is honoured.
- inv3 (finalizers destroy only their own): already proven by MockFixtures (#115); not re-tested here.

Closes #117

Milestone: M1