### PR TITLE
M1: Usable Mocking — portable MockControl SPI (#110–#119)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,27 @@ jobs:
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - run: sbt scalafmtCheckAll mimaReportBinaryIssues test
+
+  # The Rift adapter's real-container acceptance test (#113) is gated by RIFT_IT
+  # so the hermetic `build` job above stays Docker-free. ubuntu-latest ships a
+  # running Docker daemon at /var/run/docker.sock that testcontainers resolves
+  # natively, so Rift.managed() can stand up the published image here. (Docker
+  # Desktop on macOS is not auto-resolvable, which is why this can't run as part
+  # of the default unit gate.)
+  rift-it:
+    name: Rift integration test (real container)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+      - name: RiftContainerSpec against a real Rift container (testcontainers)
+        env:
+          RIFT_IT: "1"
+        run: sbt "rift/testOnly zio.bdd.mock.rift.RiftContainerSpec"

--- a/build.sbt
+++ b/build.sbt
@@ -103,7 +103,7 @@ lazy val root = (project in file("."))
   .dependsOn(core, gherkin)
 
 lazy val core = (project in file("core"))
-  .dependsOn(gherkin)
+  .dependsOn(gherkin, mock)
   .settings(
     name := "zio-bdd",
     libraryDependencies ++= commonDependencies,

--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val mimaSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .aggregate(core, gherkin)
+  .aggregate(core, gherkin, mock)
   .settings(
     name                  := "zio-bdd-root",
     description           := "A ZIO-based BDD testing framework for Scala 3",
@@ -123,6 +123,17 @@ lazy val gherkin = (project in file("gherkin"))
     name := "zio-bdd-gherkin",
     libraryDependencies ++= commonDependencies,
     mimaSettings
+  )
+
+// Portable MockControl SPI (#110). Standalone, backend-neutral: no dependency on
+// any adapter (Rift, WireMock) — adapters depend on this module, never the reverse.
+lazy val mock = (project in file("mock"))
+  .settings(
+    name := "zio-bdd-mock",
+    libraryDependencies ++= commonDependencies,
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
+    mimaPreviousArtifacts := Set.empty
   )
 
 lazy val example = (project in file("example"))

--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val mimaSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .aggregate(core, gherkin, mock)
+  .aggregate(core, gherkin, mock, rift)
   .settings(
     name                  := "zio-bdd-root",
     description           := "A ZIO-based BDD testing framework for Scala 3",
@@ -131,6 +131,25 @@ lazy val mock = (project in file("mock"))
   .settings(
     name := "zio-bdd-mock",
     libraryDependencies ++= commonDependencies,
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
+    mimaPreviousArtifacts := Set.empty
+  )
+
+// Rift adapter (#113): implements the portable MockControl SPI over the Rift
+// (Mountebank-compatible) backend. Drives the admin API via zio-http and can
+// stand up the published image via testcontainers. Depends on `mock`, never the
+// reverse.
+lazy val rift = (project in file("rift"))
+  .dependsOn(mock)
+  .settings(
+    name := "zio-bdd-rift",
+    libraryDependencies ++= commonDependencies,
+    libraryDependencies ++= Seq(
+      "dev.zio"      %% "zio-http"                   % "3.2.0",
+      "dev.zio"      %% "zio-json"                   % "0.7.3",
+      "com.dimafeng" %% "testcontainers-scala-core"  % "0.41.4"
+    ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
     mimaPreviousArtifacts := Set.empty

--- a/core/src/main/scala/zio/bdd/mock/fixtures/MockFixtures.scala
+++ b/core/src/main/scala/zio/bdd/mock/fixtures/MockFixtures.scala
@@ -1,0 +1,83 @@
+package zio.bdd.mock.fixtures
+
+import zio.*
+import zio.bdd.gherkin.ScenarioMetadata
+import zio.bdd.mock.{MockControl, MockError, MockSource, MockSpace}
+
+/**
+ * The mock spaces a fixture scope provisioned, exposed to the suite's steps.
+ */
+final case class MockFixture(spaces: List[MockSpace])
+
+/**
+ * Parser for the `@mock(name, ...)` Gherkin tag. Tags arrive without the `@`.
+ */
+object MockTag:
+  private val pattern = """^mock\(([^)]*)\)$""".r
+
+  /**
+   * The catalog entry names in a single `@mock(...)` tag, or `None` if the tag
+   * is not a `@mock(...)` tag at all. An empty `@mock()` yields `Some(Nil)`.
+   */
+  def parse(tag: String): Option[List[String]] =
+    pattern.findFirstMatchIn(tag.trim.stripPrefix("@")).map { m =>
+      m.group(1).split(",").map(_.trim).filter(_.nonEmpty).toList
+    }
+
+  /**
+   * All `@mock(...)` names across the tags, in order,
+   * first-occurrence-deduplicated.
+   */
+  def extract(tags: List[String]): List[String] =
+    tags.flatMap(parse(_).getOrElse(Nil)).distinct
+
+object MockFixtures:
+
+  /**
+   * Feature-tier fixtures: provision `sources` once (the three-tier model
+   * memoizes this layer per feature). Heavy, read-only fixtures shared by all
+   * of a feature's scenarios.
+   */
+  def feature(sources: MockSource*): ZLayer[MockControl, Throwable, MockFixture] =
+    ZLayer.scoped(provisionScoped(sources.toList).mapError(asThrowable))
+
+  /**
+   * Scenario-tier fixtures: deploy the catalog entries named by the scenario's
+   * `@mock(...)` tags. Fresh per scenario (share-nothing, auto-port via the
+   * adapter); a name with no catalog entry fails the scenario at setup.
+   */
+  def scenario(meta: ScenarioMetadata, catalog: Map[String, MockSource]): ZLayer[MockControl, Throwable, MockFixture] =
+    ZLayer.scoped {
+      resolve(MockTag.extract(meta.tags), catalog).flatMap(provisionScoped).mapError(asThrowable)
+    }
+
+  // Provision each source as its own scoped acquisition, so a failure partway
+  // through still tears down the spaces already created (each registers its own
+  // finalizer in the scope). The scope destroys ONLY these spaces — never a
+  // global teardown (the §5.9 invariant). A teardown that fails is logged and
+  // skipped so one bad destroy can't strand its siblings.
+  private def provisionScoped(sources: List[MockSource]): ZIO[MockControl & Scope, MockError, MockFixture] =
+    ZIO.serviceWithZIO[MockControl] { control =>
+      ZIO
+        .foreach(sources) { source =>
+          ZIO.acquireRelease(control.provision(source))(spaces =>
+            ZIO.foreachDiscard(spaces)(space =>
+              control
+                .destroy(space)
+                .catchAllCause(cause =>
+                  ZIO.logWarningCause(s"mock fixture teardown failed for ${space.id.value}", cause)
+                )
+            )
+          )
+        }
+        .map(perSource => MockFixture(perSource.flatten))
+    }
+
+  private def resolve(names: List[String], catalog: Map[String, MockSource]): IO[MockError, List[MockSource]] =
+    ZIO.foreach(names) { name =>
+      ZIO
+        .fromOption(catalog.get(name))
+        .orElseFail(MockError.InvalidDefinition(s"@mock($name): no catalog entry named '$name'"))
+    }
+
+  private def asThrowable(e: MockError): Throwable = new RuntimeException(s"MockFixtures: $e")

--- a/core/src/main/scala/zio/bdd/mock/steps/MockSteps.scala
+++ b/core/src/main/scala/zio/bdd/mock/steps/MockSteps.scala
@@ -1,0 +1,189 @@
+package zio.bdd.mock.steps
+
+import zio.*
+import zio.bdd.core.Assertions
+import zio.bdd.core.step.{Stage, ZIOSteps}
+import zio.bdd.mock.*
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest as JHttpRequest, HttpResponse as JHttpResponse}
+import scala.jdk.CollectionConverters.*
+
+/**
+ * The last response from sending a request through a mock space — staged per
+ * scenario so the response-assertion steps can read it.
+ */
+final case class MockResponse(status: Int, body: String, headers: Map[String, String])
+
+/**
+ * Mixin providing ready-made Gherkin steps for the portable mocking SPI,
+ * modelled on [[zio.bdd.http.HttpSteps]].
+ *
+ * Mix into any `ZIOSteps` suite whose environment provides a [[MockControl]] —
+ * the self-type `ZIOSteps[R & MockControl, S]` is the only wiring required (no
+ * lens, no extra given). The active [[MockSpace]] and the last response are
+ * kept in [[Stage]] (not scenario state) because a `MockSpace` carries a
+ * function and is not Schema-serialisable.
+ *
+ * ===Registered steps===
+ *   - `Given a mock space returning {int} {string} at {string}` — provision a
+ *     space
+ *   - `When the space overlays {int} {string} at {string}` — overlay a rule
+ *   - `When a {string} {string} is sent through the space` — send (honours
+ *     `inject`)
+ *   - `Then the space response status is {int}` / `… body contains {string}` /
+ *     `… header {string} is {string}` — assert the staged response
+ *   - `Then the space received {int} requests` — assert recorded count
+ *     (space-local)
+ *   - `Then a {string} request to {string} was recorded` — assert ≥1 match
+ *   - `Then exactly {int} {string} requests to {string} were recorded` — assert
+ *     exact count
+ *
+ * @tparam R
+ *   the suite environment (must provide `MockControl`)
+ * @tparam S
+ *   the suite scenario state (unused by these steps)
+ */
+trait MockSteps[R, S] { self: ZIOSteps[R & MockControl, S] =>
+
+  Given("a mock space returning " / int / " " / string / " at " / string) { (status: Int, body: String, path: String) =>
+    for
+      spaces <- mock(_.provision(MockSource.Dsl(MockSpec(List(ruleFor(status, body, path))))))
+      space  <- ZIO.fromOption(spaces.headOption).orElseFail(new IllegalStateException("provision returned no space"))
+      _      <- Stage.put(space)
+    yield ()
+  }
+
+  When("the space overlays " / int / " " / string / " at " / string) { (status: Int, body: String, path: String) =>
+    for
+      space <- activeSpace
+      _     <- mock(_.addRule(space, ruleFor(status, body, path), Priority.Overlay))
+    yield ()
+  }
+
+  When("a " / string / " " / string / " is sent through the space") { (method: String, path: String) =>
+    for
+      space <- activeSpace
+      resp  <- sendThrough(space, method, path)
+      _     <- Stage.put(resp)
+    yield ()
+  }
+
+  Then("the space response status is " / int) { (expected: Int) =>
+    stagedResponse.flatMap(r => Assertions.assertEquals(r.status, expected, "space response status mismatch"))
+  }
+
+  Then("the space response body contains " / string) { (expected: String) =>
+    stagedResponse.flatMap(r =>
+      Assertions.assertTrue(r.body.contains(expected), s"space response body '${r.body}' does not contain '$expected'")
+    )
+  }
+
+  Then("the space response header " / string / " is " / string) { (name: String, expected: String) =>
+    stagedResponse.flatMap { r =>
+      r.headers.get(name.toLowerCase) match
+        case Some(actual) => Assertions.assertEquals(actual, expected, s"response header '$name' mismatch")
+        case None =>
+          ZIO.fail(
+            new AssertionError(s"response header '$name' not present. Headers: ${r.headers.keys.mkString(", ")}")
+          )
+    }
+  }
+
+  Then("the space received " / int / " requests") { (expected: Int) =>
+    for
+      space <- activeSpace
+      reqs  <- mock(_.received(space))
+      _     <- Assertions.assertEquals(reqs.size, expected, s"recorded request count mismatch for space ${space.id.value}")
+    yield ()
+  }
+
+  Then("a " / string / " request to " / string / " was recorded") { (method: String, path: String) =>
+    for
+      space <- activeSpace
+      reqs  <- mock(_.received(space))
+      _ <- Assertions.assertTrue(
+             countMatching(reqs, method, path) >= 1,
+             s"no recorded $method request to $path. Recorded: ${reqs.map(r => s"${r.method} ${r.uri}").mkString(", ")}"
+           )
+    yield ()
+  }
+
+  Then("exactly " / int / " " / string / " requests to " / string / " were recorded") {
+    (expected: Int, method: String, path: String) =>
+      for
+        space <- activeSpace
+        reqs  <- mock(_.received(space))
+        _ <-
+          Assertions.assertEquals(countMatching(reqs, method, path), expected, s"recorded $method $path count mismatch")
+      yield ()
+  }
+
+  // ── helpers ─────────────────────────────────────────────────────────────
+
+  /**
+   * Run a MockControl operation, surfacing its typed error on the step's
+   * Throwable channel.
+   */
+  private def mock[A](f: MockControl => IO[MockError, A]): ZIO[R & MockControl, Throwable, A] =
+    ZIO.serviceWithZIO[MockControl](f).mapError(e => new RuntimeException(s"MockControl: ${describe(e)}"))
+
+  private val activeSpace: IO[Throwable, MockSpace] =
+    Stage
+      .get[MockSpace]
+      .mapError(e => new IllegalStateException(s"no active mock space — deploy one first (${e.message})"))
+
+  private val stagedResponse: IO[Throwable, MockResponse] =
+    Stage
+      .get[MockResponse]
+      .mapError(e => new IllegalStateException(s"no response staged — send a request first (${e.message})"))
+
+  private def ruleFor(status: Int, body: String, path: String): MockRule =
+    MockRule(RequestMatch(path = PathMatch.Exact(path)), ResponseDef(status = status, body = Body.Text(body)))
+
+  private def countMatching(reqs: List[RecordedRequest], method: String, path: String): Int =
+    reqs.count(r => r.method.toString.equalsIgnoreCase(method) && r.uri == path)
+
+  private def methodOf(name: String): IO[Throwable, Method] =
+    ZIO
+      .fromOption(Method.values.find(_.toString.equalsIgnoreCase(name)))
+      .orElseFail(
+        new IllegalArgumentException(
+          s"unknown HTTP method '$name'; expected one of ${Method.values.map(_.toString.toUpperCase).mkString(", ")}"
+        )
+      )
+
+  /**
+   * Send a request through the space: build the canonical request, apply the
+   * space's `inject` (the isolation decoration), then issue exactly the
+   * injected request — method included — with the JDK client.
+   */
+  private def sendThrough(space: MockSpace, method: String, path: String): IO[Throwable, MockResponse] =
+    methodOf(method).flatMap { m =>
+      val injected = space.inject(HttpRequest(m, space.baseUri + path))
+      ZIO.attemptBlocking {
+        val builder = injected.headers.foldLeft(JHttpRequest.newBuilder(URI.create(injected.uri))) { case (b, (k, v)) =>
+          b.header(k, v)
+        }
+        val publisher = injected.body match
+          case Some(body) => JHttpRequest.BodyPublishers.ofString(body)
+          case None       => JHttpRequest.BodyPublishers.noBody()
+        val request  = builder.method(injected.method.toString.toUpperCase, publisher).build()
+        val response = HttpClient.newHttpClient().send(request, JHttpResponse.BodyHandlers.ofString())
+        val headers = response
+          .headers()
+          .map()
+          .asScala
+          .collect { case (k, vs) if !vs.isEmpty => k.toLowerCase -> vs.asScala.mkString(", ") }
+          .toMap
+        MockResponse(response.statusCode, response.body, headers)
+      }
+    }
+
+  private def describe(e: MockError): String = e match
+    case MockError.ProvisionFailed(r)    => s"provision failed: $r"
+    case MockError.SpaceNotFound(s)      => s"space not found: ${s.value}"
+    case MockError.RuleNotFound(s, r)    => s"rule ${r.value} not found in space ${s.value}"
+    case MockError.InvalidDefinition(r)  => s"invalid definition: $r"
+    case MockError.CommunicationError(r) => s"communication error: $r"
+}

--- a/core/src/test/scala/zio/bdd/mock/fixtures/MockFixturesSpec.scala
+++ b/core/src/test/scala/zio/bdd/mock/fixtures/MockFixturesSpec.scala
@@ -1,0 +1,183 @@
+package zio.bdd.mock.fixtures
+
+import zio.*
+import zio.bdd.gherkin.ScenarioMetadata
+import zio.bdd.mock.*
+import zio.test.*
+
+object MockFixturesSpec extends ZIOSpecDefault:
+
+  // A MockControl that provisions one fresh, uniquely-identified space per source
+  // and logs every destroy. It has no bulk delete — so "never a global teardown"
+  // is structural; the assertions check the finalizer destroyed exactly its own.
+  private final case class TState(nextId: Int, live: Set[String], destroyed: List[String], provisions: Int)
+  private object TState:
+    val init: TState = TState(0, Set.empty, Nil, 0)
+
+  private final class TestControl(
+    ref: Ref[TState],
+    failProvision: MockSource => Boolean = _ => false,
+    failDestroy: String => Boolean = _ => false
+  ) extends MockControl:
+    def backendName: String           = "test"
+    def capabilities: Set[Capability] = Set.empty
+
+    def provision(source: MockSource): IO[MockError, List[MockSpace]] =
+      if failProvision(source) then ZIO.fail(MockError.ProvisionFailed("boom"))
+      else
+        ref.modify { s =>
+          val id = s"sp${s.nextId}"
+          (
+            List(MockSpace(s"http://localhost/$id", identity, SpaceId(id))),
+            s.copy(nextId = s.nextId + 1, live = s.live + id, provisions = s.provisions + 1)
+          )
+        }
+
+    def destroy(space: MockSpace): IO[MockError, Unit] =
+      if failDestroy(space.id.value) then ZIO.fail(MockError.CommunicationError("teardown boom"))
+      else ref.update(s => s.copy(live = s.live - space.id.value, destroyed = s.destroyed :+ space.id.value))
+
+    def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+      ZIO.fail(MockError.InvalidDefinition("n/a"))
+    def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] = ZIO.succeed(RuleId("r"))
+    def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit]                        = ZIO.unit
+    def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit]           = ZIO.unit
+    def received(space: MockSpace): IO[MockError, List[RecordedRequest]]                     = ZIO.succeed(Nil)
+    def faults: IO[Unsupported, Faults]                                                      = ZIO.fail(Unsupported(Capability.Faults, backendName))
+    def scenarios: IO[Unsupported, StatefulScenarios]                                        = ZIO.fail(Unsupported(Capability.StatefulScenarios, backendName))
+    def stateInspection: IO[Unsupported, StateInspection] =
+      ZIO.fail(Unsupported(Capability.StateInspection, backendName))
+    def scripting: IO[Unsupported, Scripting]     = ZIO.fail(Unsupported(Capability.Scripting, backendName))
+    def proxyRecord: IO[Unsupported, ProxyRecord] = ZIO.fail(Unsupported(Capability.ProxyRecord, backendName))
+    def templating: IO[Unsupported, Templating]   = ZIO.fail(Unsupported(Capability.Templating, backendName))
+
+  private val srcA = MockSource.Json("""{"a":1}""")
+  private val srcB = MockSource.Json("""{"b":2}""")
+
+  private def meta(tags: String*): ScenarioMetadata = ScenarioMetadata("s", tags.toList, None, None)
+
+  private def control: UIO[(MockControl, Ref[TState])] =
+    Ref.make(TState.init).map(ref => (TestControl(ref), ref))
+
+  def spec = suite("MockFixtures")(
+    test("MockTag parses @mock(...) names and ignores unrelated tags") {
+      assertTrue(
+        MockTag.parse("mock(a, b)").contains(List("a", "b")),
+        MockTag.parse("@mock(x)").contains(List("x")),
+        MockTag.parse("mock()").contains(Nil),
+        MockTag.parse("flags(k=v)").isEmpty,
+        MockTag.parse("smoke").isEmpty,
+        MockTag.extract(List("mock(a)", "other", "mock(b, c)")) == List("a", "b", "c")
+      )
+    },
+    test("a feature fixture provisions its sources; the finalizer destroys exactly those spaces (§5.9)") {
+      for
+        cr        <- control
+        (ctl, ref) = cr
+        during <- ZIO.scoped {
+                    MockFixtures.feature(srcA, srcB).build.map(_.get[MockFixture]).flatMap(fx => ref.get.map((fx, _)))
+                  }.provideLayer(ZLayer.succeed(ctl))
+        after <- ref.get
+      yield
+        val (fx, mid) = during
+        assertTrue(
+          fx.spaces.size == 2,
+          mid.provisions == 2,
+          mid.live.size == 2,                                      // both live within the scope
+          after.live.isEmpty,                                      // both destroyed on release
+          after.destroyed.toSet == fx.spaces.map(_.id.value).toSet // exactly its own, nothing else
+        )
+    },
+    test(
+      "two scenario fixtures from the same source get independent spaces; one teardown leaves the other live (AC1)"
+    ) {
+      for
+        cr        <- control
+        (ctl, ref) = cr
+        catalog    = Map("svc" -> srcA)
+        res <- ZIO.scoped {
+                 MockFixtures.scenario(meta("mock(svc)"), catalog).build.map(_.get[MockFixture]).flatMap { fxA =>
+                   ZIO
+                     .scoped(MockFixtures.scenario(meta("mock(svc)"), catalog).build.map(_.get[MockFixture]))
+                     .flatMap(fxB => ref.get.map((fxA, fxB, _)))
+                 }
+               }.provideLayer(ZLayer.succeed(ctl))
+      yield
+        val (fxA, fxB, afterBClosed) = res
+        val aIds                     = fxA.spaces.map(_.id.value).toSet
+        val bIds                     = fxB.spaces.map(_.id.value).toSet
+        assertTrue(
+          aIds.nonEmpty && bIds.nonEmpty,
+          aIds.intersect(bIds).isEmpty,           // independent spaces
+          afterBClosed.destroyed.toSet == bIds,   // only B's teardown ran
+          aIds.forall(afterBClosed.live.contains) // A is untouched by B's teardown
+        )
+    },
+    test(
+      "a feature fixture provisions once per build; a second build gets fresh, disjoint spaces (isolation between features)"
+    ) {
+      for
+        cr      <- control
+        (ctl, _) = cr
+        f1      <- ZIO.scoped(MockFixtures.feature(srcA).build.map(_.get[MockFixture])).provideLayer(ZLayer.succeed(ctl))
+        f2      <- ZIO.scoped(MockFixtures.feature(srcA).build.map(_.get[MockFixture])).provideLayer(ZLayer.succeed(ctl))
+      yield assertTrue(
+        f1.spaces.nonEmpty,
+        f1.spaces.map(_.id.value).toSet.intersect(f2.spaces.map(_.id.value).toSet).isEmpty
+      )
+    },
+    test("@mock(...) deploys the named catalog entries; no @mock tag provisions nothing") {
+      for
+        cr      <- control
+        (ctl, _) = cr
+        catalog  = Map("payments" -> srcA, "inventory" -> srcB)
+        tagged <-
+          ZIO
+            .scoped(MockFixtures.scenario(meta("mock(payments, inventory)"), catalog).build.map(_.get[MockFixture]))
+            .provideLayer(ZLayer.succeed(ctl))
+        untagged <- ZIO
+                      .scoped(MockFixtures.scenario(meta("smoke"), catalog).build.map(_.get[MockFixture]))
+                      .provideLayer(ZLayer.succeed(ctl))
+      yield assertTrue(tagged.spaces.size == 2, untagged.spaces.isEmpty)
+    },
+    test("@mock(unknown) referencing a missing catalog entry fails loudly, naming the entry") {
+      for
+        cr      <- control
+        (ctl, _) = cr
+        res <- ZIO
+                 .scoped(MockFixtures.scenario(meta("mock(ghost)"), Map.empty).build)
+                 .provideLayer(ZLayer.succeed(ctl))
+                 .either
+      yield assertTrue(res.isLeft, res.swap.toOption.exists(_.getMessage.contains("ghost")))
+    },
+    test("a source that fails mid-provision does not leak the spaces already provisioned") {
+      for
+        ref             <- Ref.make(TState.init)
+        ctl: MockControl = TestControl(ref, failProvision = _ == srcB) // srcA succeeds, srcB fails
+        res <- ZIO
+                 .scoped(MockFixtures.feature(srcA, srcB).build)
+                 .provideLayer(ZLayer.succeed(ctl))
+                 .either
+        after <- ref.get
+      yield assertTrue(
+        res.isLeft,                     // build failed
+        after.provisions == 1,          // only srcA got provisioned
+        after.destroyed == List("sp0"), // and it was torn down on unwind — not leaked
+        after.live.isEmpty
+      )
+    },
+    test("a teardown failure for one space does not strand the others") {
+      for
+        ref             <- Ref.make(TState.init)
+        ctl: MockControl = TestControl(ref, failDestroy = _ == "sp0") // sp0's destroy fails
+        res <- ZIO
+                 .scoped(MockFixtures.feature(srcA, srcB).build.unit)
+                 .provideLayer(ZLayer.succeed(ctl))
+                 .either
+        after <- ref.get
+      yield assertTrue(
+        res.isRight,                    // the failing finalizer is logged, not propagated
+        after.destroyed.contains("sp1") // sp1 was still destroyed despite sp0's teardown failing
+      )
+    }
+  )

--- a/core/src/test/scala/zio/bdd/mock/steps/MockStepsSpec.scala
+++ b/core/src/test/scala/zio/bdd/mock/steps/MockStepsSpec.scala
@@ -1,0 +1,231 @@
+package zio.bdd.mock.steps
+
+import zio.*
+import zio.bdd.core.FeatureResult
+import zio.bdd.core.step.ZIOSteps
+import zio.bdd.gherkin.*
+import zio.bdd.mock.*
+import zio.schema.{DeriveSchema, Schema}
+import zio.test.*
+
+import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{ConcurrentHashMap, CopyOnWriteArrayList}
+import scala.jdk.CollectionConverters.*
+
+/**
+ * Tests for MockSteps — the pre-built mock step mixin. Drives the mixin against
+ * a real in-process HTTP backend (a tiny `com.sun.net.httpserver` server) that
+ * implements `MockControl` directly, partitioning spaces by an id path prefix
+ * so recordings are genuinely space-local.
+ */
+object MockStepsSpec extends ZIOSpecDefault:
+
+  final case class TestState()
+  object TestState:
+    given Schema[TestState] = DeriveSchema.gen[TestState]
+
+  // ── In-process MockControl backed by one HttpServer ─────────────────────────
+
+  private final class TestBackend(
+    server: HttpServer,
+    recordings: ConcurrentHashMap[String, CopyOnWriteArrayList[RecordedRequest]],
+    stubs: ConcurrentHashMap[String, (Int, String)],
+    counter: AtomicInteger
+  ) extends MockControl:
+    private val port                  = server.getAddress.getPort
+    def backendName: String           = "test"
+    def capabilities: Set[Capability] = Set.empty
+
+    def provision(source: MockSource): IO[MockError, List[MockSpace]] =
+      source match
+        case MockSource.Dsl(spec) =>
+          ZIO.succeed {
+            val id = "s" + counter.incrementAndGet()
+            recordings.put(id, new CopyOnWriteArrayList[RecordedRequest]())
+            spec.rules.foreach(registerStub(id, _))
+            List(MockSpace(s"http://localhost:$port/$id", identity, SpaceId(id)))
+          }
+        case _ => ZIO.fail(MockError.InvalidDefinition("test backend only supports Dsl sources"))
+
+    def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+      ZIO.succeed { registerStub(space.id.value, rule); RuleId("r") }
+
+    def received(space: MockSpace): IO[MockError, List[RecordedRequest]] =
+      ZIO.succeed(Option(recordings.get(space.id.value)).map(_.asScala.toList).getOrElse(Nil))
+
+    def destroy(space: MockSpace): IO[MockError, Unit] =
+      ZIO.succeed { recordings.remove(space.id.value); () }
+
+    def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+      ZIO.fail(MockError.InvalidDefinition("unsupported"))
+    def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit]              = ZIO.unit
+    def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit] = ZIO.unit
+    def faults: IO[Unsupported, Faults]                                            = ZIO.fail(Unsupported(Capability.Faults, backendName))
+    def scenarios: IO[Unsupported, StatefulScenarios]                              = ZIO.fail(Unsupported(Capability.StatefulScenarios, backendName))
+    def stateInspection: IO[Unsupported, StateInspection] =
+      ZIO.fail(Unsupported(Capability.StateInspection, backendName))
+    def scripting: IO[Unsupported, Scripting]     = ZIO.fail(Unsupported(Capability.Scripting, backendName))
+    def proxyRecord: IO[Unsupported, ProxyRecord] = ZIO.fail(Unsupported(Capability.ProxyRecord, backendName))
+    def templating: IO[Unsupported, Templating]   = ZIO.fail(Unsupported(Capability.Templating, backendName))
+
+    private def registerStub(spaceId: String, rule: MockRule): Unit =
+      val path = rule.`match`.path match
+        case PathMatch.Exact(p) => p
+        case _                  => "/"
+      val body = rule.respond.body match
+        case Body.Text(v) => v
+        case Body.Json(v) => v
+        case _            => ""
+      stubs.put(stubKey(spaceId, path), (rule.respond.status, body))
+
+  private def stubKey(spaceId: String, path: String): String = spaceId + " " + path
+
+  private def methodOf(name: String): Method =
+    Method.values.find(_.toString.equalsIgnoreCase(name)).getOrElse(Method.Get)
+
+  private val makeBackend: ZIO[Scope, Throwable, MockControl] =
+    ZIO
+      .acquireRelease(
+        ZIO.attempt {
+          val recordings = new ConcurrentHashMap[String, CopyOnWriteArrayList[RecordedRequest]]()
+          val stubs      = new ConcurrentHashMap[String, (Int, String)]()
+          val server     = HttpServer.create(new InetSocketAddress("localhost", 0), 0)
+          server.createContext(
+            "/",
+            new HttpHandler:
+              def handle(exchange: HttpExchange): Unit =
+                val segments = exchange.getRequestURI.getPath.stripPrefix("/").split("/", 2)
+                val spaceId  = segments(0)
+                val path     = "/" + (if segments.length > 1 then segments(1) else "")
+                val body     = new String(exchange.getRequestBody.readAllBytes())
+                Option(recordings.get(spaceId)).foreach { rec =>
+                  rec.add(
+                    RecordedRequest(
+                      methodOf(exchange.getRequestMethod),
+                      path,
+                      Map.empty,
+                      Option(body).filter(_.nonEmpty)
+                    )
+                  )
+                }
+                val (status, payload) = Option(stubs.get(stubKey(spaceId, path))).getOrElse((404, ""))
+                val bytes             = payload.getBytes
+                exchange.getResponseHeaders.set("X-Served-By", "test-mock")
+                exchange.sendResponseHeaders(status, if bytes.isEmpty then -1 else bytes.length.toLong)
+                val os = exchange.getResponseBody
+                os.write(bytes)
+                os.close()
+          )
+          server.start()
+          (server, new TestBackend(server, recordings, stubs, new AtomicInteger(0)): MockControl)
+        }
+      )((acquired) => ZIO.attempt(acquired._1.stop(0)).orDie)
+      .map(_._2)
+
+  // ── Suite mixing in MockSteps ───────────────────────────────────────────────
+
+  private class MockSuite(control: MockControl)
+      extends ZIOSteps[MockControl, TestState]
+      with MockSteps[MockControl, TestState]:
+    override def environment: ZLayer[Any, Throwable, MockControl] = ZLayer.succeed(control)
+
+  private val F = "mock-steps.feature"
+
+  private def run(steps: List[Step]): ZIO[Any, Throwable, FeatureResult] =
+    ZIO.scoped {
+      makeBackend.flatMap { backend =>
+        new MockSuite(backend)
+          .run(List(Feature("Mock", Nil, List(Scenario("s", Nil, steps, Some(F), Some(1))))))
+          .provideEnvironment(ZEnvironment(backend))
+          .map(_.head)
+      }
+    }
+
+  private def step(t: StepType, p: String) = Step(t, p, None, None, None)
+  private val G                            = StepType.GivenStep
+  private val W                            = StepType.WhenStep
+  private val T                            = StepType.ThenStep
+
+  def spec = suite("MockSteps")(
+    test("AC1: a suite mixing MockSteps deploys, sends, and asserts the response with only MockControl in R") {
+      run(
+        List(
+          step(G, """a mock space returning 200 "pong" at "/ping""""),
+          step(W, """a "GET" "/ping" is sent through the space"""),
+          step(T, "the space response status is 200"),
+          step(T, """the space response body contains "pong""""),
+          step(T, """the space response header "x-served-by" is "test-mock"""")
+        )
+      ).map(r => assertTrue(r.isPassed))
+    },
+    test("AC2: recorded-request assertions read received(space) and are space-local") {
+      run(
+        List(
+          step(G, """a mock space returning 200 "a" at "/x""""), // space A
+          step(W, """a "GET" "/x" is sent through the space"""),
+          step(W, """a "GET" "/x" is sent through the space"""),
+          step(T, "the space received 2 requests"), // A recorded 2
+          step(T, """a "GET" request to "/x" was recorded"""),
+          step(G, """a mock space returning 200 "b" at "/y""""), // space B becomes active
+          step(W, """a "GET" "/y" is sent through the space"""),
+          step(T, "the space received 1 requests") // B has 1, NOT 3 -> space-local
+        )
+      ).map(r => assertTrue(r.isPassed))
+    },
+    test("the recorded-count assertion fails when the active space's count differs (negative)") {
+      run(
+        List(
+          step(G, """a mock space returning 200 "pong" at "/ping""""),
+          step(W, """a "GET" "/ping" is sent through the space"""),
+          step(T, "the space received 5 requests") // actually 1
+        )
+      ).map(r => assertTrue(!r.isPassed, r.error.isDefined))
+    },
+    test("an overlay rule added to the active space is served") {
+      run(
+        List(
+          step(G, """a mock space returning 404 "" at "/over""""),
+          step(W, """the space overlays 200 "yes" at "/over""""),
+          step(W, """a "GET" "/over" is sent through the space"""),
+          step(T, "the space response status is 200"),
+          step(T, """the space response body contains "yes"""")
+        )
+      ).map(r => assertTrue(r.isPassed))
+    },
+    test("the exact-count assertion filters recorded requests by method (and covers non-GET sends)") {
+      run(
+        List(
+          step(G, """a mock space returning 200 "ok" at "/x""""),
+          step(W, """a "GET" "/x" is sent through the space"""),
+          step(W, """a "GET" "/x" is sent through the space"""),
+          step(W, """a "POST" "/x" is sent through the space"""),
+          step(T, """exactly 2 "GET" requests to "/x" were recorded"""), // POST excluded by the method filter
+          step(T, "the space received 3 requests")                       // but all 3 are recorded
+        )
+      ).map(r => assertTrue(r.isPassed))
+    },
+    test("a step used before deploying a space fails with a clear error") {
+      run(List(step(T, "the space received 0 requests")))
+        .map(r => assertTrue(!r.isPassed, r.error.isDefined))
+    },
+    test("asserting a response header that is absent fails") {
+      run(
+        List(
+          step(G, """a mock space returning 200 "ok" at "/h""""),
+          step(W, """a "GET" "/h" is sent through the space"""),
+          step(T, """the space response header "x-absent" is "nope"""")
+        )
+      ).map(r => assertTrue(!r.isPassed, r.error.isDefined))
+    },
+    test("a send to an unstubbed path returns 404 through the space") {
+      run(
+        List(
+          step(G, """a mock space returning 200 "ok" at "/known""""),
+          step(W, """a "GET" "/unknown" is sent through the space"""),
+          step(T, "the space response status is 404")
+        )
+      ).map(r => assertTrue(r.isPassed))
+    }
+  )

--- a/core/src/test/scala/zio/bdd/mock/sut/SutInjectionSpec.scala
+++ b/core/src/test/scala/zio/bdd/mock/sut/SutInjectionSpec.scala
@@ -1,0 +1,104 @@
+package zio.bdd.mock.sut
+
+import zio.*
+import zio.bdd.core.step.ZIOSteps
+import zio.bdd.gherkin.*
+import zio.bdd.mock.*
+import zio.schema.{DeriveSchema, Schema}
+import zio.test.*
+
+import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
+import java.net.InetSocketAddress
+import java.util.concurrent.{ConcurrentHashMap, CopyOnWriteArrayList}
+import scala.jdk.CollectionConverters.*
+
+/**
+ * Integration proof of #117 AC1: a suite whose SUT reads its dependency URL
+ * from a per-scenario layer (`SutClient`, injected via `scenarioLayer`) runs
+ * under feature×scenario parallelism with no cross-talk — each scenario's
+ * dependency call lands in its own space.
+ */
+object SutInjectionSpec extends ZIOSpecDefault:
+
+  final case class TestState()
+  object TestState:
+    given Schema[TestState] = DeriveSchema.gen[TestState]
+
+  // A shared in-process dependency that records each request under its first path
+  // segment (the PerInstance space id baked into `space.baseUri`).
+  private final class TestDependency(port: Int, recordings: ConcurrentHashMap[String, CopyOnWriteArrayList[String]]):
+    def perInstanceSpace(id: String): MockSpace = MockSpace(s"http://localhost:$port/$id", identity, SpaceId(id))
+    def received(id: String): UIO[List[String]] =
+      ZIO.succeed(Option(recordings.get(id)).map(_.asScala.toList).getOrElse(Nil))
+    def recordedKeys: UIO[Set[String]] = ZIO.succeed(recordings.keySet.asScala.toSet)
+
+  private val dependency: ZIO[Scope, Throwable, TestDependency] =
+    ZIO
+      .acquireRelease(
+        ZIO.attempt {
+          val recordings = new ConcurrentHashMap[String, CopyOnWriteArrayList[String]]()
+          val server     = HttpServer.create(new InetSocketAddress("localhost", 0), 0)
+          server.createContext(
+            "/",
+            new HttpHandler:
+              def handle(exchange: HttpExchange): Unit =
+                val seg  = exchange.getRequestURI.getPath.stripPrefix("/").split("/", 2)
+                val key  = seg(0)
+                val path = "/" + (if seg.length > 1 then seg(1) else "")
+                recordings.computeIfAbsent(key, _ => new CopyOnWriteArrayList[String]()).add(path)
+                exchange.sendResponseHeaders(200, -1)
+                exchange.close()
+          )
+          server.start()
+          (server, new TestDependency(server.getAddress.getPort, recordings))
+        }
+      )(acquired => ZIO.attempt(acquired._1.stop(0)).orDie)
+      .map(_._2)
+
+  // The SUT's dependency client is provided per scenario, bound to a space named
+  // after the scenario — never a shared/global value.
+  private class SutSuite(dep: TestDependency) extends ZIOSteps[SutClient, TestState]:
+    override def scenarioLayer(meta: ScenarioMetadata): ZLayer[Any, Throwable, SutClient] =
+      SutClient.layer(dep.perInstanceSpace(meta.name))
+
+    When("the SUT calls its dependency at " / string) { (path: String) =>
+      ZIO.serviceWithZIO[SutClient](_.send(Method.Get, path)).unit
+    }
+
+  private def scenario(name: String, feature: String) =
+    Scenario(
+      name,
+      Nil,
+      List(Step(StepType.WhenStep, """the SUT calls its dependency at "/call"""", None, None, None)),
+      Some(s"$feature.feature"),
+      Some(1)
+    )
+
+  def spec = suite("SutInjection")(
+    test(
+      "a suite whose SUT reads its dep URL from the layer runs under feature×scenario parallelism with no cross-talk"
+    ) {
+      val featureSpecs = List(
+        "F1" -> List("F1-s1", "F1-s2", "F1-s3"),
+        "F2" -> List("F2-s1", "F2-s2", "F2-s3")
+      )
+      val allNames = featureSpecs.flatMap(_._2)
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          val suite    = new SutSuite(dep)
+          val features = featureSpecs.map((f, names) => Feature(f, Nil, names.map(scenario(_, f))))
+          for
+            results <- suite
+                         .run(features, featureParallelism = 2, scenarioParallelism = 3)
+                         .provideEnvironment(ZEnvironment[SutClient](SutClient.make(dep.perInstanceSpace("__outer__"))))
+            recs <- ZIO.foreach(allNames)(n => dep.received(n).map((n, _)))
+            keys <- dep.recordedKeys
+          yield assertTrue(
+            results.forall(_.isPassed),                // all scenarios passed under parallelism
+            recs.forall((_, r) => r == List("/call")), // each scenario's call landed in its OWN space, exactly once
+            keys == allNames.toSet                     // the server saw exactly these keys — no stray/foreign space
+          )
+        }
+      }
+    }
+  )

--- a/mock/src/main/scala/zio/bdd/mock/Capability.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Capability.scala
@@ -1,0 +1,55 @@
+package zio.bdd.mock
+
+/**
+ * Optional capabilities an adapter MAY implement beyond the total core port. An
+ * adapter advertises a capability via [[MockControl.capabilities]]; for each
+ * advertised capability its typed accessor returns an instance, and for each
+ * un-advertised one the accessor fails fast with [[Unsupported]].
+ */
+enum Capability:
+  case Faults, StatefulScenarios, StateInspection, Scripting, ProxyRecord, Templating
+
+/**
+ * How a backend keeps mock spaces isolated under parallel features/scenarios.
+ *   - PerInstance: a unique base URI per space (e.g. Rift's own port).
+ *   - Correlated: a shared base URI partitioned by a correlation header (e.g.
+ *     WireMock).
+ *
+ * Marker type only at this stage; the per-adapter behaviour lands with the
+ * isolation model in M2 (#123).
+ */
+enum Isolation:
+  case PerInstance, Correlated
+
+// Capability interfaces returned by the typed accessors on [[MockControl]].
+// Empty markers here — their operations are fleshed out in M3 (#128/#129/#132).
+
+/**
+ * Fault injection (latency, errors, connection resets). Capability:
+ * [[Capability.Faults]].
+ */
+trait Faults
+
+/**
+ * Single-state-token FSM per scenario. Capability:
+ * [[Capability.StatefulScenarios]].
+ */
+trait StatefulScenarios
+
+/**
+ * Arrange/assert scenario state without driving requests. Capability:
+ * [[Capability.StateInspection]].
+ */
+trait StateInspection
+
+/** Backend scripting hooks. Capability: [[Capability.Scripting]]. */
+trait Scripting
+
+/**
+ * Proxy/record passthrough to a real upstream. Capability:
+ * [[Capability.ProxyRecord]].
+ */
+trait ProxyRecord
+
+/** Response templating. Capability: [[Capability.Templating]]. */
+trait Templating

--- a/mock/src/main/scala/zio/bdd/mock/Dsl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Dsl.scala
@@ -1,0 +1,121 @@
+package zio.bdd.mock
+
+import zio.Duration
+
+/**
+ * Portable fluent builders over the canonical mock model (#112).
+ *
+ * The DSL is pure convenience: every builder returns one of the canonical value
+ * types from `model.scala` (or composes them), so DSL output is *structurally
+ * identical* to the same model written by hand. Nothing here is required — a
+ * suite can be authored entirely from raw `.json` sources via [[MockSource]]
+ * and still drive every mutation/assertion on [[MockControl]]. Whatever the DSL
+ * produces normalises through the one [[Provisioning]] path to the same wire
+ * contract an adapter consumes.
+ *
+ * Import the whole object to use it: `import zio.bdd.mock.dsl.*`.
+ */
+object dsl:
+
+  /**
+   * A refinement applied to a [[RequestMatch]] — the value `header(..)`,
+   * `query(..)`, `jsonPath(..)` and the body matchers produce. Kept opaque so
+   * it reads as a first-class clause in signatures while remaining a plain
+   * model transform under the hood.
+   */
+  opaque type MatchClause = RequestMatch => RequestMatch
+
+  // --- request entry points -------------------------------------------------
+
+  /** Match `method` against the exact `path`. */
+  def request(method: Method, path: String): RequestMatch =
+    RequestMatch(method = Some(method), path = PathMatch.Exact(path))
+
+  def get(path: String): RequestMatch     = request(Method.Get, path)
+  def post(path: String): RequestMatch    = request(Method.Post, path)
+  def put(path: String): RequestMatch     = request(Method.Put, path)
+  def delete(path: String): RequestMatch  = request(Method.Delete, path)
+  def patch(path: String): RequestMatch   = request(Method.Patch, path)
+  def head(path: String): RequestMatch    = request(Method.Head, path)
+  def options(path: String): RequestMatch = request(Method.Options, path)
+
+  /** Match any request — no method, no path constraint. */
+  val anyRequest: RequestMatch = RequestMatch()
+
+  // --- value-match clause builders ------------------------------------------
+
+  /** A header/query clause: `header("Authorization").matches("Bearer .*")`. */
+  final class ValueClause private[dsl] (attach: ValueMatch => MatchClause):
+    def equalTo(value: String): MatchClause  = attach(ValueMatch.Equals(value))
+    def contains(value: String): MatchClause = attach(ValueMatch.Contains(value))
+    def matches(regex: String): MatchClause  = attach(ValueMatch.Matches(regex))
+
+  def header(name: String): ValueClause =
+    ValueClause(m => rm => rm.copy(headers = rm.headers.updated(name, m)))
+
+  def query(name: String): ValueClause =
+    ValueClause(m => rm => rm.copy(query = rm.query.updated(name, m)))
+
+  /** A JSON-path body clause: `jsonPath("$.a").exists`. */
+  final class JsonPathClause private[dsl] (path: String):
+    def exists: MatchClause                 = body(BodyMatch.JsonPath(path, None))
+    def equalTo(value: String): MatchClause = body(BodyMatch.JsonPath(path, Some(value)))
+
+  def jsonPath(path: String): JsonPathClause = JsonPathClause(path)
+
+  def bodyEquals(value: String): MatchClause   = body(BodyMatch.Equals(value))
+  def bodyContains(value: String): MatchClause = body(BodyMatch.Contains(value))
+  def bodyMatches(regex: String): MatchClause  = body(BodyMatch.Matches(regex))
+  def xPath(path: String): MatchClause         = body(BodyMatch.XPath(path, None))
+
+  private def body(m: BodyMatch): MatchClause = rm => rm.copy(body = Some(m))
+
+  // --- request refinement ---------------------------------------------------
+
+  extension (rm: RequestMatch)
+    /** Refine the match by folding the clauses on, left to right. */
+    def where(clauses: MatchClause*): RequestMatch =
+      clauses.foldLeft(rm)((acc, c) => c(acc))
+
+    /** Replace the path matcher (use for regex/template matching). */
+    def withPath(m: PathMatch): RequestMatch = rm.copy(path = m)
+
+    /** Pair this match with a response to form a rule. */
+    def respondWith(response: ResponseDef): MockRule = MockRule(rm, response)
+
+  // --- response entry points + refinement -----------------------------------
+
+  /** A 200 OK response with an empty body. */
+  val ok: ResponseDef = ResponseDef(status = 200)
+
+  /** A response with the given status and an empty body. */
+  def status(code: Int): ResponseDef = ResponseDef(status = code)
+
+  extension (r: ResponseDef)
+    def json(value: String): ResponseDef   = r.copy(body = Body.Json(value))
+    def text(value: String): ResponseDef   = r.copy(body = Body.Text(value))
+    def base64(value: String): ResponseDef = r.copy(body = Body.Base64(value))
+    def withBody(b: Body): ResponseDef     = r.copy(body = b)
+    def withStatus(code: Int): ResponseDef = r.copy(status = code)
+    def withHeader(name: String, value: String): ResponseDef =
+      r.copy(headers = r.headers.updated(name, value))
+    def withLatency(d: Duration): ResponseDef = r.copy(delay = Some(d))
+
+  // --- rule + spec assembly -------------------------------------------------
+
+  extension (rule: MockRule) def withId(id: String): MockRule = rule.copy(id = Some(RuleId(id)))
+
+  /** Assemble rules into a spec. */
+  def mock(rules: MockRule*): MockSpec = MockSpec(rules.toList)
+
+  extension (spec: MockSpec)
+    /**
+     * Set the advisory port (always stripped on provision — see [[MockSpec]]).
+     */
+    def onPort(port: Int): MockSpec = spec.copy(port = Some(port))
+
+    /** Wrap this spec as a DSL [[MockSource]]. */
+    def source: MockSource = MockSource.Dsl(spec)
+
+  /** Build a DSL [[MockSource]] straight from rules. */
+  def dslSource(rules: MockRule*): MockSource = mock(rules*).source

--- a/mock/src/main/scala/zio/bdd/mock/MockControl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockControl.scala
@@ -3,17 +3,31 @@ package zio.bdd.mock
 import zio.{IO, ZIO}
 
 /**
- * Type-level tag for a concrete backend, used to pin a [[NativeSpec]] to one
- * provider. Concrete backends (Rift, WireMock) define their own marker; the
- * native escape hatch is fleshed out in #119.
+ * Phantom tag pinning a [[NativeSpec]] — and the test that uses it — to one
+ * concrete backend, so the escape hatch is honest about the portability it
+ * trades away. A `NativeSpec[Backend.Rift]` can only be provisioned by a Rift
+ * adapter; a backend that does not recognise the spec rejects it.
  */
-trait Backend
+sealed trait Backend
+object Backend:
+  sealed trait Rift     extends Backend
+  sealed trait WireMock extends Backend
 
 /**
  * A backend-specific provisioning payload — the escape hatch that trades
- * portability for full access to one backend. Fleshed out in #119.
+ * portability for full access to one backend (#119). A natively-provisioned
+ * [[MockSpace]] still participates in destroy/received/overlays/isolation
+ * exactly like a portable one; only its *definition* is backend-pinned.
+ *
+ * The WireMock Java-builder variant lands with the WireMock adapter (M2, #122):
+ * it needs that library's types, which the neutral SPI must not depend on.
  */
-trait NativeSpec[B <: Backend]
+enum NativeSpec[B <: Backend]:
+  /** A raw Rift/Mountebank imposter document; may carry `_rift` extensions. */
+  case Rift(imposterJson: String) extends NativeSpec[Backend.Rift]
+
+  /** A raw WireMock stub-mapping document. */
+  case WireMock(stubMappingJson: String) extends NativeSpec[Backend.WireMock]
 
 /**
  * The total core port every adapter MUST implement. This is the hinge of the

--- a/mock/src/main/scala/zio/bdd/mock/MockControl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockControl.scala
@@ -1,0 +1,74 @@
+package zio.bdd.mock
+
+import zio.IO
+
+/**
+ * Where mock definitions come from. A placeholder marker at this stage — the
+ * DSL builders and raw/file/resource/dir entry points land in #111. Everything
+ * normalises to the canonical model before it reaches [[MockControl]].
+ */
+trait MockSource
+
+/**
+ * Type-level tag for a concrete backend, used to pin a [[NativeSpec]] to one
+ * provider. Concrete backends (Rift, WireMock) define their own marker; the
+ * native escape hatch is fleshed out in #119.
+ */
+trait Backend
+
+/**
+ * A backend-specific provisioning payload — the escape hatch that trades
+ * portability for full access to one backend. Fleshed out in #119.
+ */
+trait NativeSpec[B <: Backend]
+
+/**
+ * The total core port every adapter MUST implement. This is the hinge of the
+ * portable mocking feature (#109): steps, fixtures, overlays and the
+ * conformance suite all program against this interface, never against a
+ * concrete backend.
+ *
+ * Errors are values: the core operations fail with the typed [[MockError]] and
+ * the capability accessors with the typed [[Unsupported]] — no `Throwable`
+ * leaks into these signatures.
+ */
+trait MockControl:
+
+  /** The optional capabilities this adapter advertises. */
+  def capabilities: Set[Capability]
+
+  /** Stand up one or more mock spaces from a portable source. */
+  def provision(source: MockSource): IO[MockError, List[MockSpace]]
+
+  /**
+   * Stand up mock spaces from a backend-specific native spec (escape hatch).
+   */
+  def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]]
+
+  /**
+   * Add a rule to a space, returning its id. Overlay rules sit above base
+   * rules.
+   */
+  def addRule(space: MockSpace, rule: MockRule, priority: Priority = Priority.Overlay): IO[MockError, RuleId]
+
+  /** Remove a single rule from a space. */
+  def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit]
+
+  /** Replace all rules of a space with the given set. */
+  def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit]
+
+  /** Tear down exactly this space — never a global reset. */
+  def destroy(space: MockSpace): IO[MockError, Unit]
+
+  /** The requests this space recorded, for assertions. */
+  def received(space: MockSpace): IO[MockError, List[RecordedRequest]]
+
+  // Typed capability accessors. Each returns an instance when the capability is
+  // advertised, or fails fast with `Unsupported` (naming the gap and backend).
+
+  def faults: IO[Unsupported, Faults]
+  def scenarios: IO[Unsupported, StatefulScenarios]
+  def stateInspection: IO[Unsupported, StateInspection]
+  def scripting: IO[Unsupported, Scripting]
+  def proxyRecord: IO[Unsupported, ProxyRecord]
+  def templating: IO[Unsupported, Templating]

--- a/mock/src/main/scala/zio/bdd/mock/MockControl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockControl.scala
@@ -3,13 +3,6 @@ package zio.bdd.mock
 import zio.IO
 
 /**
- * Where mock definitions come from. A placeholder marker at this stage — the
- * DSL builders and raw/file/resource/dir entry points land in #111. Everything
- * normalises to the canonical model before it reaches [[MockControl]].
- */
-trait MockSource
-
-/**
  * Type-level tag for a concrete backend, used to pin a [[NativeSpec]] to one
  * provider. Concrete backends (Rift, WireMock) define their own marker; the
  * native escape hatch is fleshed out in #119.

--- a/mock/src/main/scala/zio/bdd/mock/MockControl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockControl.scala
@@ -1,6 +1,6 @@
 package zio.bdd.mock
 
-import zio.IO
+import zio.{IO, ZIO}
 
 /**
  * Type-level tag for a concrete backend, used to pin a [[NativeSpec]] to one
@@ -27,8 +27,30 @@ trait NativeSpec[B <: Backend]
  */
 trait MockControl:
 
+  /**
+   * Stable, human-readable name of the backing provider (e.g. "rift",
+   * "wiremock"). Named in every [[Unsupported]] this adapter raises so a
+   * capability gap points at the backend that has it.
+   */
+  def backendName: String
+
   /** The optional capabilities this adapter advertises. */
   def capabilities: Set[Capability]
+
+  /**
+   * Fail-fast capability negotiation: declare what a suite needs up front.
+   * Succeeds when every required capability is advertised; otherwise fails with
+   * the first missing one (in argument order), naming it and the backend.
+   *
+   * Run this at wiring time — e.g. `ZLayer.fromZIO(control.require(Faults) *>
+   * ...)` — so a backend that lacks a needed capability is rejected at layer
+   * construction, never mid-scenario. The accessors stay the only per-call
+   * gate; `require` just moves the same failure earlier.
+   */
+  final def require(required: Capability*): IO[Unsupported, Unit] =
+    required.find(c => !capabilities.contains(c)) match
+      case Some(missing) => ZIO.fail(Unsupported(missing, backendName))
+      case None          => ZIO.unit
 
   /** Stand up one or more mock spaces from a portable source. */
   def provision(source: MockSource): IO[MockError, List[MockSpace]]

--- a/mock/src/main/scala/zio/bdd/mock/MockError.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockError.scala
@@ -1,0 +1,23 @@
+package zio.bdd.mock
+
+/**
+ * Typed failures of the MockControl core port. Deliberately *not* a `Throwable`
+ * subtype: the port keeps `Throwable` out of its public signatures, surfacing
+ * backend failures as values an adapter normalises a cause into (as text).
+ */
+enum MockError:
+  case ProvisionFailed(reason: String)
+  case SpaceNotFound(space: SpaceId)
+  case RuleNotFound(space: SpaceId, rule: RuleId)
+  case InvalidDefinition(reason: String)
+  case CommunicationError(reason: String)
+
+/**
+ * Typed failure of a capability accessor when the backend does not advertise
+ * the capability. Names both the gap and the backend. Not a `Throwable`: the
+ * capability accessors expose it as the narrow error channel `IO[Unsupported,
+ * _]`.
+ */
+final case class Unsupported(capability: Capability, backend: String):
+  def message: String =
+    s"Capability $capability is not supported by backend '$backend'"

--- a/mock/src/main/scala/zio/bdd/mock/MockOverlay.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockOverlay.scala
@@ -1,0 +1,50 @@
+package zio.bdd.mock
+
+import zio.*
+
+/**
+ * Overlay and mutation helpers over the [[MockControl]] core port (#116).
+ *
+ *   - [[scoped]] — a revertible overlay: each rule is added at
+ *     [[Priority.Overlay]] (highest priority, shadowing the base rules) on
+ *     acquire and removed on release, so an overlay applied in a hook or `When`
+ *     step reverts exactly when the scope closes.
+ *   - [[remove]] / [[replaceAll]] — targeted and wholesale mutation for steps
+ *     that change a live space ("now everything times out").
+ *
+ * Rule identity is the adapter's responsibility: an adapter that addresses
+ * stubs positionally (Rift, until EtaCassiopeia/rift#202) maps the [[RuleId]]
+ * to a live index; these helpers only thread the ids that `addRule` returned
+ * back to `removeRule`.
+ */
+object MockOverlay:
+
+  /**
+   * Apply `rules` as a scoped overlay. Each rule registers its own finalizer,
+   * so a failure partway through still removes the rules already added; the
+   * scope removes ONLY the rules it added. A teardown failure is logged and
+   * skipped so one bad removal can't strand its siblings.
+   */
+  def scoped(space: MockSpace)(rules: MockRule*): ZIO[MockControl & Scope, MockError, List[RuleId]] =
+    ZIO.serviceWithZIO[MockControl] { control =>
+      ZIO.foreach(rules.toList) { rule =>
+        ZIO.acquireRelease(control.addRule(space, rule, Priority.Overlay))(id =>
+          control
+            .removeRule(space, id)
+            .catchAllCause(cause =>
+              ZIO.logWarningCause(s"overlay teardown failed for rule ${id.value} on space ${space.id.value}", cause)
+            )
+        )
+      }
+    }
+
+  /** Targeted mutation: remove a single rule by its [[RuleId]]. */
+  def remove(space: MockSpace, id: RuleId): ZIO[MockControl, MockError, Unit] =
+    ZIO.serviceWithZIO[MockControl](_.removeRule(space, id))
+
+  /**
+   * Wholesale mutation: replace every rule in `space` (e.g. a `When` step that
+   * makes everything time out).
+   */
+  def replaceAll(space: MockSpace, rules: MockRule*): ZIO[MockControl, MockError, Unit] =
+    ZIO.serviceWithZIO[MockControl](_.replaceRules(space, rules.toList))

--- a/mock/src/main/scala/zio/bdd/mock/MockSource.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockSource.scala
@@ -1,0 +1,33 @@
+package zio.bdd.mock
+
+/**
+ * A minimal, portable spec a [[MockSource.Dsl]] carries: canonical rules plus
+ * an *advisory* port. The fluent builders that produce a `MockSpec` land in
+ * #112 — here it is just the neutral payload the DSL source wraps.
+ *
+ * `port` is advisory only: [[Provisioning]] always strips it and auto-assigns a
+ * fresh free port (see the fixed-port trap in #111). It is retained on the
+ * normalized form purely for diagnostics.
+ */
+final case class MockSpec(rules: List[MockRule], port: Option[Int] = None)
+
+/**
+ * Where mock definitions come from. Every case normalizes through the single
+ * [[Provisioning]] path to one [[NormalizedSource]] per space before reaching
+ * an adapter, so adapters never re-implement loading, memoization or auto-port.
+ *
+ *   - `Dsl` : already-canonical rules built in-code.
+ *   - `Json` : a raw backend wire document, inline.
+ *   - `Resource` : a classpath resource holding a raw wire document.
+ *   - `File` : a filesystem file holding a raw wire document.
+ *   - `Dir` : a filesystem directory; each regular file becomes one space.
+ *
+ * The raw cases stay un-parsed here: each adapter parses its own wire format
+ * (#113 Rift, #122 WireMock). This module owns only the neutral plumbing.
+ */
+enum MockSource:
+  case Dsl(spec: MockSpec)
+  case Json(raw: String)
+  case Resource(path: String)
+  case File(path: String)
+  case Dir(path: String)

--- a/mock/src/main/scala/zio/bdd/mock/Provisioning.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Provisioning.scala
@@ -1,0 +1,184 @@
+package zio.bdd.mock
+
+import zio.*
+
+import java.net.ServerSocket
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+
+/**
+ * The neutral, normalized form of a single mock space — the "wire config" every
+ * [[MockSource]] reduces to before an adapter consumes it.
+ *
+ *   - `name` : the space label (the file name for a [[MockSource.Dir]];
+ *     "dsl"/"json"/the resource or file base name otherwise).
+ *   - `payload` : canonical rules (from the DSL) or raw backend wire text (from
+ *     json/resource/file) the adapter parses itself.
+ *   - `authoredPort`: the advisory port the author requested, if any. Always
+ *     stripped on provision — kept only for diagnostics.
+ */
+final case class NormalizedSource(name: String, payload: SourcePayload, authoredPort: Option[Int])
+
+/** The two shapes a normalized source can take. */
+enum SourcePayload:
+  case Rules(rules: List[MockRule])
+  case Raw(text: String)
+
+private object MockIO:
+  /**
+   * Turn a JVM exception into a typed [[MockError.ProvisionFailed]] without
+   * losing the path/exception class, and without rendering a null message as
+   * the literal "null". `CommunicationError` is reserved for backend comms, so
+   * a source-read failure is *not* one.
+   */
+  def failed(action: String, e: Throwable): MockError =
+    val msg = Option(e.getMessage).getOrElse("<no message>")
+    MockError.ProvisionFailed(s"$action failed: ${e.getClass.getSimpleName}: $msg")
+
+/**
+ * Hands out localhost ports that are free at the moment of issue and distinct
+ * across the allocator's lifetime — the antidote to the fixed-port trap: an
+ * authored port is never honored, every space gets its own auto-assigned port.
+ *
+ * Allocation probes the OS (`ServerSocket(0)`) and closes the probe, so there
+ * is an inherent TOCTOU window before the caller binds the port; distinctness
+ * within the allocator removes the *self*-collision (provisioning the same
+ * fixed-port source twice), which is the trap this issue targets.
+ */
+trait PortAllocator:
+  def freePort: IO[MockError, Int]
+
+final case class PortAllocatorLive(issued: Ref[Set[Int]]) extends PortAllocator:
+  // Bound the dedup retry so a constrained ephemeral range surfaces as a typed
+  // failure instead of livelocking on probe→close→same-port forever.
+  private val maxAttempts = 100
+
+  private val probe: IO[MockError, Int] =
+    ZIO
+      .scoped(ZIO.fromAutoCloseable(ZIO.attempt(ServerSocket(0))).map(_.getLocalPort))
+      .mapError(MockIO.failed("allocating a free port", _))
+
+  def freePort: IO[MockError, Int] =
+    def go(attempt: Int): IO[MockError, Int] =
+      if attempt >= maxAttempts then
+        ZIO.fail(MockError.ProvisionFailed(s"could not obtain a distinct free port after $maxAttempts attempts"))
+      else
+        probe.flatMap { p =>
+          issued
+            .modify(s => if s(p) then (false, s) else (true, s + p))
+            .flatMap(added => if added then ZIO.succeed(p) else go(attempt + 1))
+        }
+    go(0)
+
+object PortAllocator:
+  val make: UIO[PortAllocator]     = Ref.make(Set.empty[Int]).map(PortAllocatorLive(_))
+  val layer: ULayer[PortAllocator] = ZLayer(make)
+
+/**
+ * The single provisioning entry point (#111). Normalizes any [[MockSource]] to
+ * one [[NormalizedSource]] per space — memoizing the parsed form so repeated
+ * provisioning of the same source is cheap — then for each space strips the
+ * authored port, auto-assigns a free one, asks the adapter to serve the
+ * payload, and assembles the resolved [[MockSpace]] whose `baseUri` reflects
+ * the auto-assigned port.
+ */
+final case class Provisioning(allocator: PortAllocator, cache: Ref[Map[MockSource, List[NormalizedSource]]]):
+
+  /** Resolve a source to one normalized form per space; memoized by source. */
+  def normalize(source: MockSource): IO[MockError, List[NormalizedSource]] =
+    cache.get.flatMap(_.get(source) match
+      case Some(cached) => ZIO.succeed(cached)
+      case None         => load(source).tap(ns => cache.update(_.updated(source, ns)))
+    )
+
+  /**
+   * Stand up one space per normalized source. `serve` is the adapter seam: it
+   * receives the normalized payload and the resolved [[MockSpace]] (whose
+   * `baseUri` already carries the auto-assigned port) and binds the backend.
+   */
+  def provision[E >: MockError](
+    source: MockSource
+  )(serve: (NormalizedSource, MockSpace) => IO[E, Unit]): IO[E, List[MockSpace]] =
+    normalize(source).flatMap { sources =>
+      ZIO.foreach(sources) { src =>
+        for
+          port <- allocator.freePort
+          space = MockSpace(s"http://localhost:$port", identity, SpaceId(s"${src.name}-$port"))
+          _    <- serve(src, space)
+        yield space
+      }
+    }
+
+  private def load(source: MockSource): IO[MockError, List[NormalizedSource]] =
+    source match
+      case MockSource.Dsl(spec) =>
+        ZIO.succeed(List(NormalizedSource("dsl", SourcePayload.Rules(spec.rules), spec.port)))
+      case MockSource.Json(raw) =>
+        ZIO.succeed(List(NormalizedSource("json", SourcePayload.Raw(raw), None)))
+      case MockSource.Resource(path) =>
+        readResource(path).map(t => List(NormalizedSource(baseName(path), SourcePayload.Raw(t), None)))
+      case MockSource.File(path) =>
+        readFile(path).map(t => List(NormalizedSource(baseName(path), SourcePayload.Raw(t), None)))
+      case MockSource.Dir(path) =>
+        readDir(path)
+
+  private def readResource(path: String): IO[MockError, String] =
+    val normalized = path.stripPrefix("/")
+    // Acquire the (possibly null) stream uninterruptibly and always close it, so
+    // an interrupt or read failure can never leak the handle.
+    ZIO.acquireReleaseWith(
+      ZIO
+        .attemptBlocking(Option(getClass.getClassLoader.getResourceAsStream(normalized)))
+        .mapError(MockIO.failed(s"opening resource $path", _))
+    )(opt => ZIO.foreachDiscard(opt)(s => ZIO.attempt(s.close()).ignore)) {
+      case None => ZIO.fail(MockError.InvalidDefinition(s"resource not found: $path"))
+      case Some(stream) =>
+        ZIO
+          .attemptBlocking(String(stream.readAllBytes(), StandardCharsets.UTF_8))
+          .mapError(MockIO.failed(s"reading resource $path", _))
+    }
+
+  private def readFile(path: String): IO[MockError, String] =
+    val p = Paths.get(path)
+    ZIO
+      .attemptBlocking(Files.isRegularFile(p))
+      .mapError(MockIO.failed(s"stat-ing file $path", _))
+      .flatMap { isFile =>
+        if !isFile then ZIO.fail(MockError.InvalidDefinition(s"file not found: $path"))
+        else
+          ZIO
+            .attemptBlocking(Files.readString(p, StandardCharsets.UTF_8))
+            .mapError(MockIO.failed(s"reading file $path", _))
+      }
+
+  private def readDir(path: String): IO[MockError, List[NormalizedSource]] =
+    val dir = Paths.get(path)
+    for
+      isDir <- ZIO
+                 .attemptBlocking(Files.isDirectory(dir))
+                 .mapError(MockIO.failed(s"stat-ing directory $path", _))
+      _ <- ZIO.unless(isDir)(ZIO.fail(MockError.InvalidDefinition(s"not a directory: $path")))
+      files <- ZIO.attemptBlocking {
+                 import scala.jdk.CollectionConverters.*
+                 val stream = Files.list(dir)
+                 try stream.iterator().asScala.filter(Files.isRegularFile(_)).toList.sortBy(_.getFileName.toString)
+                 finally stream.close()
+               }
+                 .mapError(MockIO.failed(s"listing directory $path", _))
+      out <- ZIO.foreach(files) { f =>
+               readFile(f.toString).map(t => NormalizedSource(f.getFileName.toString, SourcePayload.Raw(t), None))
+             }
+    yield out
+
+  private def baseName(path: String): String =
+    Option(Paths.get(path).getFileName).map(_.toString).getOrElse(path)
+
+object Provisioning:
+  private def from(allocator: PortAllocator): UIO[Provisioning] =
+    Ref.make(Map.empty[MockSource, List[NormalizedSource]]).map(Provisioning(allocator, _))
+
+  val make: UIO[Provisioning] = PortAllocator.make.flatMap(from)
+
+  val layer: URLayer[PortAllocator, Provisioning] = ZLayer(ZIO.serviceWithZIO[PortAllocator](from))
+
+  val live: ULayer[Provisioning] = PortAllocator.layer >>> layer

--- a/mock/src/main/scala/zio/bdd/mock/SutClient.scala
+++ b/mock/src/main/scala/zio/bdd/mock/SutClient.scala
@@ -1,0 +1,71 @@
+package zio.bdd.mock
+
+import zio.*
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest as JHttpRequest, HttpResponse as JHttpResponse}
+import scala.jdk.CollectionConverters.*
+
+/** A response the SUT received from its (mocked) dependency. */
+final case class SutResponse(status: Int, body: String, headers: Map[String, String])
+
+/**
+ * The SUT's dependency client, bound to one [[MockSpace]]. It derives the
+ * dependency base URL from `space.baseUri` and applies `space.inject` to every
+ * request, so the share-nothing isolation decoration (e.g. a Correlated
+ * backend's correlation header) rides along.
+ *
+ * Provide it per scenario via [[SutClient.layer]] — never a process-wide env
+ * var — so parallel scenarios each target their own space with no cross-talk.
+ */
+trait SutClient:
+  /**
+   * The base URL the SUT should treat as its dependency endpoint
+   * (`space.baseUri`).
+   */
+  def baseUrl: String
+
+  /**
+   * Issue a request to the bound space: `path` is resolved against [[baseUrl]]
+   * and the space's `inject` is applied before sending.
+   */
+  def send(
+    method: Method,
+    path: String,
+    headers: Map[String, String] = Map.empty,
+    body: Option[String] = None
+  ): IO[Throwable, SutResponse]
+
+object SutClient:
+  def make(space: MockSpace): SutClient = Live(space)
+
+  /** Per-scenario layer: bind the SUT's dependency client to `space`. */
+  def layer(space: MockSpace): ULayer[SutClient] = ZLayer.succeed(make(space))
+
+  private final case class Live(space: MockSpace) extends SutClient:
+    def baseUrl: String = space.baseUri
+
+    def send(
+      method: Method,
+      path: String,
+      headers: Map[String, String],
+      body: Option[String]
+    ): IO[Throwable, SutResponse] =
+      val injected = space.inject(HttpRequest(method, space.baseUri + path, headers, body))
+      ZIO.attemptBlocking {
+        val builder = injected.headers.foldLeft(JHttpRequest.newBuilder(URI.create(injected.uri))) { case (b, (k, v)) =>
+          b.header(k, v)
+        }
+        val publisher = injected.body match
+          case Some(content) => JHttpRequest.BodyPublishers.ofString(content)
+          case None          => JHttpRequest.BodyPublishers.noBody()
+        val request  = builder.method(injected.method.toString.toUpperCase, publisher).build()
+        val response = HttpClient.newHttpClient().send(request, JHttpResponse.BodyHandlers.ofString())
+        val respHeaders = response
+          .headers()
+          .map()
+          .asScala
+          .collect { case (k, vs) if !vs.isEmpty => k.toLowerCase -> vs.asScala.mkString(", ") }
+          .toMap
+        SutResponse(response.statusCode, response.body, respHeaders)
+      }

--- a/mock/src/main/scala/zio/bdd/mock/model.scala
+++ b/mock/src/main/scala/zio/bdd/mock/model.scala
@@ -1,0 +1,124 @@
+package zio.bdd.mock
+
+import zio.Duration
+
+/**
+ * Backend-neutral canonical model for the portable MockControl SPI (#110).
+ *
+ * Every adapter (Rift, WireMock, …) normalises its own wire format to these
+ * types, so Gherkin steps, hooks, overlays and assertions stay backend-neutral.
+ * All types here are immutable value types — case classes and enums.
+ */
+
+/** HTTP method a rule matches or a recorded request used. */
+enum Method:
+  case Get, Post, Put, Delete, Patch, Head, Options, Trace, Connect
+
+/** How a request path is matched. The default is [[PathMatch.Any]]. */
+enum PathMatch:
+  case Any
+  case Exact(path: String)
+  case Regex(pattern: String)
+  case Template(template: String) // e.g. "/users/{id}"
+
+/** How a single scalar value (query param or header) is matched. */
+enum ValueMatch:
+  case Equals(value: String)
+  case Contains(value: String)
+  case Matches(regex: String)
+
+/** How a request body is matched. */
+enum BodyMatch:
+  case Equals(value: String)
+  case Contains(value: String)
+  case Matches(regex: String)
+  case JsonPath(path: String, expected: Option[String] = None)
+  case XPath(path: String, expected: Option[String] = None)
+
+/**
+ * A response body payload. Covers Text | Json | Base64 (plus the empty body).
+ */
+enum Body:
+  case Empty
+  case Text(value: String)
+  case Json(value: String)
+  case Base64(value: String)
+
+/** Ordering bucket for a rule: overlay rules sit above base rules. */
+enum Priority:
+  case Base, Overlay
+
+/** Opaque identifier for a rule within a [[MockSpace]]. */
+opaque type RuleId = String
+object RuleId:
+  def apply(value: String): RuleId         = value
+  extension (id: RuleId) def value: String = id
+
+/** Opaque identifier for a [[MockSpace]] (the unit of isolation). */
+opaque type SpaceId = String
+object SpaceId:
+  def apply(value: String): SpaceId         = value
+  extension (id: SpaceId) def value: String = id
+
+/**
+ * Portable HTTP request the SUT issues. [[MockSpace.inject]] decorates it (e.g.
+ * rewriting the base URI or adding a correlation header) so a mock space can be
+ * reached under share-nothing isolation. SUT-side wiring lands in #117.
+ */
+final case class HttpRequest(
+  method: Method,
+  uri: String,
+  headers: Map[String, String] = Map.empty,
+  body: Option[String] = None
+)
+
+/**
+ * A request the backend recorded, used to assert what the SUT actually sent.
+ */
+final case class RecordedRequest(
+  method: Method,
+  uri: String,
+  headers: Map[String, String] = Map.empty,
+  body: Option[String] = None
+)
+
+/**
+ * What to match on an incoming request. Every field is optional/permissive by
+ * default.
+ */
+final case class RequestMatch(
+  method: Option[Method] = None,
+  path: PathMatch = PathMatch.Any,
+  query: Map[String, ValueMatch] = Map.empty,
+  headers: Map[String, ValueMatch] = Map.empty,
+  body: Option[BodyMatch] = None
+)
+
+/** The response a matched rule serves. */
+final case class ResponseDef(
+  status: Int = 200,
+  headers: Map[String, String] = Map.empty,
+  body: Body = Body.Empty,
+  delay: Option[Duration] = None
+)
+
+/** A single stub: when a request matches, respond accordingly. */
+final case class MockRule(
+  `match`: RequestMatch,
+  respond: ResponseDef,
+  id: Option[RuleId] = None
+)
+
+/**
+ * The unit of isolation. Hides *how* isolation is achieved:
+ *   - PerInstance: a unique `baseUri` per space; `inject = identity`.
+ *   - Correlated: a shared `baseUri`; `inject` stamps a correlation header.
+ *
+ * The SUT must target `baseUri` AND apply `inject` so the correlation rides
+ * along. Isolation invariants and SUT wiring land in #117.
+ */
+final case class MockSpace(
+  baseUri: String,
+  inject: HttpRequest => HttpRequest,
+  id: SpaceId
+)

--- a/mock/src/test/resources/mocks/ping.json
+++ b/mock/src/test/resources/mocks/ping.json
@@ -1,0 +1,1 @@
+{ "rules": [ { "path": "/ping", "status": 200, "body": "pong" } ] }

--- a/mock/src/test/scala/zio/bdd/mock/CapabilityNegotiationSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/CapabilityNegotiationSpec.scala
@@ -1,0 +1,120 @@
+package zio.bdd.mock
+
+import zio.*
+import zio.test.*
+
+object CapabilityNegotiationSpec extends ZIOSpecDefault:
+
+  // A minimal adapter that advertises exactly `caps` and is honest about them:
+  // each accessor returns an instance iff its capability is advertised. Used to
+  // exercise `require` negotiation without standing up a real backend.
+  private final case class StubMockControl(backendName: String, caps: Set[Capability]) extends MockControl:
+    def capabilities: Set[Capability] = caps
+
+    def provision(source: MockSource): IO[MockError, List[MockSpace]]                      = ZIO.succeed(Nil)
+    def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] = ZIO.succeed(Nil)
+    def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+      ZIO.succeed(RuleId("r1"))
+    def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit]              = ZIO.unit
+    def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit] = ZIO.unit
+    def destroy(space: MockSpace): IO[MockError, Unit]                             = ZIO.unit
+    def received(space: MockSpace): IO[MockError, List[RecordedRequest]]           = ZIO.succeed(Nil)
+
+    private def cap[A](c: Capability)(a: => A): IO[Unsupported, A] =
+      if caps(c) then ZIO.succeed(a) else ZIO.fail(Unsupported(c, backendName))
+
+    def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(new Faults {})
+    def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(new StatefulScenarios {})
+    def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(new StateInspection {})
+    def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(new Scripting {})
+    def proxyRecord: IO[Unsupported, ProxyRecord]         = cap(Capability.ProxyRecord)(new ProxyRecord {})
+    def templating: IO[Unsupported, Templating]           = cap(Capability.Templating)(new Templating {})
+
+  def spec = suite("capability fail-fast negotiation")(
+    test("require fails at layer construction, before first use") {
+      // AC1: declaring a needed capability against a backend lacking it must be
+      // rejected when the layer is built — the program that *uses* the mock must
+      // never run. Two independent proofs: (a) building the layer in isolation
+      // already fails, and (b) the `used` Ref stays false, so construction
+      // failed before first use (not at the accessor).
+      val backend = StubMockControl("rift", Set.empty)
+      val layer   = ZLayer.fromZIO(backend.require(Capability.Faults).as[MockControl](backend))
+      for
+        used      <- Ref.make(false)
+        buildExit <- ZIO.scoped(layer.build).exit
+        program: ZIO[MockControl, Unsupported, Unit] =
+          used.set(true) *> ZIO.serviceWithZIO[MockControl](_.faults).unit
+        exit    <- program.provideLayer(layer).exit
+        wasUsed <- used.get
+      yield assertTrue(
+        buildExit.causeOption.flatMap(_.failureOption).contains(Unsupported(Capability.Faults, "rift")),
+        exit.isFailure,
+        exit.causeOption.flatMap(_.failureOption).contains(Unsupported(Capability.Faults, "rift")),
+        !wasUsed
+      )
+    },
+    test("require succeeds at layer construction so the wired capability is usable") {
+      // AC1 positive path: when the capability IS advertised, the same wiring
+      // pattern builds the layer, runs the program, and yields a real instance.
+      val backend = StubMockControl("rift", Set(Capability.Faults))
+      val layer   = ZLayer.fromZIO(backend.require(Capability.Faults).as[MockControl](backend))
+      for
+        used <- Ref.make(false)
+        program: ZIO[MockControl, Unsupported, Faults] =
+          used.set(true) *> ZIO.serviceWithZIO[MockControl](_.faults)
+        exit    <- program.provideLayer(layer).exit
+        wasUsed <- used.get
+      yield assertTrue(exit.isSuccess, wasUsed)
+    },
+    test("require names the backend and the missing capability") {
+      // Scope: the failure message must name both the backend and the gap.
+      val backend = StubMockControl("wiremock", Set(Capability.Templating))
+      for either <- backend.require(Capability.Faults).either
+      yield
+        val msg = either.swap.toOption.map(_.message).getOrElse("")
+        assertTrue(
+          either == Left(Unsupported(Capability.Faults, "wiremock")),
+          msg.contains("wiremock"),
+          msg.contains("Faults")
+        )
+    },
+    test("require is fail-fast on the first missing capability and passes when satisfied") {
+      // Deterministic: fails with the first missing capability in argument order;
+      // succeeds when every required capability is advertised (including empty).
+      val partial = StubMockControl("stub", Set(Capability.Faults))
+      val full    = StubMockControl("stub", Capability.values.toSet)
+      for
+        firstMissing <- partial.require(Capability.Faults, Capability.Scripting, Capability.Templating).either
+        allPresent   <- full.require(Capability.values*).either
+        noneRequired <- partial.require().either
+      yield assertTrue(
+        firstMissing == Left(Unsupported(Capability.Scripting, "stub")),
+        allPresent == Right(()),
+        noneRequired == Right(())
+      )
+    },
+    test("advertised accessors and require both succeed for every capability") {
+      // AC2: for an advertised capability the accessor never returns Unsupported,
+      // and require for that capability succeeds — the two sides of the honesty
+      // contract agree. This stub is honest by construction; the real check for a
+      // *dishonest* adapter (advertises a capability but its accessor still fails)
+      // belongs to the cross-adapter conformance suite (M2, #122).
+      val all: MockControl = StubMockControl("stub", Capability.values.toSet)
+      val accessors: List[(Capability, MockControl => IO[Unsupported, Any])] = List(
+        Capability.Faults            -> (_.faults),
+        Capability.StatefulScenarios -> (_.scenarios),
+        Capability.StateInspection   -> (_.stateInspection),
+        Capability.Scripting         -> (_.scripting),
+        Capability.ProxyRecord       -> (_.proxyRecord),
+        Capability.Templating        -> (_.templating)
+      )
+      ZIO
+        .foreach(accessors) { (cap, access) =>
+          for
+            accessed <- access(all).either
+            required <- all.require(cap).either
+          yield assertTrue(accessed.isRight, required == Right(()))
+        }
+        .map(_.reduce(_ && _))
+    }
+  )

--- a/mock/src/test/scala/zio/bdd/mock/DslSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/DslSpec.scala
@@ -1,0 +1,187 @@
+package zio.bdd.mock
+
+import zio.*
+import zio.bdd.mock.dsl.*
+import zio.test.*
+
+/**
+ * AC2 gate: the DSL is a pure convenience over the canonical model. Every
+ * builder expression must equal the hand-written case class it stands for, and
+ * a full DSL spec must normalise through the real [[Provisioning]] path to
+ * exactly the canonical rules — i.e. DSL output IS the wire contract an adapter
+ * consumes. (Adapter-level "identical JSON behaviour" is verified by the
+ * conformance suite in #113/#122; no adapter parses JSON in this module.)
+ */
+object DslSpec extends ZIOSpecDefault:
+
+  def spec = suite("mock DSL builders")(
+    suite("request matchers equal the canonical RequestMatch")(
+      test("get/post/... set method + exact path") {
+        assertTrue(
+          get("/x") == RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/x")),
+          post("/x") == RequestMatch(method = Some(Method.Post), path = PathMatch.Exact("/x")),
+          put("/x") == RequestMatch(method = Some(Method.Put), path = PathMatch.Exact("/x")),
+          delete("/x") == RequestMatch(method = Some(Method.Delete), path = PathMatch.Exact("/x")),
+          patch("/x") == RequestMatch(method = Some(Method.Patch), path = PathMatch.Exact("/x")),
+          head("/x") == RequestMatch(method = Some(Method.Head), path = PathMatch.Exact("/x")),
+          options("/x") == RequestMatch(method = Some(Method.Options), path = PathMatch.Exact("/x")),
+          anyRequest == RequestMatch()
+        )
+      },
+      test("withPath replaces the path matcher with regex/template") {
+        assertTrue(
+          get("/ignored").withPath(PathMatch.Template("/users/{id}")) ==
+            RequestMatch(method = Some(Method.Get), path = PathMatch.Template("/users/{id}")),
+          get("/ignored").withPath(PathMatch.Regex("/u/.*")) ==
+            RequestMatch(method = Some(Method.Get), path = PathMatch.Regex("/u/.*"))
+        )
+      },
+      test("header(...).{equalTo,contains,matches} add a header value matcher") {
+        assertTrue(
+          get("/x").where(header("Authorization").matches("Bearer .*")) ==
+            RequestMatch(
+              method = Some(Method.Get),
+              path = PathMatch.Exact("/x"),
+              headers = Map("Authorization" -> ValueMatch.Matches("Bearer .*"))
+            ),
+          get("/x").where(header("X").equalTo("1")) ==
+            RequestMatch(Some(Method.Get), PathMatch.Exact("/x"), headers = Map("X" -> ValueMatch.Equals("1"))),
+          get("/x").where(header("X").contains("ab")) ==
+            RequestMatch(Some(Method.Get), PathMatch.Exact("/x"), headers = Map("X" -> ValueMatch.Contains("ab")))
+        )
+      },
+      test("query(...).{equalTo,contains,matches} add a query value matcher") {
+        assertTrue(
+          get("/x").where(query("page").equalTo("1")) ==
+            RequestMatch(Some(Method.Get), PathMatch.Exact("/x"), query = Map("page" -> ValueMatch.Equals("1"))),
+          get("/x").where(query("page").contains("1")).query == Map("page" -> ValueMatch.Contains("1")),
+          get("/x").where(query("page").matches("\\d+")).query == Map("page" -> ValueMatch.Matches("\\d+"))
+        )
+      },
+      test("jsonPath(...).exists / .equalTo set a JsonPath body matcher") {
+        assertTrue(
+          post("/x").where(jsonPath("$.a").exists).body.contains(BodyMatch.JsonPath("$.a", None)),
+          post("/x").where(jsonPath("$.a").equalTo("v")).body.contains(BodyMatch.JsonPath("$.a", Some("v")))
+        )
+      },
+      test("body matchers (equals/contains/matches/xPath) set the body matcher") {
+        assertTrue(
+          post("/x").where(bodyEquals("hi")).body.contains(BodyMatch.Equals("hi")),
+          post("/x").where(bodyContains("h")).body.contains(BodyMatch.Contains("h")),
+          post("/x").where(bodyMatches("h.")).body.contains(BodyMatch.Matches("h.")),
+          post("/x").where(xPath("/a/b")).body.contains(BodyMatch.XPath("/a/b", None))
+        )
+      },
+      test("clauses targeting the same slot are last-wins") {
+        assertTrue(
+          get("/x").where(bodyEquals("a"), bodyContains("b")).body.contains(BodyMatch.Contains("b")),
+          get("/x").where(header("X").equalTo("1"), header("X").matches("2")).headers ==
+            Map("X" -> ValueMatch.Matches("2"))
+        )
+      },
+      test("where folds multiple clauses onto one match") {
+        val rm = get("/x").where(
+          header("Authorization").matches("Bearer .*"),
+          query("page").equalTo("1"),
+          jsonPath("$.id").exists
+        )
+        assertTrue(
+          rm == RequestMatch(
+            method = Some(Method.Get),
+            path = PathMatch.Exact("/x"),
+            query = Map("page" -> ValueMatch.Equals("1")),
+            headers = Map("Authorization" -> ValueMatch.Matches("Bearer .*")),
+            body = Some(BodyMatch.JsonPath("$.id", None))
+          )
+        )
+      }
+    ),
+    suite("response builders equal the canonical ResponseDef")(
+      test("ok / status set the status with an empty body") {
+        assertTrue(
+          ok == ResponseDef(status = 200),
+          status(402) == ResponseDef(status = 402)
+        )
+      },
+      test("json/text/base64/withBody set the body") {
+        assertTrue(
+          ok.json("{}") == ResponseDef(status = 200, body = Body.Json("{}")),
+          ok.text("hi") == ResponseDef(status = 200, body = Body.Text("hi")),
+          ok.base64("YQ==") == ResponseDef(status = 200, body = Body.Base64("YQ==")),
+          status(402).withBody(Body.Text("nope")) == ResponseDef(status = 402, body = Body.Text("nope"))
+        )
+      },
+      test("withHeader / withStatus / withLatency refine the response") {
+        assertTrue(
+          ok.withHeader("Content-Type", "application/json") ==
+            ResponseDef(status = 200, headers = Map("Content-Type" -> "application/json")),
+          ok.withStatus(204) == ResponseDef(status = 204),
+          ok.json("{}").withLatency(50.millis) ==
+            ResponseDef(status = 200, body = Body.Json("{}"), delay = Some(50.millis))
+        )
+      }
+    ),
+    suite("rule + spec assembly")(
+      test("respondWith pairs a match and a response into a MockRule") {
+        assertTrue(
+          get("/ping").respondWith(ok.text("pong")) ==
+            MockRule(
+              `match` = RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+              respond = ResponseDef(status = 200, body = Body.Text("pong"))
+            )
+        )
+      },
+      test("withId stamps a rule id") {
+        assertTrue(
+          get("/ping").respondWith(ok).withId("r1").id.contains(RuleId("r1"))
+        )
+      },
+      test("a full DSL rule equals the hand-built canonical rule") {
+        val built = get("/ignored")
+          .withPath(PathMatch.Template("/users/{id}"))
+          .where(header("Authorization").matches("Bearer .*"), jsonPath("$.name").exists)
+          .respondWith(status(201).json("""{"ok":true}""").withHeader("Location", "/users/1").withLatency(10.millis))
+          .withId("create-user")
+
+        val canonical = MockRule(
+          `match` = RequestMatch(
+            method = Some(Method.Get),
+            path = PathMatch.Template("/users/{id}"),
+            headers = Map("Authorization" -> ValueMatch.Matches("Bearer .*")),
+            body = Some(BodyMatch.JsonPath("$.name", None))
+          ),
+          respond = ResponseDef(
+            status = 201,
+            headers = Map("Location" -> "/users/1"),
+            body = Body.Json("""{"ok":true}"""),
+            delay = Some(10.millis)
+          ),
+          id = Some(RuleId("create-user"))
+        )
+        assertTrue(built == canonical)
+      },
+      test("mock / onPort / source assemble a spec and a Dsl source") {
+        val r1 = get("/a").respondWith(ok)
+        val r2 = post("/b").respondWith(status(201))
+        assertTrue(
+          mock(r1, r2) == MockSpec(List(r1, r2)),
+          mock(r1).onPort(8080) == MockSpec(List(r1), port = Some(8080)),
+          mock(r1, r2).source == MockSource.Dsl(MockSpec(List(r1, r2))),
+          dslSource(r1, r2) == MockSource.Dsl(MockSpec(List(r1, r2)))
+        )
+      }
+    ),
+    test("a DSL spec normalizes through Provisioning to exactly its canonical rules") {
+      // Ties DSL output to the real wire contract: the same Provisioning path the
+      // raw sources use yields SourcePayload.Rules(handBuiltRules) for the DSL.
+      val r1 = get("/ping").respondWith(ok.text("pong"))
+      val r2 = post("/echo").where(jsonPath("$.msg").exists).respondWith(status(201))
+      for
+        prov <- Provisioning.make
+        norm <- prov.normalize(dslSource(r1, r2))
+      yield assertTrue(
+        norm.size == 1,
+        norm.head.payload == SourcePayload.Rules(List(r1, r2))
+      )
+    }
+  )

--- a/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
@@ -9,6 +9,7 @@ object MockControlModelSpec extends ZIOSpecDefault:
   // existence proves `MockControl` is implementable end-to-end with no adapter
   // dependency (AC1); it also exercises the capability fail-fast contract (AC4).
   private final case class StubMockControl(backend: String, caps: Set[Capability]) extends MockControl:
+    def backendName: String           = backend
     def capabilities: Set[Capability] = caps
 
     def provision(source: MockSource): IO[MockError, List[MockSpace]] =

--- a/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
@@ -1,0 +1,137 @@
+package zio.bdd.mock
+
+import zio.*
+import zio.test.*
+
+object MockControlModelSpec extends ZIOSpecDefault:
+
+  // A minimal in-spec adapter that implements the *total* core port. Its mere
+  // existence proves `MockControl` is implementable end-to-end with no adapter
+  // dependency (AC1); it also exercises the capability fail-fast contract (AC4).
+  private final case class StubMockControl(backend: String, caps: Set[Capability]) extends MockControl:
+    def capabilities: Set[Capability] = caps
+
+    def provision(source: MockSource): IO[MockError, List[MockSpace]] =
+      ZIO.succeed(List(MockSpace("http://localhost:0", identity, SpaceId("s1"))))
+
+    def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+      ZIO.succeed(Nil)
+
+    def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+      ZIO.succeed(RuleId("r1"))
+
+    def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit]              = ZIO.unit
+    def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit] = ZIO.unit
+    def destroy(space: MockSpace): IO[MockError, Unit]                             = ZIO.unit
+    def received(space: MockSpace): IO[MockError, List[RecordedRequest]]           = ZIO.succeed(Nil)
+
+    private def cap[A](c: Capability)(a: => A): IO[Unsupported, A] =
+      if caps(c) then ZIO.succeed(a) else ZIO.fail(Unsupported(c, backend))
+
+    def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(new Faults {})
+    def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(new StatefulScenarios {})
+    def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(new StateInspection {})
+    def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(new Scripting {})
+    def proxyRecord: IO[Unsupported, ProxyRecord]         = cap(Capability.ProxyRecord)(new ProxyRecord {})
+    def templating: IO[Unsupported, Templating]           = cap(Capability.Templating)(new Templating {})
+
+  def spec = suite("MockControl port + canonical model")(
+    test("the total port is implementable by a stub adapter") {
+      val control: MockControl = StubMockControl("stub", Set.empty)
+      val rule = MockRule(
+        `match` = RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+        respond = ResponseDef(status = 200, body = Body.Text("pong"))
+      )
+      for
+        spaces <- control.provision(new MockSource {})
+        space  <- ZIO.fromOption(spaces.headOption).orElseFail(MockError.ProvisionFailed("stub returned no space"))
+        id     <- control.addRule(space, rule)
+        _      <- control.replaceRules(space, List(rule))
+        _      <- control.removeRule(space, id)
+        recs   <- control.received(space)
+        _      <- control.destroy(space)
+      yield
+        val req = HttpRequest(Method.Get, "http://x/")
+        assertTrue(
+          spaces.nonEmpty,
+          id == RuleId("r1"),
+          recs.isEmpty,
+          space.inject(req) == req // stub isolation is identity
+        )
+    },
+    test("Body covers Text | Json | Base64 (plus Empty)") {
+      val bodies: List[Body] = List(Body.Text("a"), Body.Json("{}"), Body.Base64("YQ=="), Body.Empty)
+      val shapes = bodies.map {
+        case Body.Text(_)   => "text"
+        case Body.Json(_)   => "json"
+        case Body.Base64(_) => "base64"
+        case Body.Empty     => "empty"
+      }
+      assertTrue(shapes == List("text", "json", "base64", "empty"))
+    },
+    test("PathMatch covers Exact | Regex | Template (plus Any)") {
+      val paths: List[PathMatch] =
+        List(PathMatch.Exact("/u"), PathMatch.Regex("/u/.*"), PathMatch.Template("/u/{id}"), PathMatch.Any)
+      val shapes = paths.map {
+        case PathMatch.Exact(_)    => "exact"
+        case PathMatch.Regex(_)    => "regex"
+        case PathMatch.Template(_) => "template"
+        case PathMatch.Any         => "any"
+      }
+      assertTrue(shapes == List("exact", "regex", "template", "any"))
+    },
+    test("MockError and Unsupported are typed, not Throwable") {
+      val err: MockError   = MockError.SpaceNotFound(SpaceId("s1"))
+      val uns: Unsupported = Unsupported(Capability.Faults, "stub")
+      assertTrue(
+        !err.isInstanceOf[Throwable],
+        !uns.isInstanceOf[Throwable],
+        uns.message.contains("Faults"),
+        uns.message.contains("stub")
+      )
+    },
+    test("every capability accessor fails fast with its own Unsupported when not advertised") {
+      // Each accessor must name *its own* capability — the likeliest copy-paste bug in adapters.
+      val accessors: List[(Capability, MockControl => IO[Unsupported, Any])] = List(
+        Capability.Faults            -> (_.faults),
+        Capability.StatefulScenarios -> (_.scenarios),
+        Capability.StateInspection   -> (_.stateInspection),
+        Capability.Scripting         -> (_.scripting),
+        Capability.ProxyRecord       -> (_.proxyRecord),
+        Capability.Templating        -> (_.templating)
+      )
+      val none: MockControl = StubMockControl("stub", Set.empty)
+      val all: MockControl  = StubMockControl("stub", Capability.values.toSet)
+      ZIO
+        .foreach(accessors) { (cap, access) =>
+          for
+            unsupported <- access(none).either
+            supported   <- access(all).either
+          yield assertTrue(
+            unsupported == Left(Unsupported(cap, "stub")),
+            supported.isRight
+          )
+        }
+        .map(_.reduce(_ && _))
+    },
+    test("Isolation enum has both isolation modes") {
+      assertTrue(Isolation.values.toSet == Set(Isolation.PerInstance, Isolation.Correlated))
+    },
+    test("model types are immutable value types (case-class semantics)") {
+      val r1 = ResponseDef(status = 200, body = Body.Json("{}"))
+      val r2 = r1.copy(status = 404)
+      assertTrue(
+        r1 == ResponseDef(status = 200, body = Body.Json("{}")),
+        r1.status == 200, // original unchanged by copy
+        r2.status == 404,
+        r2.body == Body.Json("{}")
+      )
+    },
+    test("RuleId and SpaceId are zero-cost newtypes carrying their value") {
+      assertTrue(
+        RuleId("r1") == RuleId("r1"),
+        RuleId("r1").value == "r1",
+        SpaceId("s1").value == "s1"
+      )
+    }
+  )

--- a/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
@@ -118,6 +118,17 @@ object MockControlModelSpec extends ZIOSpecDefault:
     test("Isolation enum has both isolation modes") {
       assertTrue(Isolation.values.toSet == Set(Isolation.PerInstance, Isolation.Correlated))
     },
+    test("NativeSpec is backend-tagged and carries its raw payload") {
+      // The type ascriptions are the real assertion: they only compile because
+      // each case is pinned to its backend tag (Rift / WireMock).
+      val rift: NativeSpec[Backend.Rift]     = NativeSpec.Rift("""{"stubs":[]}""")
+      val wire: NativeSpec[Backend.WireMock] = NativeSpec.WireMock("""{"mappings":[]}""")
+      assertTrue(
+        rift.isInstanceOf[NativeSpec.Rift],
+        wire.isInstanceOf[NativeSpec.WireMock],
+        (rift match { case NativeSpec.Rift(j) => j; case _ => "" }) == """{"stubs":[]}"""
+      )
+    },
     test("model types are immutable value types (case-class semantics)") {
       val r1 = ResponseDef(status = 200, body = Body.Json("{}"))
       val r2 = r1.copy(status = 404)

--- a/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
@@ -43,7 +43,7 @@ object MockControlModelSpec extends ZIOSpecDefault:
         respond = ResponseDef(status = 200, body = Body.Text("pong"))
       )
       for
-        spaces <- control.provision(new MockSource {})
+        spaces <- control.provision(MockSource.Dsl(MockSpec(Nil)))
         space  <- ZIO.fromOption(spaces.headOption).orElseFail(MockError.ProvisionFailed("stub returned no space"))
         id     <- control.addRule(space, rule)
         _      <- control.replaceRules(space, List(rule))

--- a/mock/src/test/scala/zio/bdd/mock/MockOverlaySpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockOverlaySpec.scala
@@ -1,0 +1,214 @@
+package zio.bdd.mock
+
+import zio.*
+import zio.test.*
+
+object MockOverlaySpec extends ZIOSpecDefault:
+
+  // A MockControl that models an ordered, per-space rule list. addRule(Overlay)
+  // prepends (highest priority → shadows base); addRule(Base) appends; removeRule
+  // deletes by id; replaceRules swaps the whole list. No global teardown exists,
+  // so a scope can only ever touch the rules it added.
+  private final case class RuleEntry(id: String, rule: MockRule)
+  private final case class TState(nextId: Int, rules: Map[String, List[RuleEntry]])
+  private object TState:
+    val init: TState = TState(0, Map.empty)
+
+  private final class TestControl(
+    ref: Ref[TState],
+    failAddRule: MockRule => Boolean = _ => false,
+    failRemoveRule: String => Boolean = _ => false
+  ) extends MockControl:
+    def backendName: String           = "test"
+    def capabilities: Set[Capability] = Set.empty
+
+    def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+      if failAddRule(rule) then ZIO.fail(MockError.InvalidDefinition("add boom"))
+      else
+        ref.modify { s =>
+          val id      = s"r${s.nextId}"
+          val current = s.rules.getOrElse(space.id.value, Nil)
+          val updated = priority match
+            case Priority.Overlay => RuleEntry(id, rule) :: current
+            case Priority.Base    => current :+ RuleEntry(id, rule)
+          (RuleId(id), s.copy(nextId = s.nextId + 1, rules = s.rules.updated(space.id.value, updated)))
+        }
+
+    def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit] =
+      if failRemoveRule(id.value) then ZIO.fail(MockError.CommunicationError("remove boom"))
+      else
+        ref.modify { s =>
+          val current = s.rules.getOrElse(space.id.value, Nil)
+          if current.exists(_.id == id.value) then
+            (ZIO.unit, s.copy(rules = s.rules.updated(space.id.value, current.filterNot(_.id == id.value))))
+          else (ZIO.fail(MockError.RuleNotFound(space.id, id)), s)
+        }.flatten
+
+    def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit] =
+      ref.update { s =>
+        val entries = rules.zipWithIndex.map { case (r, i) => RuleEntry(s"x${s.nextId + i}", r) }
+        s.copy(nextId = s.nextId + rules.size, rules = s.rules.updated(space.id.value, entries))
+      }
+
+    def provision(source: MockSource): IO[MockError, List[MockSpace]] = ZIO.succeed(Nil)
+    def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+      ZIO.fail(MockError.InvalidDefinition("n/a"))
+    def destroy(space: MockSpace): IO[MockError, Unit]                   = ZIO.unit
+    def received(space: MockSpace): IO[MockError, List[RecordedRequest]] = ZIO.succeed(Nil)
+    def faults: IO[Unsupported, Faults]                                  = ZIO.fail(Unsupported(Capability.Faults, backendName))
+    def scenarios: IO[Unsupported, StatefulScenarios]                    = ZIO.fail(Unsupported(Capability.StatefulScenarios, backendName))
+    def stateInspection: IO[Unsupported, StateInspection] =
+      ZIO.fail(Unsupported(Capability.StateInspection, backendName))
+    def scripting: IO[Unsupported, Scripting]     = ZIO.fail(Unsupported(Capability.Scripting, backendName))
+    def proxyRecord: IO[Unsupported, ProxyRecord] = ZIO.fail(Unsupported(Capability.ProxyRecord, backendName))
+    def templating: IO[Unsupported, Templating]   = ZIO.fail(Unsupported(Capability.Templating, backendName))
+
+  private def rulesOf(ref: Ref[TState], space: MockSpace): UIO[List[MockRule]] =
+    ref.get.map(_.rules.getOrElse(space.id.value, Nil).map(_.rule))
+
+  private def rule(path: String): MockRule =
+    MockRule(RequestMatch(path = PathMatch.Exact(path)), ResponseDef(status = 200, body = Body.Text(path)))
+
+  private val base    = rule("/base")
+  private val overlay = rule("/overlay")
+  private val spaceA  = MockSpace("http://a", identity, SpaceId("A"))
+  private val spaceB  = MockSpace("http://b", identity, SpaceId("B"))
+
+  def spec = suite("MockOverlay")(
+    test("a scoped overlay shadows the base rule and reverts exactly on release (AC1)") {
+      for
+        ref             <- Ref.make(TState.init)
+        ctl: MockControl = TestControl(ref)
+        _               <- ctl.addRule(spaceA, base, Priority.Base)
+        during <- ZIO.scoped {
+                    MockOverlay.scoped(spaceA)(overlay) *> rulesOf(ref, spaceA)
+                  }.provideLayer(ZLayer.succeed(ctl))
+        after <- rulesOf(ref, spaceA)
+      yield assertTrue(
+        during == List(overlay, base), // overlay prepended → shadows base, base still present
+        after == List(base)            // reverted exactly to the base rule
+      )
+    },
+    test("concurrent overlays on different spaces don't interfere (AC2)") {
+      for
+        ref             <- Ref.make(TState.init)
+        ctl: MockControl = TestControl(ref)
+        _               <- ctl.addRule(spaceA, base, Priority.Base)
+        _               <- ctl.addRule(spaceB, base, Priority.Base)
+        res <- ZIO.scoped {
+                 MockOverlay.scoped(spaceA)(overlay) *> ZIO.scoped {
+                   MockOverlay.scoped(spaceB)(overlay) *> (rulesOf(ref, spaceA) <*> rulesOf(ref, spaceB))
+                 }.flatMap(bothOpen => (rulesOf(ref, spaceA) <*> rulesOf(ref, spaceB)).map((bothOpen, _)))
+               }.provideLayer(ZLayer.succeed(ctl))
+      yield
+        val (bothOpen, afterBClosed) = res
+        val (aBoth, bBoth)           = bothOpen
+        val (aAfter, bAfter)         = afterBClosed
+        assertTrue(
+          aBoth == List(overlay, base),  // A overlaid
+          bBoth == List(overlay, base),  // B overlaid — neither leaked into the other
+          aAfter == List(overlay, base), // closing B left A's overlay intact
+          bAfter == List(base)           // only B reverted
+        )
+    },
+    test("a scoped overlay adds all rules and removes all of them on release") {
+      for
+        ref             <- Ref.make(TState.init)
+        ctl: MockControl = TestControl(ref)
+        _               <- ctl.addRule(spaceA, base, Priority.Base)
+        during <- ZIO.scoped {
+                    MockOverlay.scoped(spaceA)(rule("/o1"), rule("/o2")) *> rulesOf(ref, spaceA)
+                  }.provideLayer(ZLayer.succeed(ctl))
+        after <- rulesOf(ref, spaceA)
+      yield assertTrue(
+        during.size == 3,
+        during.last == base,                                   // overlays sit above the base
+        during.take(2).toSet == Set(rule("/o1"), rule("/o2")), // both overlays applied
+        after == List(base)                                    // all overlays removed on release
+      )
+    },
+    test("remove deletes one rule by id; replaceAll replaces every rule") {
+      for
+        ref             <- Ref.make(TState.init)
+        ctl: MockControl = TestControl(ref)
+        id1             <- ctl.addRule(spaceA, rule("/x"), Priority.Base)
+        _               <- ctl.addRule(spaceA, rule("/y"), Priority.Base)
+        _               <- MockOverlay.remove(spaceA, id1).provideLayer(ZLayer.succeed(ctl))
+        afterRemove     <- rulesOf(ref, spaceA)
+        _               <- MockOverlay.replaceAll(spaceA, rule("/z")).provideLayer(ZLayer.succeed(ctl))
+        afterReplace    <- rulesOf(ref, spaceA)
+      yield assertTrue(
+        afterRemove == List(rule("/y")), // only /x removed
+        afterReplace == List(rule("/z")) // everything replaced
+      )
+    },
+    test("a failed addRule mid-overlay reverts the rules already added") {
+      for
+        ref             <- Ref.make(TState.init)
+        ctl: MockControl = TestControl(ref, failAddRule = _.`match`.path == PathMatch.Exact("/bad"))
+        _               <- ctl.addRule(spaceA, base, Priority.Base)
+        res <- ZIO
+                 .scoped(MockOverlay.scoped(spaceA)(rule("/o1"), rule("/bad")))
+                 .provideLayer(ZLayer.succeed(ctl))
+                 .either
+        after <- rulesOf(ref, spaceA)
+      yield assertTrue(
+        res.isLeft,         // the overlay failed
+        after == List(base) // /o1 was rolled back — only the base rule remains
+      )
+    },
+    test("a teardown failure for one overlay rule does not strand the others") {
+      for
+        ref <- Ref.make(TState.init)
+        // The first overlay rule added gets id "r0"; make its removal fail on release.
+        ctl: MockControl = TestControl(ref, failRemoveRule = _ == "r0")
+        res <- ZIO
+                 .scoped(MockOverlay.scoped(spaceA)(rule("/o1"), rule("/o2")).unit)
+                 .provideLayer(ZLayer.succeed(ctl))
+                 .either
+        after <- rulesOf(ref, spaceA)
+      yield assertTrue(
+        res.isRight,               // the logged teardown failure doesn't fail the scope
+        after == List(rule("/o1")) // /o2 was still removed; only the stuck /o1 remains
+      )
+    },
+    test("an overlay scope closes cleanly even if its rules were replaced wholesale while open") {
+      for
+        ref             <- Ref.make(TState.init)
+        ctl: MockControl = TestControl(ref)
+        res <- ZIO.scoped {
+                 MockOverlay.scoped(spaceA)(overlay) *> MockOverlay.replaceAll(spaceA, rule("/timeout"))
+               }.provideLayer(ZLayer.succeed(ctl)).either
+        after <- rulesOf(ref, spaceA)
+      yield assertTrue(
+        res.isRight,                    // overlay teardown hits RuleNotFound, is logged, scope still closes
+        after == List(rule("/timeout")) // the wholesale replacement stands
+      )
+    },
+    test("remove of an unknown rule id surfaces RuleNotFound") {
+      for
+        ref             <- Ref.make(TState.init)
+        ctl: MockControl = TestControl(ref)
+        res             <- MockOverlay.remove(spaceA, RuleId("ghost")).provideLayer(ZLayer.succeed(ctl)).either
+      yield assertTrue(res == Left(MockError.RuleNotFound(spaceA.id, RuleId("ghost"))))
+    },
+    test("overlays applied in parallel on different spaces each see only their own") {
+      for
+        ref             <- Ref.make(TState.init)
+        ctl: MockControl = TestControl(ref)
+        _               <- ctl.addRule(spaceA, base, Priority.Base)
+        _               <- ctl.addRule(spaceB, base, Priority.Base)
+        seen <- ZIO
+                  .scoped(MockOverlay.scoped(spaceA)(rule("/oa")) *> rulesOf(ref, spaceA))
+                  .provideLayer(ZLayer.succeed(ctl))
+                  .zipPar(
+                    ZIO
+                      .scoped(MockOverlay.scoped(spaceB)(rule("/ob")) *> rulesOf(ref, spaceB))
+                      .provideLayer(ZLayer.succeed(ctl))
+                  )
+      yield assertTrue(
+        seen._1 == List(rule("/oa"), base), // A's scope saw only A's overlay
+        seen._2 == List(rule("/ob"), base)  // B's scope saw only B's overlay
+      )
+    }
+  )

--- a/mock/src/test/scala/zio/bdd/mock/ProvisioningSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/ProvisioningSpec.scala
@@ -1,0 +1,210 @@
+package zio.bdd.mock
+
+import zio.*
+import zio.test.*
+
+import java.net.{ServerSocket, URI}
+import java.nio.file.{Files, Path}
+
+object ProvisioningSpec extends ZIOSpecDefault:
+
+  // A canonical rule used wherever a DSL source needs content. Its shape is
+  // irrelevant to this issue — provisioning never inspects the rules, only
+  // routes them through normalisation and auto-port assignment.
+  private val pingRule =
+    MockRule(
+      `match` = RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+      respond = ResponseDef(status = 200, body = Body.Text("pong"))
+    )
+
+  /**
+   * A `serve` callback that records the (space, normalized source) it was asked
+   * to stand up, without binding anything.
+   */
+  private def recording(log: Ref[List[(MockSpace, NormalizedSource)]]): (NormalizedSource, MockSpace) => UIO[Unit] =
+    (src, space) => log.update(_ :+ (space, src))
+
+  private def portOf(space: MockSpace): Int = URI(space.baseUri).getPort
+
+  private def isInvalidDefinition(res: Either[MockError, Any]): Boolean =
+    res.left.exists(_.isInstanceOf[MockError.InvalidDefinition])
+
+  def spec = suite("Provisioning")(
+    test("provision resolves a classpath Resource to one space carrying its raw text") {
+      for
+        prov   <- Provisioning.make
+        log    <- Ref.make(List.empty[(MockSpace, NormalizedSource)])
+        spaces <- prov.provision(MockSource.Resource("mocks/ping.json"))(recording(log))
+        seen   <- log.get
+      yield
+        val (space, src) = seen.head
+        assertTrue(
+          spaces.size == 1,
+          seen.size == 1,
+          src.name == "ping.json",
+          src.payload match
+            case SourcePayload.Raw(t) => t.contains("\"/ping\"")
+            case _                    => false,
+          portOf(space) > 0
+        )
+    },
+    test("provision of a Dir yields one space per file, named by file") {
+      ZIO.scoped {
+        for
+          dir    <- tempDir
+          _      <- writeFile(dir.resolve("a.json"), """{"a":1}""")
+          _      <- writeFile(dir.resolve("b.json"), """{"b":2}""")
+          prov   <- Provisioning.make
+          log    <- Ref.make(List.empty[(MockSpace, NormalizedSource)])
+          spaces <- prov.provision(MockSource.Dir(dir.toString))(recording(log))
+          seen   <- log.get
+        yield assertTrue(
+          spaces.size == 2,
+          seen.map(_._2.name).sorted == List("a.json", "b.json"),
+          // every resolved space got its own auto-assigned port
+          spaces.map(portOf).distinct.size == 2
+        )
+      }
+    },
+    test("provisioning a fixed-port source twice gives two independently bindable spaces (fixed-port trap)") {
+      // The source authors a single fixed port; provisioning it twice must NOT
+      // try to bind that port twice. Each provision auto-assigns a distinct free
+      // port, so both `serve` calls can bind a real socket simultaneously.
+      val authored        = 18080
+      val fixedPortSource = MockSource.Dsl(MockSpec(List(pingRule), port = Some(authored)))
+
+      def bindServe(sockets: Ref[List[ServerSocket]]): (NormalizedSource, MockSpace) => IO[MockError, Unit] =
+        (_, space) =>
+          ZIO
+            .attempt(ServerSocket(portOf(space)))
+            .mapError(e => MockError.CommunicationError(e.getMessage))
+            .flatMap(s => sockets.update(_ :+ s))
+
+      ZIO.scoped {
+        for
+          prov    <- Provisioning.make
+          sockets <- Ref.make(List.empty[ServerSocket])
+          _       <- ZIO.addFinalizer(sockets.get.flatMap(ss => ZIO.foreachDiscard(ss)(s => ZIO.succeed(s.close()))))
+          first   <- prov.provision(fixedPortSource)(bindServe(sockets))
+          second  <- prov.provision(fixedPortSource)(bindServe(sockets))
+          bound   <- sockets.get
+        yield
+          val p1 = portOf(first.head)
+          val p2 = portOf(second.head)
+          assertTrue(
+            first.size == 1,
+            second.size == 1,
+            p1 != p2, // authored port was stripped + auto-assigned, twice
+            p1 != authored,
+            p2 != authored,
+            bound.size == 2, // both sockets bound at once -> no collision
+            bound.forall(_.isBound)
+          )
+      }
+    },
+    test("authored port is advisory: stripped from baseUri, auto-assigned port used instead") {
+      val authored = 19090
+      for
+        prov   <- Provisioning.make
+        log    <- Ref.make(List.empty[(MockSpace, NormalizedSource)])
+        spaces <- prov.provision(MockSource.Dsl(MockSpec(List(pingRule), port = Some(authored))))(recording(log))
+      yield
+        val space = spaces.head
+        assertTrue(
+          portOf(space) != authored,
+          portOf(space) > 0,
+          space.baseUri.startsWith("http://localhost:"),
+          space.inject(HttpRequest(Method.Get, "http://x/")) == HttpRequest(Method.Get, "http://x/")
+        )
+    },
+    test("normalize memoizes: a source deleted after first normalize still resolves from cache") {
+      ZIO.scoped {
+        for
+          dir   <- tempDir
+          file   = dir.resolve("once.json")
+          _     <- writeFile(file, """{"once":true}""")
+          prov  <- Provisioning.make
+          first <- prov.normalize(MockSource.File(file.toString))
+          _     <- ZIO.attempt(Files.delete(file)).orDie
+          again <- prov.normalize(MockSource.File(file.toString))
+        yield assertTrue(
+          first == again,
+          first.head.payload == SourcePayload.Raw("""{"once":true}""")
+        )
+      }
+    },
+    test("a Dsl source normalizes to canonical rules with its advisory port retained") {
+      for
+        prov <- Provisioning.make
+        norm <- prov.normalize(MockSource.Dsl(MockSpec(List(pingRule), port = Some(1234))))
+      yield assertTrue(
+        norm.size == 1,
+        norm.head.authoredPort.contains(1234),
+        norm.head.payload == SourcePayload.Rules(List(pingRule))
+      )
+    },
+    test("a Json source normalizes to a raw payload named \"json\" with no authored port") {
+      for
+        prov <- Provisioning.make
+        norm <- prov.normalize(MockSource.Json("""{"raw":true}"""))
+      yield assertTrue(
+        norm.size == 1,
+        norm.head.name == "json",
+        norm.head.authoredPort.isEmpty,
+        norm.head.payload == SourcePayload.Raw("""{"raw":true}""")
+      )
+    },
+    test("a File source normalizes to the file's raw contents, named by file") {
+      ZIO.scoped {
+        for
+          dir  <- tempDir
+          file  = dir.resolve("greeting.json")
+          _    <- writeFile(file, """{"hello":"world"}""")
+          prov <- Provisioning.make
+          norm <- prov.normalize(MockSource.File(file.toString))
+        yield assertTrue(
+          norm.size == 1,
+          norm.head.name == "greeting.json",
+          norm.head.payload == SourcePayload.Raw("""{"hello":"world"}""")
+        )
+      }
+    },
+    test("a missing Resource fails with InvalidDefinition") {
+      for
+        prov <- Provisioning.make
+        res  <- prov.normalize(MockSource.Resource("mocks/does-not-exist.json")).either
+      yield assertTrue(isInvalidDefinition(res))
+    },
+    test("a missing File fails with InvalidDefinition") {
+      for
+        prov <- Provisioning.make
+        res  <- prov.normalize(MockSource.File("/no/such/path/missing.json")).either
+      yield assertTrue(isInvalidDefinition(res))
+    },
+    test("a Dir pointing at a non-directory fails with InvalidDefinition") {
+      ZIO.scoped {
+        for
+          dir  <- tempDir
+          file  = dir.resolve("not-a-dir.json")
+          _    <- writeFile(file, "{}")
+          prov <- Provisioning.make
+          res  <- prov.normalize(MockSource.Dir(file.toString)).either
+        yield assertTrue(isInvalidDefinition(res))
+      }
+    }
+  )
+
+  // --- filesystem helpers (scoped temp dir, auto-deleted) -------------------
+
+  private val tempDir: ZIO[Scope, Throwable, Path] =
+    ZIO.acquireRelease(ZIO.attempt(Files.createTempDirectory("provisioning-spec"))) { dir =>
+      ZIO.attempt {
+        import scala.jdk.CollectionConverters.*
+        val walk = Files.walk(dir)
+        try walk.iterator().asScala.toList.sortBy(_.toString).reverse.foreach(Files.deleteIfExists(_))
+        finally walk.close()
+      }.orDie
+    }
+
+  private def writeFile(path: Path, content: String): ZIO[Any, Throwable, Unit] =
+    ZIO.attempt(Files.writeString(path, content)).unit

--- a/mock/src/test/scala/zio/bdd/mock/RawSourceNoDslSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/RawSourceNoDslSpec.scala
@@ -1,0 +1,127 @@
+package zio.bdd.mock
+
+import zio.*
+import zio.test.*
+
+/**
+ * AC1 gate: a suite authored entirely from raw `.json` sources (no DSL) must
+ * still drive every mutation and assertion on [[MockControl]]. This file
+ * deliberately does NOT `import zio.bdd.mock.dsl.*` — that it compiles and runs
+ * proves the DSL builders are pure convenience, never a requirement. Overlay
+ * rules are constructed from the bare canonical model, not the DSL.
+ */
+object RawSourceNoDslSpec extends ZIOSpecDefault:
+
+  // An in-memory adapter: rules and the loaded source payload live in Refs.
+  // `provision` runs through the real [[Provisioning]] path so a raw `.json`
+  // source is genuinely read (a missing resource fails the test), then records
+  // the normalized payload per space. Enough to exercise
+  // addRule/removeRule/replaceRules/received/destroy and the provisionNative
+  // escape hatch without any backend.
+  private final case class InMemoryControl(
+    prov: Provisioning,
+    rules: Ref[Map[SpaceId, List[(RuleId, MockRule)]]],
+    loaded: Ref[Map[SpaceId, SourcePayload]],
+    seq: Ref[Int]
+  ) extends MockControl:
+    def capabilities: Set[Capability] = Set.empty
+
+    def provision(source: MockSource): IO[MockError, List[MockSpace]] =
+      prov.provision(source) { (norm, space) =>
+        rules.update(_.updated(space.id, Nil)) *> loaded.update(_.updated(space.id, norm.payload))
+      }
+
+    def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+      val space = MockSpace("http://localhost:0", identity, SpaceId("native"))
+      rules.update(_.updated(space.id, Nil)).as(List(space))
+
+    def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+      seq.updateAndGet(_ + 1).map(n => RuleId(s"r$n")).flatMap { id =>
+        rules.update(m => m.updated(space.id, m.getOrElse(space.id, Nil) :+ (id, rule))).as(id)
+      }
+
+    def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit] =
+      rules.update(m => m.updated(space.id, m.getOrElse(space.id, Nil).filterNot(_._1 == id)))
+
+    def replaceRules(space: MockSpace, rs: List[MockRule]): IO[MockError, Unit] =
+      rules.update(m => m.updated(space.id, rs.map(r => (RuleId("replaced"), r))))
+
+    def destroy(space: MockSpace): IO[MockError, Unit] =
+      rules.update(_.removed(space.id))
+
+    def received(space: MockSpace): IO[MockError, List[RecordedRequest]] =
+      ZIO.succeed(Nil)
+
+    private def unsupported[A](c: Capability): IO[Unsupported, A] = ZIO.fail(Unsupported(c, "in-memory"))
+    def faults: IO[Unsupported, Faults]                           = unsupported(Capability.Faults)
+    def scenarios: IO[Unsupported, StatefulScenarios]             = unsupported(Capability.StatefulScenarios)
+    def stateInspection: IO[Unsupported, StateInspection]         = unsupported(Capability.StateInspection)
+    def scripting: IO[Unsupported, Scripting]                     = unsupported(Capability.Scripting)
+    def proxyRecord: IO[Unsupported, ProxyRecord]                 = unsupported(Capability.ProxyRecord)
+    def templating: IO[Unsupported, Templating]                   = unsupported(Capability.Templating)
+
+  private def control: UIO[InMemoryControl] =
+    for
+      prov   <- Provisioning.make
+      rules  <- Ref.make(Map.empty[SpaceId, List[(RuleId, MockRule)]])
+      loaded <- Ref.make(Map.empty[SpaceId, SourcePayload])
+      seq    <- Ref.make(0)
+    yield InMemoryControl(prov, rules, loaded, seq)
+
+  // A canonical overlay rule built WITHOUT the DSL — bare model constructors only.
+  private val overlay: MockRule =
+    MockRule(
+      `match` = RequestMatch(method = Some(Method.Post), path = PathMatch.Exact("/echo")),
+      respond = ResponseDef(status = 201, body = Body.Json("""{"ok":true}"""))
+    )
+
+  def spec = suite("raw .json source drives every mutation/assertion without the DSL")(
+    test("provision from a .json resource, then add/replace/remove/received/destroy") {
+      for
+        mc       <- control
+        spaces   <- mc.provision(MockSource.Resource("mocks/ping.json"))
+        space    <- ZIO.fromOption(spaces.headOption).orElseFail(MockError.ProvisionFailed("no space"))
+        payload  <- mc.loaded.get.map(_(space.id))
+        id       <- mc.addRule(space, overlay)
+        afterAdd <- mc.rules.get
+        _        <- mc.replaceRules(space, List(overlay))
+        afterRep <- mc.rules.get
+        _        <- mc.removeRule(space, RuleId("replaced"))
+        afterRem <- mc.rules.get
+        recs     <- mc.received(space)
+        _        <- mc.destroy(space)
+        afterDel <- mc.rules.get
+      yield assertTrue(
+        spaces.size == 1,
+        // the raw .json was genuinely read by the provisioning path
+        payload match
+          case SourcePayload.Raw(t) => t.contains("\"/ping\"")
+          case _                    => false,
+        id == RuleId("r1"),
+        afterAdd(space.id).map(_._2) == List(overlay),
+        afterRep(space.id).map(_._2) == List(overlay),
+        afterRem(space.id).isEmpty,
+        recs.isEmpty,
+        !afterDel.contains(space.id)
+      )
+    },
+    test("provisioning a missing .json resource fails — no DSL fallback hides it") {
+      for
+        mc  <- control
+        res <- mc.provision(MockSource.Resource("mocks/does-not-exist.json")).either
+      yield assertTrue(res == Left(MockError.InvalidDefinition("resource not found: mocks/does-not-exist.json")))
+    },
+    test("provisionNative escape hatch stands up a space without a portable source") {
+      val nativeSpec = new NativeSpec[Backend] {}
+      for
+        mc     <- control
+        spaces <- mc.provisionNative(nativeSpec)
+      yield assertTrue(spaces.map(_.id) == List(SpaceId("native")))
+    },
+    test("an unadvertised capability fails fast with typed Unsupported") {
+      for
+        mc  <- control
+        res <- mc.faults.either
+      yield assertTrue(res == Left(Unsupported(Capability.Faults, "in-memory")))
+    }
+  )

--- a/mock/src/test/scala/zio/bdd/mock/RawSourceNoDslSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/RawSourceNoDslSpec.scala
@@ -113,7 +113,7 @@ object RawSourceNoDslSpec extends ZIOSpecDefault:
       yield assertTrue(res == Left(MockError.InvalidDefinition("resource not found: mocks/does-not-exist.json")))
     },
     test("provisionNative escape hatch stands up a space without a portable source") {
-      val nativeSpec = new NativeSpec[Backend] {}
+      val nativeSpec = NativeSpec.Rift("""{"stubs":[]}""")
       for
         mc     <- control
         spaces <- mc.provisionNative(nativeSpec)

--- a/mock/src/test/scala/zio/bdd/mock/RawSourceNoDslSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/RawSourceNoDslSpec.scala
@@ -24,6 +24,7 @@ object RawSourceNoDslSpec extends ZIOSpecDefault:
     loaded: Ref[Map[SpaceId, SourcePayload]],
     seq: Ref[Int]
   ) extends MockControl:
+    def backendName: String           = "in-memory"
     def capabilities: Set[Capability] = Set.empty
 
     def provision(source: MockSource): IO[MockError, List[MockSpace]] =

--- a/mock/src/test/scala/zio/bdd/mock/SutClientSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/SutClientSpec.scala
@@ -1,0 +1,173 @@
+package zio.bdd.mock
+
+import zio.*
+import zio.test.*
+
+import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
+import java.net.{InetSocketAddress, URI}
+import java.net.http.{HttpClient, HttpRequest as JHttpRequest, HttpResponse as JHttpResponse}
+import java.util.concurrent.{ConcurrentHashMap, CopyOnWriteArrayList}
+import scala.jdk.CollectionConverters.*
+
+object SutClientSpec extends ZIOSpecDefault:
+
+  // An in-process stand-in for the SUT's dependency. It records each request under
+  // a space key = the `x-correlation-id` header if present (Correlated isolation),
+  // else the first path segment (PerInstance isolation). A request that carries
+  // neither (e.g. inject was bypassed) lands under the wrong key, so a Correlated
+  // request without inject never reaches its space.
+  private final class TestDependency(
+    port: Int,
+    recordings: ConcurrentHashMap[String, CopyOnWriteArrayList[(String, String)]]
+  ):
+    def perInstanceSpace(id: String): MockSpace =
+      MockSpace(s"http://localhost:$port/$id", identity, SpaceId(id))
+
+    def correlatedSpace(id: String): MockSpace =
+      MockSpace(
+        s"http://localhost:$port",
+        req => req.copy(headers = req.headers + ("x-correlation-id" -> id)),
+        SpaceId(id)
+      )
+
+    def received(id: String): UIO[List[(String, String)]] =
+      ZIO.succeed(Option(recordings.get(id)).map(_.asScala.toList).getOrElse(Nil))
+
+  private val dependency: ZIO[Scope, Throwable, TestDependency] =
+    ZIO
+      .acquireRelease(
+        ZIO.attempt {
+          val recordings = new ConcurrentHashMap[String, CopyOnWriteArrayList[(String, String)]]()
+          val server     = HttpServer.create(new InetSocketAddress("localhost", 0), 0)
+          server.createContext(
+            "/",
+            new HttpHandler:
+              def handle(exchange: HttpExchange): Unit =
+                val full    = exchange.getRequestURI.getPath
+                val method  = exchange.getRequestMethod
+                val reqBody = new String(exchange.getRequestBody.readAllBytes())
+                val header  = Option(exchange.getRequestHeaders.getFirst("x-correlation-id"))
+                val (key, path) = header match
+                  case Some(h) => (h, full)
+                  case None =>
+                    val seg = full.stripPrefix("/").split("/", 2)
+                    (seg(0), "/" + (if seg.length > 1 then seg(1) else ""))
+                recordings.computeIfAbsent(key, _ => new CopyOnWriteArrayList[(String, String)]()).add((method, path))
+                // Echo the request body back, stamp a header, and fail /down — so a
+                // test can pin SutResponse status/body/header decoding and the
+                // non-2xx-is-a-value contract.
+                val status    = if path.endsWith("/down") then 503 else 200
+                val respBytes = reqBody.getBytes
+                exchange.getResponseHeaders.set("X-Served-By", "dep")
+                exchange.sendResponseHeaders(status, if respBytes.isEmpty then -1 else respBytes.length.toLong)
+                val os = exchange.getResponseBody
+                os.write(respBytes)
+                os.close()
+          )
+          server.start()
+          (server, new TestDependency(server.getAddress.getPort, recordings))
+        }
+      )(acquired => ZIO.attempt(acquired._1.stop(0)).orDie)
+      .map(_._2)
+
+  // Send a raw request with NO inject applied (bypasses SutClient).
+  private def rawGet(url: String): ZIO[Any, Throwable, Int] =
+    ZIO.attemptBlocking {
+      val req = JHttpRequest.newBuilder(URI.create(url)).GET().build()
+      HttpClient.newHttpClient().send(req, JHttpResponse.BodyHandlers.ofString()).statusCode
+    }
+
+  def spec = suite("SutClient")(
+    test("baseUrl derives from the space; PerInstance spaces target distinct endpoints (no fixed port)") {
+      ZIO.scoped {
+        dependency.map { dep =>
+          val a = SutClient.make(dep.perInstanceSpace("A"))
+          val b = SutClient.make(dep.perInstanceSpace("B"))
+          assertTrue(
+            a.baseUrl == dep.perInstanceSpace("A").baseUri, // derived from the space, not hardcoded
+            a.baseUrl.endsWith("/A"),
+            a.baseUrl != b.baseUrl // distinct per space
+          )
+        }
+      }
+    },
+    test("SutClient applies inject so Correlated requests reach their own space (no cross-talk)") {
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          for
+            _    <- SutClient.make(dep.correlatedSpace("A")).send(Method.Get, "/x")
+            _    <- SutClient.make(dep.correlatedSpace("B")).send(Method.Post, "/y")
+            recA <- dep.received("A")
+            recB <- dep.received("B")
+          yield assertTrue(recA == List(("GET", "/x")), recB == List(("POST", "/y")))
+        }
+      }
+    },
+    test("a Correlated request without inject does NOT reach its space (inject is load-bearing)") {
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          val spaceA = dep.correlatedSpace("A")
+          for
+            _        <- rawGet(spaceA.baseUri + "/x")                 // shared baseUri, no correlation header
+            withoutI <- dep.received("A")
+            _        <- SutClient.make(spaceA).send(Method.Get, "/x") // same, but via inject
+            withInj  <- dep.received("A")
+          yield assertTrue(
+            withoutI.isEmpty,              // not routed to A — inject was load-bearing
+            withInj == List(("GET", "/x")) // with inject it reaches A
+          )
+        }
+      }
+    },
+    test("concurrent SUT calls via per-space clients don't cross-talk (PerInstance)") {
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          val n = 25
+          for
+            _ <-
+              ZIO.foreachParDiscard(1 to n)(i => SutClient.make(dep.perInstanceSpace(s"s$i")).send(Method.Get, s"/p$i"))
+            recs <- ZIO.foreach((1 to n).toList)(i => dep.received(s"s$i").map((i, _)))
+          yield assertTrue(recs.forall((i, r) => r == List(("GET", s"/p$i"))))
+        }
+      }
+    },
+    test("concurrent SUT calls via per-space clients don't cross-talk (Correlated, shared base URL)") {
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          val n = 25
+          for
+            _ <-
+              ZIO.foreachParDiscard(1 to n)(i => SutClient.make(dep.correlatedSpace(s"c$i")).send(Method.Get, s"/q$i"))
+            recs <- ZIO.foreach((1 to n).toList)(i => dep.received(s"c$i").map((i, _)))
+          yield assertTrue(recs.forall((i, r) => r == List(("GET", s"/q$i"))))
+        }
+      }
+    },
+    test("send issues the inject-rewritten request URI, not the original (inject may rewrite the URI)") {
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          val rewriting = dep.perInstanceSpace("Z").copy(inject = req => req.copy(uri = req.uri + "-rewritten"))
+          for
+            _   <- SutClient.make(rewriting).send(Method.Get, "/orig")
+            rec <- dep.received("Z")
+          yield assertTrue(rec == List(("GET", "/orig-rewritten"))) // the inject's URI rewrite was honoured
+        }
+      }
+    },
+    test("send returns the decoded dependency response (status, body, headers); a non-2xx is a value, not an error") {
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          val client = SutClient.make(dep.perInstanceSpace("R"))
+          for
+            ok   <- client.send(Method.Post, "/echo", body = Some("hello"))
+            down <- client.send(Method.Get, "/down")
+          yield assertTrue(
+            ok.status == 200,
+            ok.body == "hello",                            // request body sent + response body decoded
+            ok.headers.get("x-served-by").contains("dep"), // header normalised to lower-case
+            down.status == 503                             // non-2xx surfaced as a SutResponse, not a failure
+          )
+        }
+      }
+    }
+  )

--- a/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
@@ -1,0 +1,82 @@
+package zio.bdd.mock.rift
+
+import zio.*
+import zio.bdd.mock.{MockControl, MockError, Provisioning}
+import zio.http.Client
+import com.dimafeng.testcontainers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+
+/**
+ * Entry points for the Rift adapter — the default, zero-native-artifact
+ * provider of the portable mocking SPI (#113).
+ *
+ *   - [[connect]] targets an already-running Rift admin endpoint with a known
+ *     imposter port pool (used by tests and when Rift runs out-of-band).
+ *   - [[managed]] stands up the published Rift image via testcontainers and
+ *     stops it with the layer's scope finalizer.
+ */
+object Rift:
+
+  // Pinned to v0.2.0: the first release where DELETE /imposters/:port tears down
+  // existing keep-alive connections, so a destroyed imposter stops serving even
+  // a pooled client (EtaCassiopeia/rift#207).
+  val DefaultImage: String     = "zainalpour/rift-proxy:v0.2.0"
+  val DefaultAdminPort: Int    = 2525
+  val DefaultImposterBase: Int = 4545
+  val DefaultPoolSize: Int     = 16
+
+  /**
+   * Adapter over an already-running Rift: `adminBase` is the admin URL,
+   * `imposterPorts` the pool of ports imposters may bind, and `hostFor` maps an
+   * imposter port to its SUT-reachable base URI (the identity under host
+   * networking).
+   */
+  def connect(
+    adminBase: String,
+    imposterPorts: List[Int]
+  )(hostFor: Int => String): URLayer[Client & Provisioning, MockControl] =
+    ZLayer {
+      RiftEndpoint.pooled(adminBase, imposterPorts)(hostFor).flatMap(RiftMockControl.make)
+    }
+
+  /**
+   * Start the Rift image via testcontainers, exposing the admin port plus a
+   * pool of imposter ports, and expose a [[MockControl]] bound to it. The
+   * container is stopped when the layer's scope closes.
+   *
+   * Container port-mapping wrinkle: testcontainers maps each exposed imposter
+   * port to an arbitrary host port, so each [[zio.bdd.mock.MockSpace]]
+   * `baseUri` is built from the *host-mapped* port. On CI you may instead run
+   * Rift with host networking and a pre-mapped port pool, where the mapping is
+   * identity.
+   */
+  def managed(
+    image: String = DefaultImage,
+    poolSize: Int = DefaultPoolSize,
+    adminPort: Int = DefaultAdminPort,
+    imposterBasePort: Int = DefaultImposterBase
+  ): ZLayer[Client & Provisioning, MockError, MockControl] =
+    ZLayer.scoped {
+      val imposterPorts = (0 until poolSize).map(imposterBasePort + _).toList
+      for
+        container <- ZIO.acquireRelease(
+                       ZIO.attemptBlocking {
+                         val c = GenericContainer(
+                           dockerImage = image,
+                           exposedPorts = adminPort :: imposterPorts,
+                           waitStrategy = Wait.forHttp("/imposters").forPort(adminPort)
+                         )
+                         c.start()
+                         c
+                       }
+                         .mapError(t => MockError.ProvisionFailed(s"starting Rift container '$image': ${message(t)}"))
+                     )(c => ZIO.attemptBlocking(c.stop()).orDie)
+        host      = container.host
+        admin     = s"http://$host:${container.mappedPort(adminPort)}"
+        endpoint <- RiftEndpoint.pooled(admin, imposterPorts)(p => s"http://$host:${container.mappedPort(p)}")
+        control  <- RiftMockControl.make(endpoint)
+      yield control
+    }
+
+  private def message(t: Throwable): String =
+    Option(t.getMessage).getOrElse(t.getClass.getSimpleName)

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftEndpoint.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftEndpoint.scala
@@ -1,0 +1,50 @@
+package zio.bdd.mock.rift
+
+import zio.*
+import zio.bdd.mock.MockError
+
+/**
+ * Where Rift's admin API lives and how an imposter's port maps to a URI the SUT
+ * can actually reach — the seam that isolates the container port-mapping
+ * wrinkle from the protocol logic.
+ *
+ * With a container, imposters bind ports *inside* the container that
+ * testcontainers maps to arbitrary host ports, so the adapter cannot pick a
+ * host port up front (the way [[zio.bdd.mock.Provisioning]] does for in-process
+ * backends). Instead it draws an imposter port from a pre-exposed pool and asks
+ * the endpoint for the reachable base URI. Under host networking the mapping is
+ * the identity; the pooled implementation below covers both.
+ */
+private[rift] trait RiftEndpoint:
+  /** Base URL of the admin API, e.g. `http://localhost:2525`. */
+  def adminBase: String
+
+  /** Take an imposter port from the pool, or fail if the pool is exhausted. */
+  def acquirePort: IO[MockError, Int]
+
+  /** Return a port to the pool after an imposter is destroyed. */
+  def releasePort(port: Int): UIO[Unit]
+
+  /** The SUT-reachable base URI for an imposter bound to `imposterPort`. */
+  def baseUriFor(imposterPort: Int): String
+
+private[rift] object RiftEndpoint:
+
+  /**
+   * A fixed pool of imposter ports plus a caller-supplied mapping from an
+   * imposter port to its reachable URI (identity under host networking; the
+   * container's host-mapped port otherwise).
+   */
+  def pooled(admin: String, ports: List[Int])(hostFor: Int => String): UIO[RiftEndpoint] =
+    Ref.make(ports).map(free => Pooled(admin, free, hostFor))
+
+  private final case class Pooled(adminBase: String, free: Ref[List[Int]], hostFor: Int => String) extends RiftEndpoint:
+    def acquirePort: IO[MockError, Int] =
+      free.modify {
+        case head :: tail => (ZIO.succeed(head), tail)
+        case Nil          => (ZIO.fail(MockError.ProvisionFailed("Rift imposter port pool exhausted")), Nil)
+      }.flatten
+
+    def releasePort(port: Int): UIO[Unit] = free.update(port :: _)
+
+    def baseUriFor(imposterPort: Int): String = hostFor(imposterPort)

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -49,7 +49,15 @@ private[rift] final case class RiftMockControl(
     yield spaces
 
   def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
-    ZIO.fail(MockError.InvalidDefinition("the Rift adapter does not support native specs yet (#119)"))
+    spec match
+      // A native Rift imposter goes through the same serveSpace machinery as a
+      // portable Raw source (pool port, `_rift`/stub passthrough, tracking), so
+      // the resulting space participates in destroy/received/overlays/isolation
+      // exactly like a portable one.
+      case NativeSpec.Rift(imposterJson) =>
+        serveSpace(NormalizedSource("native", SourcePayload.Raw(imposterJson), None)).map(List(_))
+      case NativeSpec.WireMock(_) =>
+        ZIO.fail(MockError.InvalidDefinition("the Rift adapter cannot provision a WireMock native spec"))
 
   def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
     withImposter(space) { imp =>

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -1,0 +1,209 @@
+package zio.bdd.mock.rift
+
+import zio.*
+import zio.bdd.mock.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.http.{Body, Client, Header, MediaType, Request, URL, Method as HttpMethod}
+
+/**
+ * The Rift adapter: implements the portable [[MockControl]] core port by
+ * driving Rift's Mountebank-compatible admin API over zio-http.
+ *
+ * PerInstance isolation: each [[MockSpace]] is one imposter on its own port and
+ * `inject == identity`. `destroy` deletes exactly that imposter (`DELETE
+ * /imposters/:port`) — never the global `DELETE /imposters` reset, so tearing
+ * down one space never touches another (#113 AC2).
+ *
+ * Rule identity: Mountebank addresses stubs by positional index, which shifts
+ * as stubs are inserted/removed. The adapter therefore hands out stable opaque
+ * [[RuleId]]s and tracks their current order per imposter, translating an id to
+ * its live index on removal — so a [[RuleId]] never silently points at the
+ * wrong stub after an overlay insert.
+ *
+ * Capabilities are intentionally empty here: the optional capability
+ * *interfaces* (faults, scenarios, …) are fleshed out in M3, so this adapter
+ * advertises none and every accessor fails fast with [[Unsupported]].
+ */
+private[rift] final case class RiftMockControl(
+  endpoint: RiftEndpoint,
+  client: Client,
+  provisioning: Provisioning,
+  spaces: Ref[Map[SpaceId, RiftMockControl.Imposter]],
+  ids: Ref[Int]
+) extends MockControl:
+
+  def backendName: String           = "rift"
+  def capabilities: Set[Capability] = Set.empty
+
+  def provision(source: MockSource): IO[MockError, List[MockSpace]] =
+    for
+      sources <- provisioning.normalize(source)
+      created <- Ref.make(List.empty[MockSpace])
+      // Provision atomically: tear down any spaces already stood up if a later
+      // space in the same source fails, so a partial batch never orphans
+      // imposters/ports the caller can't reach.
+      spaces <- ZIO
+                  .foreach(sources)(src => serveSpace(src).tap(s => created.update(s :: _)))
+                  .onError(_ => created.get.flatMap(ZIO.foreachDiscard(_)(s => destroy(s).ignore)))
+    yield spaces
+
+  def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+    ZIO.fail(MockError.InvalidDefinition("the Rift adapter does not support native specs yet (#119)"))
+
+  def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+    withImposter(space) { imp =>
+      for
+        ruleId <- freshId
+        // First match wins in Mountebank, so an overlay rule goes on top
+        // (index 0) and a base rule is appended after the existing stubs.
+        index <- priority match
+                   case Priority.Overlay => ZIO.succeed(0)
+                   case Priority.Base    => imp.stubs.get.map(_.size)
+        u   <- url(s"/imposters/${imp.port}/stubs")
+        res <- send(jsonRequest(HttpMethod.POST, u, RiftProtocol.addStubBody(index, rule)))
+        _   <- expectSuccess(s"add rule to imposter ${imp.port}", res)
+        _   <- imp.stubs.update(v => if priority == Priority.Overlay then ruleId +: v else v :+ ruleId)
+      yield ruleId
+    }
+
+  def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit] =
+    withImposter(space) { imp =>
+      imp.stubs.get.flatMap { ordered =>
+        ordered.indexOf(id) match
+          case -1 => ZIO.fail(MockError.RuleNotFound(space.id, id))
+          case idx =>
+            for
+              u   <- url(s"/imposters/${imp.port}/stubs/$idx")
+              res <- send(Request(method = HttpMethod.DELETE, url = u))
+              _   <- expectSuccess(s"remove rule from imposter ${imp.port}", res)
+              _   <- imp.stubs.update(_.patch(idx, Nil, 1))
+            yield ()
+      }
+    }
+
+  def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit] =
+    withImposter(space) { imp =>
+      for
+        ruleIds <- freshIds(rules.size)
+        u       <- url(s"/imposters/${imp.port}/stubs")
+        res     <- send(jsonRequest(HttpMethod.PUT, u, RiftProtocol.replaceStubsBody(rules)))
+        _       <- expectSuccess(s"replace rules on imposter ${imp.port}", res)
+        _       <- imp.stubs.set(ruleIds)
+      yield ()
+    }
+
+  def destroy(space: MockSpace): IO[MockError, Unit] =
+    withImposter(space) { imp =>
+      for
+        u   <- url(s"/imposters/${imp.port}")
+        res <- send(Request(method = HttpMethod.DELETE, url = u))
+        // A 404 means the imposter is already gone — destroy is idempotent.
+        _ <- ZIO.unless(res._1 == 404)(expectSuccess(s"destroy imposter ${imp.port}", res))
+        _ <- endpoint.releasePort(imp.port)
+        _ <- spaces.update(_ - space.id)
+      yield ()
+    }
+
+  def received(space: MockSpace): IO[MockError, List[RecordedRequest]] =
+    withImposter(space) { imp =>
+      for
+        u    <- url(s"/imposters/${imp.port}")
+        res  <- send(Request(method = HttpMethod.GET, url = u))
+        body <- expectSuccess(s"read imposter ${imp.port}", res)
+        // A malformed view is a backend/protocol fault, not a bad user definition.
+        recs <- ZIO.fromEither(RiftProtocol.parseRecorded(body)).mapError(MockError.CommunicationError(_))
+      yield recs
+    }
+
+  def faults: IO[Unsupported, Faults]                   = unsupported(Capability.Faults)
+  def scenarios: IO[Unsupported, StatefulScenarios]     = unsupported(Capability.StatefulScenarios)
+  def stateInspection: IO[Unsupported, StateInspection] = unsupported(Capability.StateInspection)
+  def scripting: IO[Unsupported, Scripting]             = unsupported(Capability.Scripting)
+  def proxyRecord: IO[Unsupported, ProxyRecord]         = unsupported(Capability.ProxyRecord)
+  def templating: IO[Unsupported, Templating]           = unsupported(Capability.Templating)
+
+  // ---------------------------------------------------------------------------
+
+  private def serveSpace(src: NormalizedSource): IO[MockError, MockSpace] =
+    endpoint.acquirePort.flatMap { port =>
+      val stand =
+        for
+          bodyAndCount <- imposterBody(port, src)
+          (body, count) = bodyAndCount
+          _            <- postImposter(port, body)
+          ruleIds      <- freshIds(count)
+          stubs        <- Ref.make(ruleIds)
+          id            = SpaceId(s"${src.name}-$port")
+          space         = MockSpace(endpoint.baseUriFor(port), identity, id)
+          _            <- spaces.update(_.updated(id, RiftMockControl.Imposter(port, stubs)))
+        yield space
+      // Release the port back to the pool on *any* failure after acquiring it
+      // (malformed source, POST rejected, …) so a bad provision can't leak slots.
+      stand.onError(_ => endpoint.releasePort(port))
+    }
+
+  private def imposterBody(port: Int, src: NormalizedSource): IO[MockError, (Json, Int)] =
+    src.payload match
+      case SourcePayload.Rules(rules) =>
+        ZIO.succeed((RiftProtocol.imposter(port, src.name, rules), rules.length))
+      case SourcePayload.Raw(text) =>
+        ZIO.fromEither(RiftProtocol.imposterFromRaw(port, src.name, text)).mapError(MockError.InvalidDefinition(_))
+
+  private def postImposter(port: Int, body: Json): IO[MockError, Unit] =
+    for
+      u   <- url("/imposters")
+      res <- send(jsonRequest(HttpMethod.POST, u, body))
+      _   <- expectSuccess(s"create imposter on port $port", res)
+    yield ()
+
+  private def freshId: UIO[RuleId] = ids.updateAndGet(_ + 1).map(n => RuleId(s"r$n"))
+
+  private def freshIds(n: Int): UIO[Vector[RuleId]] = ZIO.foreach(0 until n)(_ => freshId).map(_.toVector)
+
+  private def withImposter[A](space: MockSpace)(f: RiftMockControl.Imposter => IO[MockError, A]): IO[MockError, A] =
+    spaces.get.flatMap(_.get(space.id) match
+      case Some(imp) => f(imp)
+      case None      => ZIO.fail(MockError.SpaceNotFound(space.id))
+    )
+
+  private def unsupported[A](c: Capability): IO[Unsupported, A] = ZIO.fail(Unsupported(c, backendName))
+
+  private def url(path: String): IO[MockError, URL] =
+    ZIO
+      .fromEither(URL.decode(endpoint.adminBase + path))
+      .mapError(e => MockError.CommunicationError(s"invalid admin URL ${endpoint.adminBase}$path: ${e.getMessage}"))
+
+  private def jsonRequest(method: HttpMethod, u: URL, body: Json): Request =
+    Request(method = method, url = u, body = Body.fromString(body.toJson))
+      .addHeader(Header.ContentType(MediaType.application.json))
+
+  private def send(req: Request): IO[MockError, (Int, String)] =
+    Client
+      .batched(req)
+      .flatMap(resp => resp.body.asString.map(body => (resp.status.code, body)))
+      .provideEnvironment(ZEnvironment(client))
+      .mapError { t =>
+        val msg = Option(t.getMessage).filter(_.nonEmpty).fold("")(m => s": $m")
+        MockError.CommunicationError(s"${t.getClass.getSimpleName}$msg")
+      }
+
+  private def expectSuccess(action: String, res: (Int, String)): IO[MockError, String] =
+    val (code, body) = res
+    if code >= 200 && code < 300 then ZIO.succeed(body)
+    else ZIO.fail(MockError.CommunicationError(s"$action: Rift returned HTTP $code: ${body.take(1000)}"))
+
+private[rift] object RiftMockControl:
+  final case class Imposter(port: Int, stubs: Ref[Vector[RuleId]])
+
+  /**
+   * Build an adapter against an endpoint, taking the zio-http [[Client]] and
+   * [[Provisioning]] from the environment.
+   */
+  def make(endpoint: RiftEndpoint): URIO[Client & Provisioning, MockControl] =
+    for
+      client <- ZIO.service[Client]
+      prov   <- ZIO.service[Provisioning]
+      spaces <- Ref.make(Map.empty[SpaceId, Imposter])
+      ids    <- Ref.make(0)
+    yield RiftMockControl(endpoint, client, prov, spaces, ids)

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -1,0 +1,161 @@
+package zio.bdd.mock.rift
+
+import zio.bdd.mock.*
+import zio.json.*
+import zio.json.ast.Json
+
+/**
+ * Pure translation between the canonical mock model and Rift's
+ * Mountebank-compatible wire JSON. No effects, no I/O — every function is a
+ * total mapping over value types, so the protocol is unit-testable without a
+ * backend.
+ */
+private[rift] object RiftProtocol:
+
+  // ---------------------------------------------------------------------------
+  // Canonical model -> Mountebank wire JSON
+  // ---------------------------------------------------------------------------
+
+  /**
+   * A full `POST /imposters` body for one space: one imposter, recording on.
+   */
+  def imposter(port: Int, name: String, rules: List[MockRule]): Json =
+    Json.Obj(
+      "port"           -> Json.Num(port),
+      "protocol"       -> Json.Str("http"),
+      "name"           -> Json.Str(name),
+      "recordRequests" -> Json.Bool(true),
+      "stubs"          -> Json.Arr(rules.map(stub)*)
+    )
+
+  /** A single Mountebank stub: predicates (ANDed) + one response. */
+  def stub(rule: MockRule): Json =
+    val idField = rule.id.map(id => "id" -> Json.Str(id.value)).toList
+    Json.Obj(
+      (idField ++ List(
+        "predicates" -> Json.Arr(predicates(rule.`match`)*),
+        "responses"  -> Json.Arr(response(rule.respond))
+      ))*
+    )
+
+  /** The `{stubs: [...]}` body for `PUT /imposters/:port/stubs`. */
+  def replaceStubsBody(rules: List[MockRule]): Json =
+    Json.Obj("stubs" -> Json.Arr(rules.map(stub)*))
+
+  /** The `{index, stub}` body for `POST /imposters/:port/stubs`. */
+  def addStubBody(index: Int, rule: MockRule): Json =
+    Json.Obj("index" -> Json.Num(index), "stub" -> stub(rule))
+
+  def predicates(m: RequestMatch): List[Json] =
+    val methodPred = m.method.map(meth => equalsObj("method" -> Json.Str(methodName(meth))))
+    val pathPred = m.path match
+      case PathMatch.Any         => None
+      case PathMatch.Exact(p)    => Some(equalsObj("path" -> Json.Str(p)))
+      case PathMatch.Regex(r)    => Some(matchesObj("path" -> Json.Str(r)))
+      case PathMatch.Template(t) => Some(matchesObj("path" -> Json.Str(templateToRegex(t))))
+    val queryPreds  = m.query.toList.map((k, vm) => valuePred("query", k, vm))
+    val headerPreds = m.headers.toList.map((k, vm) => valuePred("headers", k, vm))
+    val bodyPred    = m.body.map(bodyPredicate)
+    methodPred.toList ++ pathPred.toList ++ queryPreds ++ headerPreds ++ bodyPred.toList
+
+  def response(r: ResponseDef): Json =
+    val headers =
+      if r.headers.isEmpty then Nil
+      else List("headers" -> Json.Obj(r.headers.toList.map((k, v) => k -> Json.Str(v))*))
+    val body = r.body match
+      case Body.Empty     => Nil
+      case Body.Text(v)   => List("body" -> Json.Str(v))
+      case Body.Json(v)   => List("body" -> Json.Str(v))
+      case Body.Base64(v) => List("body" -> Json.Str(v), "_mode" -> Json.Str("binary"))
+    val isObj = Json.Obj((("statusCode" -> Json.Num(r.status)) :: headers ++ body)*)
+    val behaviors =
+      r.delay.map(d => "_behaviors" -> Json.Obj("wait" -> Json.Num(d.toMillis.toInt))).toList
+    Json.Obj((("is" -> isObj) :: behaviors)*)
+
+  /** Rebuild a raw imposter doc, forcing our pool port and recording on. */
+  def imposterFromRaw(port: Int, name: String, raw: String): Either[String, (Json, Int)] =
+    raw.fromJson[Json].flatMap {
+      case obj: Json.Obj =>
+        val fields    = obj.fields.toMap
+        val stubCount = fields.get("stubs").collect { case Json.Arr(es) => es.length }.getOrElse(0)
+        val forced = upsert(
+          obj,
+          "port"           -> Json.Num(port),
+          "protocol"       -> fields.getOrElse("protocol", Json.Str("http")),
+          "name"           -> fields.getOrElse("name", Json.Str(name)),
+          "recordRequests" -> Json.Bool(true)
+        )
+        Right((forced, stubCount))
+      case _ => Left("raw Rift source must be a JSON object (an imposter document)")
+    }
+
+  // ---------------------------------------------------------------------------
+  // Mountebank wire JSON -> canonical model (recorded requests)
+  // ---------------------------------------------------------------------------
+
+  private case class WireReq(
+    method: String,
+    path: String,
+    headers: Option[Map[String, String]] = None,
+    body: Option[String] = None
+  ) derives JsonDecoder
+  private case class WireView(requests: Option[List[WireReq]] = None) derives JsonDecoder
+
+  /** Parse the `requests[]` of a `GET /imposters/:port` view. */
+  def parseRecorded(viewJson: String): Either[String, List[RecordedRequest]] =
+    viewJson.fromJson[WireView].map { v =>
+      v.requests.getOrElse(Nil).map { r =>
+        RecordedRequest(
+          method = methodFromWire(r.method),
+          uri = r.path,
+          headers = r.headers.getOrElse(Map.empty),
+          body = r.body
+        )
+      }
+    }
+
+  // ---------------------------------------------------------------------------
+  // helpers
+  // ---------------------------------------------------------------------------
+
+  def methodName(m: Method): String = m.toString.toUpperCase
+
+  // Rift records standard, upper-case HTTP method names; an unrecognized token
+  // (never produced by Rift) falls back to GET rather than failing a read.
+  def methodFromWire(s: String): Method =
+    Method.values.find(_.toString.equalsIgnoreCase(s)).getOrElse(Method.Get)
+
+  // "/users/{id}" -> anchored regex "^/users/[^/]+$" (Mountebank has no template).
+  def templateToRegex(t: String): String =
+    "^" + t.replaceAll("\\{[^/}]+\\}", "[^/]+") + "$"
+
+  private def equalsObj(fields: (String, Json)*): Json  = Json.Obj("equals" -> Json.Obj(fields*))
+  private def matchesObj(fields: (String, Json)*): Json = Json.Obj("matches" -> Json.Obj(fields*))
+
+  private def valuePred(selector: String, key: String, vm: ValueMatch): Json =
+    val (op, value) = vm match
+      case ValueMatch.Equals(v)   => ("equals", v)
+      case ValueMatch.Contains(v) => ("contains", v)
+      case ValueMatch.Matches(r)  => ("matches", r)
+    Json.Obj(op -> Json.Obj(selector -> Json.Obj(key -> Json.Str(value))))
+
+  private def bodyPredicate(bm: BodyMatch): Json =
+    bm match
+      case BodyMatch.Equals(v)   => Json.Obj("equals" -> Json.Obj("body" -> Json.Str(v)))
+      case BodyMatch.Contains(v) => Json.Obj("contains" -> Json.Obj("body" -> Json.Str(v)))
+      case BodyMatch.Matches(r)  => Json.Obj("matches" -> Json.Obj("body" -> Json.Str(r)))
+      case BodyMatch.JsonPath(path, expected) =>
+        selectorPred("jsonpath", path, expected)
+      case BodyMatch.XPath(path, expected) =>
+        selectorPred("xpath", path, expected)
+
+  private def selectorPred(kind: String, path: String, expected: Option[String]): Json =
+    val sel = kind -> Json.Obj("selector" -> Json.Str(path))
+    expected match
+      case Some(e) => Json.Obj(sel, "equals" -> Json.Obj("body" -> Json.Str(e)))
+      case None    => Json.Obj(sel, "exists" -> Json.Obj("body" -> Json.Bool(true)))
+
+  private def upsert(obj: Json.Obj, overrides: (String, Json)*): Json.Obj =
+    val overrideKeys = overrides.map(_._1).toSet
+    val kept         = obj.fields.filterNot((k, _) => overrideKeys(k))
+    Json.Obj(kept ++ overrides)

--- a/rift/src/test/scala/zio/bdd/mock/rift/FakeRift.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/FakeRift.scala
@@ -1,0 +1,94 @@
+package zio.bdd.mock.rift
+
+import zio.*
+import zio.http.*
+import zio.json.ast.Json
+
+/**
+ * An in-process stand-in for Rift's admin API: it records the admin calls the
+ * adapter makes and serves canned imposter views, so the adapter's protocol and
+ * isolation behaviour can be unit-tested with no Docker and no real backend.
+ *
+ * It deliberately does NOT serve imposter traffic — "serving" is the real
+ * container's job, proven by the tagged [[RiftContainerSpec]].
+ */
+final case class FakeRift(
+  posted: Ref[Chunk[String]],
+  deletedPorts: Ref[Chunk[Int]],
+  globalDeletes: Ref[Int],
+  stubCalls: Ref[Chunk[String]],
+  views: Ref[Map[Int, String]],
+  failProvision: Ref[Boolean]
+):
+  /**
+   * Preset the `GET /imposters/:port` view (e.g. to inject recorded requests).
+   */
+  def setView(port: Int, json: String): UIO[Unit] = views.update(_.updated(port, json))
+
+  val routes: Routes[Any, Response] =
+    Routes(
+      Method.POST / "imposters" -> handler { (req: Request) =>
+        req.body.asString.orDie.flatMap { body =>
+          val port = FakeRift.portOf(body).getOrElse(0)
+          failProvision.get.flatMap {
+            case true =>
+              ZIO.succeed(
+                Response(status = Status.BadRequest, body = Body.fromString("""{"errors":[{"code":"400"}]}"""))
+              )
+            case false =>
+              posted.update(_ :+ body) *>
+                views.update(m => if m.contains(port) then m else m.updated(port, FakeRift.emptyView(port))) *>
+                ZIO.succeed(Response(status = Status.Created, body = Body.fromString(s"""{"port":$port}""")))
+          }
+        }
+      },
+      Method.GET / "imposters" / int("port") -> handler { (port: Int, _: Request) =>
+        views.get.map(m => Response(body = Body.fromString(m.getOrElse(port, FakeRift.emptyView(port)))))
+      },
+      Method.DELETE / "imposters" / int("port") -> handler { (port: Int, _: Request) =>
+        (deletedPorts.update(_ :+ port) *> views.update(_ - port)).as(Response.ok)
+      },
+      Method.DELETE / "imposters" -> handler { (_: Request) =>
+        globalDeletes.update(_ + 1).as(Response.ok)
+      },
+      Method.POST / "imposters" / int("port") / "stubs" -> handler { (port: Int, req: Request) =>
+        req.body.asString.orDie.flatMap(b => stubCalls.update(_ :+ s"POST $port $b")).as(Response.ok)
+      },
+      Method.PUT / "imposters" / int("port") / "stubs" -> handler { (port: Int, req: Request) =>
+        req.body.asString.orDie.flatMap(b => stubCalls.update(_ :+ s"PUT $port $b")).as(Response.ok)
+      },
+      Method.DELETE / "imposters" / int("port") / "stubs" / int("index") -> handler {
+        (port: Int, index: Int, _: Request) =>
+          stubCalls.update(_ :+ s"DELETE $port/$index").as(Response.ok)
+      }
+    )
+
+object FakeRift:
+  private def emptyView(port: Int): String = s"""{"port":$port,"requests":[]}"""
+
+  def make: UIO[FakeRift] =
+    for
+      a <- Ref.make(Chunk.empty[String])
+      b <- Ref.make(Chunk.empty[Int])
+      c <- Ref.make(0)
+      d <- Ref.make(Chunk.empty[String])
+      e <- Ref.make(Map.empty[Int, String])
+      f <- Ref.make(false)
+    yield FakeRift(a, b, c, d, e, f)
+
+  def portOf(body: String): Option[Int] =
+    import zio.json.*
+    body.fromJson[Json].toOption.flatMap {
+      case o: Json.Obj => o.fields.toMap.get("port").collect { case Json.Num(n) => n.intValue }
+      case _           => None
+    }
+
+  /** Stand a fresh fake up on an ephemeral port inside the current scope. */
+  def started: ZIO[Scope, Throwable, (String, FakeRift)] =
+    for
+      fake  <- make
+      env   <- Server.defaultWithPort(0).build
+      server = env.get[Server]
+      _     <- server.install(fake.routes)
+      port  <- server.port
+    yield (s"http://localhost:$port", fake)

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
@@ -1,0 +1,83 @@
+package zio.bdd.mock.rift
+
+import zio.*
+import zio.bdd.mock.*
+import zio.http.{Client, Request, URL}
+import zio.test.*
+
+/**
+ * End-to-end acceptance against a REAL Rift container (#113 AC1/AC2). Opt-in:
+ * runs only when `RIFT_IT` is set, so the default `sbt test` stays hermetic and
+ * Docker-free. Run it with `RIFT_IT=1 sbt rift/test`.
+ */
+object RiftContainerSpec extends ZIOSpecDefault:
+
+  private val pingRule = MockRule(
+    `match` = RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+    respond = ResponseDef(status = 200, body = Body.Text("pong"))
+  )
+  private val pingSource = MockSource.Dsl(MockSpec(List(pingRule)))
+
+  // Imposter binds slightly after provision returns; retry the first hit briefly.
+  private val upWithin: Schedule[Any, Any, Any] = Schedule.recurs(20) && Schedule.spaced(100.millis)
+
+  private def httpGet(base: String, path: String): ZIO[Client, Throwable, (Int, String)] =
+    for
+      url  <- ZIO.fromEither(URL.decode(base + path))
+      resp <- Client.batched(Request.get(url))
+      body <- resp.body.asString
+    yield (resp.status.code, body)
+
+  // Teardown is observed even through the client's pooled keep-alive connection:
+  // as of Rift v0.2.0 (rift#207) DELETE /imposters/:port closes existing
+  // connections, so a destroyed imposter stops serving. Poll briefly since the
+  // socket close races the DELETE response.
+  private def waitUntilGone(base: String): ZIO[Client, Nothing, Boolean] =
+    (ZIO.sleep(100.millis) *> httpGet(base, "/ping").either.map(_.isLeft))
+      .repeatUntilEquals(true)
+      .timeoutTo(false)(identity)(5.seconds)
+
+  private val realSuite = suite("RiftContainerSpec (real Rift container)")(
+    test("provisions, serves, records, and destroys a space") {
+      for
+        control  <- ZIO.service[MockControl]
+        spaces   <- control.provision(pingSource)
+        space     = spaces.head
+        served   <- httpGet(space.baseUri, "/ping").retry(upWithin)
+        recorded <- control.received(space)
+        _        <- control.destroy(space)
+        gone     <- waitUntilGone(space.baseUri)
+      yield assertTrue(
+        spaces.size == 1,
+        served == (200, "pong"),                                          // serves
+        recorded.exists(r => r.method == Method.Get && r.uri == "/ping"), // records
+        gone                                                              // destroyed
+      )
+    },
+    test("destroy(A) leaves B intact (never a global reset)") {
+      for
+        control <- ZIO.service[MockControl]
+        a       <- control.provision(pingSource).map(_.head)
+        b       <- control.provision(pingSource).map(_.head)
+        _       <- httpGet(a.baseUri, "/ping").retry(upWithin)
+        _       <- httpGet(b.baseUri, "/ping").retry(upWithin)
+        _       <- control.destroy(a)
+        gone    <- waitUntilGone(a.baseUri)
+        bAfter  <- httpGet(b.baseUri, "/ping") // B must still serve after A is destroyed
+      yield assertTrue(gone, bAfter == (200, "pong"))
+    }
+  ).provideSome[Client](Provisioning.live, riftBackend) @@ TestAspect.sequential @@ TestAspect.withLiveClock
+
+  // Two ways to reach a real Rift: testcontainers spins one up (default), or —
+  // when RIFT_ADMIN points at an already-running Rift admin URL whose imposter
+  // ports are mapped 1:1 to localhost — connect to it directly. The latter
+  // exercises the same adapter without depending on the host's testcontainers
+  // Docker discovery.
+  private def riftBackend: ZLayer[Client & Provisioning, MockError, MockControl] =
+    sys.env.get("RIFT_ADMIN") match
+      case Some(admin) => Rift.connect(admin, (4545 until 4561).toList)(p => s"http://localhost:$p")
+      case None        => Rift.managed()
+
+  def spec =
+    if sys.env.contains("RIFT_IT") then realSuite.provideShared(Client.default)
+    else suite("RiftContainerSpec (skipped — set RIFT_IT=1 to run against a real Rift container)")()

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
@@ -18,6 +18,10 @@ object RiftContainerSpec extends ZIOSpecDefault:
   )
   private val pingSource = MockSource.Dsl(MockSpec(List(pingRule)))
 
+  // A backend-native Rift imposter document for the escape hatch (#119).
+  private val nativeImposter =
+    """{"port":9999,"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/native"}}],"responses":[{"is":{"statusCode":200,"body":"native!"}}]}]}"""
+
   // Imposter binds slightly after provision returns; retry the first hit briefly.
   private val upWithin: Schedule[Any, Any, Any] = Schedule.recurs(20) && Schedule.spaced(100.millis)
 
@@ -65,6 +69,22 @@ object RiftContainerSpec extends ZIOSpecDefault:
         gone    <- waitUntilGone(a.baseUri)
         bAfter  <- httpGet(b.baseUri, "/ping") // B must still serve after A is destroyed
       yield assertTrue(gone, bAfter == (200, "pong"))
+    },
+    test("a natively-provisioned space serves, records, and is space-local on destroy") {
+      for
+        control  <- ZIO.service[MockControl]
+        spaces   <- control.provisionNative(NativeSpec.Rift(nativeImposter))
+        space     = spaces.head
+        served   <- httpGet(space.baseUri, "/native").retry(upWithin)
+        recorded <- control.received(space)
+        _        <- control.destroy(space)
+        gone     <- waitUntilGone(space.baseUri)
+      yield assertTrue(
+        spaces.size == 1,
+        served == (200, "native!"),                                         // serves
+        recorded.exists(r => r.method == Method.Get && r.uri == "/native"), // records
+        gone                                                                // space-local destroy
+      )
     }
   ).provideSome[Client](Provisioning.live, riftBackend) @@ TestAspect.sequential @@ TestAspect.withLiveClock
 

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -1,0 +1,236 @@
+package zio.bdd.mock.rift
+
+import zio.*
+import zio.bdd.mock.*
+import zio.http.Client
+import zio.test.*
+
+object RiftMockControlSpec extends ZIOSpecDefault:
+
+  private val pingRule = MockRule(
+    `match` = RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+    respond = ResponseDef(status = 200, body = Body.Text("pong"))
+  )
+  private val pingSource = MockSource.Dsl(MockSpec(List(pingRule)))
+
+  private def portOf(baseUri: String): Int = baseUri.substring(baseUri.lastIndexOf(':') + 1).toInt
+
+  /**
+   * Set up a fresh fake admin server + a Rift adapter (with the given imposter
+   * port pool) bound to it, in a scope.
+   */
+  private def withAdapterPool(ports: List[Int])(
+    use: (MockControl, FakeRift) => UIO[TestResult]
+  ): ZIO[Client & Provisioning, Throwable, TestResult] =
+    ZIO.scoped {
+      for
+        adminAndFake <- FakeRift.started
+        (admin, fake) = adminAndFake
+        endpoint     <- RiftEndpoint.pooled(admin, ports)(p => s"http://localhost:$p")
+        control      <- RiftMockControl.make(endpoint)
+        result       <- use(control, fake)
+      yield result
+    }
+
+  private def withAdapter(
+    use: (MockControl, FakeRift) => UIO[TestResult]
+  ): ZIO[Client & Provisioning, Throwable, TestResult] =
+    withAdapterPool((4545 until 4600).toList)(use)
+
+  def spec = suite("RiftMockControl (adapter vs fake admin API)")(
+    test("provision creates one recording imposter per space; baseUri reflects its port; inject is identity") {
+      withAdapter { (control, fake) =>
+        for
+          spacesE <- control.provision(pingSource).either
+          posted  <- fake.posted.get
+        yield
+          val spaces = spacesE.toOption.toList.flatten
+          val space  = spaces.head
+          val req    = HttpRequest(Method.Get, "http://sut/")
+          assertTrue(
+            spacesE.isRight,
+            spaces.size == 1,
+            posted.size == 1,
+            posted.head.contains("\"recordRequests\":true"),
+            FakeRift.portOf(posted.head).contains(portOf(space.baseUri)),
+            space.baseUri == s"http://localhost:${portOf(space.baseUri)}",
+            space.inject(req) == req
+          )
+      }
+    },
+    test("destroy(A) deletes only A's imposter — never the global reset — and leaves B intact") {
+      withAdapter { (control, fake) =>
+        for
+          aE       <- control.provision(pingSource).either
+          bE       <- control.provision(pingSource).either
+          a         = aE.toOption.get.head
+          b         = bE.toOption.get.head
+          destroyE <- control.destroy(a).either
+          deleted  <- fake.deletedPorts.get
+          globals  <- fake.globalDeletes.get
+          recvBE   <- control.received(b).either
+          recvAE   <- control.received(a).either
+        yield assertTrue(
+          aE.isRight && bE.isRight,
+          a.baseUri != b.baseUri,
+          destroyE.isRight,
+          globals == 0,                        // never DELETE /imposters
+          deleted == Chunk(portOf(a.baseUri)), // exactly A's port, once
+          !deleted.contains(portOf(b.baseUri)),
+          recvBE.isRight,                               // B still addressable
+          recvAE == Left(MockError.SpaceNotFound(a.id)) // A is gone from the adapter
+        )
+      }
+    },
+    test("received parses the recorded requests from the imposter view") {
+      withAdapter { (control, fake) =>
+        for
+          sE  <- control.provision(pingSource).either
+          s    = sE.toOption.get.head
+          port = portOf(s.baseUri)
+          _ <- fake.setView(
+                 port,
+                 s"""{"port":$port,"requests":[{"method":"GET","path":"/ping","headers":{},"body":null}]}"""
+               )
+          recvE <- control.received(s).either
+        yield assertTrue(recvE == Right(List(RecordedRequest(Method.Get, "/ping", Map.empty, None))))
+      }
+    },
+    test("addRule/replaceRules/removeRule hit the stubs sub-resource endpoints") {
+      withAdapter { (control, fake) =>
+        for
+          sE    <- control.provision(pingSource).either
+          s      = sE.toOption.get.head
+          port   = portOf(s.baseUri)
+          addE  <- control.addRule(s, pingRule, Priority.Base).either                   // r2 -> index 1
+          rmE   <- ZIO.fromEither(addE).flatMap(id => control.removeRule(s, id)).either // remove r2 (index 1)
+          _     <- control.replaceRules(s, List(pingRule)).either                       // PUT all stubs
+          calls <- fake.stubCalls.get
+        yield assertTrue(
+          addE == Right(RuleId("r2")), // r1 is the provisioned stub; r2 appended at index 1
+          rmE.isRight,
+          calls.exists(_.startsWith(s"POST $port")),
+          calls.exists(_.startsWith(s"PUT $port")),
+          calls.contains(s"DELETE $port/1")
+        )
+      }
+    },
+    test("rule ids stay stable: an overlay insert does not misroute a later removal") {
+      withAdapter { (control, fake) =>
+        for
+          sE    <- control.provision(pingSource).either                                  // r1 at index 0
+          s      = sE.toOption.get.head
+          port   = portOf(s.baseUri)
+          baseE <- control.addRule(s, pingRule, Priority.Base).either                    // r2 -> index 1 -> [r1, r2]
+          ovE   <- control.addRule(s, pingRule, Priority.Overlay).either                 // r3 -> index 0 -> [r3, r1, r2]
+          rmE   <- ZIO.fromEither(baseE).flatMap(id => control.removeRule(s, id)).either // remove r2
+          calls <- fake.stubCalls.get
+        yield assertTrue(
+          baseE == Right(RuleId("r2")),
+          ovE == Right(RuleId("r3")),
+          rmE.isRight,
+          calls.contains(s"DELETE $port/2") // r2 shifted to index 2 by the overlay insert
+        )
+      }
+    },
+    test("removeRule of an unknown id fails with RuleNotFound") {
+      withAdapter { (control, _) =>
+        for
+          sE  <- control.provision(pingSource).either
+          s    = sE.toOption.get.head
+          rmE <- control.removeRule(s, RuleId("ghost")).either
+        yield assertTrue(rmE == Left(MockError.RuleNotFound(s.id, RuleId("ghost"))))
+      }
+    },
+    test("a failed provision releases the imposter port — no pool leak") {
+      withAdapterPool(List(4545)) { (control, fake) =>
+        for
+          _    <- fake.failProvision.set(true)
+          fail <- control.provision(pingSource).either // POST 400 -> fails; port must be released
+          _    <- fake.failProvision.set(false)
+          ok   <- control.provision(pingSource).either // would be "pool exhausted" if the port leaked
+        yield assertTrue(
+          fail.isLeft,
+          ok.isRight,
+          ok.toOption.get.head.baseUri == "http://localhost:4545"
+        )
+      }
+    },
+    test("an exhausted imposter port pool fails with a typed ProvisionFailed") {
+      withAdapterPool(List(4545)) { (control, _) =>
+        for
+          _    <- control.provision(pingSource).either // takes 4545
+          next <- control.provision(pingSource).either // pool empty
+        yield assertTrue(
+          next.swap.toOption.exists {
+            case MockError.ProvisionFailed(m) => m.contains("exhausted")
+            case _                            => false
+          }
+        )
+      }
+    },
+    test("advertises no capabilities; accessors fail fast; native specs unsupported") {
+      withAdapter { (control, _) =>
+        for
+          faultsE <- control.faults.either
+          nativeE <- control.provisionNative(new NativeSpec[Backend] {}).either
+        yield assertTrue(
+          control.capabilities.isEmpty,
+          faultsE == Left(Unsupported(Capability.Faults, "rift")),
+          nativeE.swap.toOption.exists {
+            case MockError.InvalidDefinition(_) => true
+            case _                              => false
+          }
+        )
+      }
+    },
+    test("a raw JSON source is provisioned with our port + recordRequests forced; malformed raw is InvalidDefinition") {
+      withAdapter { (control, fake) =>
+        val raw =
+          """{"port":9999,"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/x"}}],"responses":[{"is":{"statusCode":204}}]}]}"""
+        for
+          sE        <- control.provision(MockSource.Json(raw)).either
+          posted    <- fake.posted.get
+          malformed <- control.provision(MockSource.Json("not json")).either
+        yield
+          val body = posted.headOption.getOrElse("")
+          assertTrue(
+            sE.isRight,
+            body.contains("\"recordRequests\":true"),
+            FakeRift.portOf(body).contains(portOf(sE.toOption.get.head.baseUri)),
+            !body.contains("9999"), // advisory port overridden by the pool port
+            malformed.swap.toOption.exists {
+              case MockError.InvalidDefinition(_) => true
+              case _                              => false
+            }
+          )
+      }
+    },
+    test("received surfaces a malformed imposter view as a CommunicationError") {
+      withAdapter { (control, fake) =>
+        for
+          sE   <- control.provision(pingSource).either
+          s     = sE.toOption.get.head
+          _    <- fake.setView(portOf(s.baseUri), "this is not json")
+          recv <- control.received(s).either
+        yield assertTrue(recv.swap.toOption.exists {
+          case MockError.CommunicationError(_) => true
+          case _                               => false
+        })
+      }
+    },
+    test("a non-2xx admin response surfaces as a typed CommunicationError, not a swallowed success") {
+      withAdapter { (control, fake) =>
+        for
+          _ <- fake.failProvision.set(true)
+          e <- control.provision(pingSource).either
+        yield assertTrue(
+          e.isLeft,
+          e.swap.toOption.exists {
+            case MockError.CommunicationError(msg) => msg.contains("400")
+            case _                                 => false
+          }
+        )
+      }
+    }
+  ).provide(Client.default, Provisioning.live) @@ TestAspect.withLiveClock

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -13,6 +13,14 @@ object RiftMockControlSpec extends ZIOSpecDefault:
   )
   private val pingSource = MockSource.Dsl(MockSpec(List(pingRule)))
 
+  // A full Rift imposter document with backend-specific `_rift` extensions — the
+  // kind of full-fidelity spec the native escape hatch exists for.
+  private val nativeImposter =
+    """{"port":9999,"protocol":"http",
+      | "stubs":[{"predicates":[{"equals":{"path":"/native"}}],
+      |           "responses":[{"is":{"statusCode":200,"body":"native!"}}]}],
+      | "_rift":{"script":{"engine":"rhai","code":"200"}}}""".stripMargin
+
   private def portOf(baseUri: String): Int = baseUri.substring(baseUri.lastIndexOf(':') + 1).toInt
 
   /**
@@ -169,19 +177,108 @@ object RiftMockControlSpec extends ZIOSpecDefault:
         )
       }
     },
-    test("advertises no capabilities; accessors fail fast; native specs unsupported") {
+    test("advertises no capabilities; every accessor fails fast") {
       withAdapter { (control, _) =>
-        for
-          faultsE <- control.faults.either
-          nativeE <- control.provisionNative(new NativeSpec[Backend] {}).either
+        for faultsE <- control.faults.either
         yield assertTrue(
           control.capabilities.isEmpty,
-          faultsE == Left(Unsupported(Capability.Faults, "rift")),
-          nativeE.swap.toOption.exists {
-            case MockError.InvalidDefinition(_) => true
-            case _                              => false
-          }
+          faultsE == Left(Unsupported(Capability.Faults, "rift"))
         )
+      }
+    },
+    test("provisionNative(Rift) stands up a full-fidelity space (stubs + _rift) on our pooled port") {
+      withAdapter { (control, fake) =>
+        for
+          sE     <- control.provisionNative(NativeSpec.Rift(nativeImposter)).either
+          posted <- fake.posted.get
+        yield
+          val space = sE.toOption.get.head
+          val body  = posted.headOption.getOrElse("")
+          val req   = HttpRequest(Method.Get, "http://sut/")
+          assertTrue(
+            sE.isRight,
+            body.contains("\"_rift\""),                            // full-fidelity: _rift extensions preserved
+            body.contains("/native"),                              // the native stub preserved
+            body.contains("\"recordRequests\":true"),              // forced on so received() works
+            FakeRift.portOf(body).contains(portOf(space.baseUri)), // our pool port, not the spec's 9999
+            !body.contains("9999"),
+            space.inject(req) == req // isolation: identity inject like a portable space
+          )
+      }
+    },
+    test("a natively-provisioned space participates in received and is space-local on destroy") {
+      withAdapter { (control, fake) =>
+        for
+          sE  <- control.provisionNative(NativeSpec.Rift(nativeImposter)).either
+          s    = sE.toOption.get.head
+          port = portOf(s.baseUri)
+          _ <- fake.setView(
+                 port,
+                 s"""{"port":$port,"requests":[{"method":"GET","path":"/native","headers":{},"body":null}]}"""
+               )
+          recvE    <- control.received(s).either
+          destroyE <- control.destroy(s).either
+          deleted  <- fake.deletedPorts.get
+          globals  <- fake.globalDeletes.get
+        yield assertTrue(
+          recvE == Right(List(RecordedRequest(Method.Get, "/native", Map.empty, None))),
+          destroyE.isRight,
+          deleted == Chunk(port), // space-local: only this imposter
+          globals == 0            // never the global reset
+        )
+      }
+    },
+    test("native spaces isolate: two get distinct ports; destroy(A) leaves B") {
+      withAdapter { (control, _) =>
+        for
+          aE    <- control.provisionNative(NativeSpec.Rift(nativeImposter)).either
+          bE    <- control.provisionNative(NativeSpec.Rift(nativeImposter)).either
+          a      = aE.toOption.get.head
+          b      = bE.toOption.get.head
+          _     <- control.destroy(a).either
+          recvB <- control.received(b).either
+          recvA <- control.received(a).either
+        yield assertTrue(
+          a.baseUri != b.baseUri,
+          recvB.isRight,
+          recvA == Left(MockError.SpaceNotFound(a.id))
+        )
+      }
+    },
+    test("provisionNative rejects a non-Rift (WireMock) spec with InvalidDefinition") {
+      withAdapter { (control, _) =>
+        for e <- control.provisionNative(NativeSpec.WireMock("{}")).either
+        yield assertTrue(e.swap.toOption.exists {
+          case MockError.InvalidDefinition(_) => true
+          case _                              => false
+        })
+      }
+    },
+    test("a native space participates in overlays with stable rule ids (native stub is counted)") {
+      withAdapter { (control, fake) =>
+        for
+          sE    <- control.provisionNative(NativeSpec.Rift(nativeImposter)).either       // native stub -> [r1]
+          s      = sE.toOption.get.head
+          port   = portOf(s.baseUri)
+          baseE <- control.addRule(s, pingRule, Priority.Base).either                    // r2 -> index 1 -> [r1, r2]
+          ovE   <- control.addRule(s, pingRule, Priority.Overlay).either                 // r3 -> index 0 -> [r3, r1, r2]
+          rmE   <- ZIO.fromEither(baseE).flatMap(id => control.removeRule(s, id)).either // remove r2
+          calls <- fake.stubCalls.get
+        yield assertTrue(
+          baseE == Right(RuleId("r2")), // only holds if the native imposter's 1 stub was counted
+          ovE == Right(RuleId("r3")),
+          rmE.isRight,
+          calls.contains(s"DELETE $port/2") // r2 shifted to index 2 by the overlay insert
+        )
+      }
+    },
+    test("provisionNative(Rift) with malformed JSON fails with InvalidDefinition") {
+      withAdapter { (control, _) =>
+        for e <- control.provisionNative(NativeSpec.Rift("not json")).either
+        yield assertTrue(e.swap.toOption.exists {
+          case MockError.InvalidDefinition(_) => true
+          case _                              => false
+        })
       }
     },
     test("a raw JSON source is provisioned with our port + recordRequests forced; malformed raw is InvalidDefinition") {

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
@@ -1,0 +1,135 @@
+package zio.bdd.mock.rift
+
+import zio.bdd.mock.*
+import zio.json.ast.Json
+import zio.test.*
+
+object RiftProtocolSpec extends ZIOSpecDefault:
+
+  private def field(j: Json, k: String): Option[Json] = j match
+    case o: Json.Obj => o.fields.toMap.get(k)
+    case _           => None
+
+  extension (j: Json) private def /(k: String): Json = field(j, k).getOrElse(Json.Null)
+  private def arr(j: Json): List[Json] = j match
+    case Json.Arr(es) => es.toList
+    case _            => Nil
+
+  private val pingRule = MockRule(
+    `match` = RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+    respond = ResponseDef(status = 200, headers = Map("Content-Type" -> "text/plain"), body = Body.Text("pong"))
+  )
+
+  def spec = suite("RiftProtocol (canonical <-> Mountebank)")(
+    test("imposter carries port, http protocol, recordRequests, and one stub per rule") {
+      val j = RiftProtocol.imposter(4545, "ping", List(pingRule))
+      assertTrue(
+        j / "port" == Json.Num(4545),
+        j / "protocol" == Json.Str("http"),
+        j / "recordRequests" == Json.Bool(true),
+        arr(j / "stubs").size == 1
+      )
+    },
+    test("an exact path + method rule becomes equals predicates and an `is` response") {
+      val stub       = RiftProtocol.stub(pingRule)
+      val preds      = arr(stub / "predicates")
+      val methodPred = preds.find(p => (p / "equals" / "method") != Json.Null)
+      val pathPred   = preds.find(p => (p / "equals" / "path") != Json.Null)
+      val isResp     = arr(stub / "responses").head / "is"
+      assertTrue(
+        methodPred.exists(_ / "equals" / "method" == Json.Str("GET")),
+        pathPred.exists(_ / "equals" / "path" == Json.Str("/ping")),
+        isResp / "statusCode" == Json.Num(200),
+        isResp / "body" == Json.Str("pong"),
+        isResp / "headers" / "Content-Type" == Json.Str("text/plain")
+      )
+    },
+    test("a regex path becomes a matches predicate; a template path is anchored regex") {
+      val regex = RiftProtocol.stub(pingRule.copy(`match` = RequestMatch(path = PathMatch.Regex("/u/.*"))))
+      val tmpl  = RiftProtocol.stub(pingRule.copy(`match` = RequestMatch(path = PathMatch.Template("/users/{id}"))))
+      assertTrue(
+        arr(regex / "predicates").head / "matches" / "path" == Json.Str("/u/.*"),
+        arr(tmpl / "predicates").head / "matches" / "path" == Json.Str("^/users/[^/]+$")
+      )
+    },
+    test("a response delay becomes a _behaviors.wait in milliseconds") {
+      import zio.*
+      val withDelay = RiftProtocol.response(ResponseDef(status = 201, delay = Some(50.millis)))
+      assertTrue(
+        withDelay / "is" / "statusCode" == Json.Num(201),
+        withDelay / "_behaviors" / "wait" == Json.Num(50)
+      )
+    },
+    test("PathMatch.Any emits no path predicate") {
+      val stub = RiftProtocol.stub(pingRule.copy(`match` = RequestMatch(method = Some(Method.Post))))
+      val keys =
+        arr(stub / "predicates").map(p => p match { case o: Json.Obj => o.fields.map(_._1).toSet; case _ => Set.empty })
+      assertTrue(arr(stub / "predicates").size == 1, keys.head == Set("equals"))
+    },
+    test("parseRecorded reads the requests[] of a GET imposter view") {
+      val view =
+        """{"port":4545,"requests":[
+          |  {"method":"GET","path":"/ping","headers":{"Host":"x"},"body":null},
+          |  {"method":"POST","path":"/echo","body":"hi"}
+          |]}""".stripMargin
+      val parsed = RiftProtocol.parseRecorded(view)
+      assertTrue(
+        parsed == Right(
+          List(
+            RecordedRequest(Method.Get, "/ping", Map("Host" -> "x"), None),
+            RecordedRequest(Method.Post, "/echo", Map.empty, Some("hi"))
+          )
+        )
+      )
+    },
+    test("response body kinds: Empty omits body; Json sets body; Base64 sets _mode binary") {
+      val empty = RiftProtocol.response(ResponseDef(body = Body.Empty))
+      val json  = RiftProtocol.response(ResponseDef(body = Body.Json("""{"a":1}""")))
+      val b64   = RiftProtocol.response(ResponseDef(body = Body.Base64("YQ==")))
+      assertTrue(
+        field(empty / "is", "body").isEmpty,
+        json / "is" / "body" == Json.Str("""{"a":1}"""),
+        b64 / "is" / "body" == Json.Str("YQ=="),
+        b64 / "is" / "_mode" == Json.Str("binary")
+      )
+    },
+    test("query/header/body matchers map to their Mountebank operators") {
+      val rule = MockRule(
+        `match` = RequestMatch(
+          query = Map("q" -> ValueMatch.Equals("1")),
+          headers = Map("H" -> ValueMatch.Contains("x")),
+          body = Some(BodyMatch.Matches("ab.*"))
+        ),
+        respond = ResponseDef()
+      )
+      val preds = arr(RiftProtocol.stub(rule) / "predicates")
+      assertTrue(
+        preds.exists(p => p / "equals" / "query" / "q" == Json.Str("1")),
+        preds.exists(p => p / "contains" / "headers" / "H" == Json.Str("x")),
+        preds.exists(p => p / "matches" / "body" == Json.Str("ab.*"))
+      )
+    },
+    test("a JsonPath body matcher emits a jsonpath selector with an equals body") {
+      val rule = MockRule(RequestMatch(body = Some(BodyMatch.JsonPath("$.id", Some("7")))), ResponseDef())
+      val pred = arr(RiftProtocol.stub(rule) / "predicates").head
+      assertTrue(
+        pred / "jsonpath" / "selector" == Json.Str("$.id"),
+        pred / "equals" / "body" == Json.Str("7")
+      )
+    },
+    test("parseRecorded fails on malformed JSON; imposterFromRaw rejects a non-object document") {
+      assertTrue(
+        RiftProtocol.parseRecorded("not json").isLeft,
+        RiftProtocol.imposterFromRaw(1, "x", "[1,2,3]").isLeft
+      )
+    },
+    test("imposterFromRaw forces our port and recordRequests while keeping stubs") {
+      val raw           = """{"port":9999,"protocol":"http","stubs":[{"predicates":[],"responses":[]}]}"""
+      val Right((j, n)) = RiftProtocol.imposterFromRaw(4600, "json", raw): @unchecked
+      assertTrue(
+        j / "port" == Json.Num(4600),
+        j / "recordRequests" == Json.Bool(true),
+        n == 1
+      )
+    }
+  )


### PR DESCRIPTION
Milestone **M1 (Usable Mocking)** — the portable `MockControl` SPI plus the default Rift adapter, ready for use end-to-end. Promotes `epic/m1-usable-mocking` (rebased onto current `master`).

## What's in M1
- **#110** — `MockControl` core port + canonical model (backend-neutral).
- **#111** — `MockSource` + provisioning (dsl/json/resource/file/dir, auto-port; the fixed-port trap).
- **#112** — portable mock DSL builders + raw/native escape hatches.
- **#118** — capability model + fail-fast negotiation (`require(c*)`).
- **#113** — Rift adapter (Mountebank-compatible) over the container/subprocess backend, + a real-container CI job.
- **#119** — native escape hatch `provisionNative[B]` (backend-typed, full-fidelity, honours lifecycle/isolation).
- **#114** — `MockSteps[R,S]` mixin + recorded-request assertion steps.
- **#115** — `MockFixtures` feature/scenario `Scoped` layers + tag-driven `@mock(...)` setup.
- **#116** — overlay + mutation helpers (`MockOverlay`: scoped overlay, targeted/wholesale replace).
- **#117** — `MockSpace.inject` + SUT base-URL injection (`SutClient`) + the three isolation-invariant tests.

## Verification
- Full suite green on the rebased epic: **751 tests** (mock + gherkin + core + rift), 0 failures, scalafmt clean.
- CI runs `build` (hermetic) + a real-container `rift-it` job (testcontainers against `zainalpour/rift-proxy:v0.2.0`).

## Notes
- Surfaced and reported two upstream Rift issues along the way: keep-alive teardown (EtaCassiopeia/rift#207, fixed in v0.2.0, now pinned) and single-port deployment ergonomics (EtaCassiopeia/rift#202 / #212).
- Deferred to later milestones: WireMock adapter + native Java-builder spec (M2/#122), Correlated isolation mode wiring (#123), capability operations (M3).

Closes #110, #111, #112, #113, #114, #115, #116, #117, #118, #119