### PR TITLE
feat: flag-driven mock selection in hooks (OpenFeature matrix)

### DIFF
--- a/core/src/main/scala/zio/bdd/mock/fixtures/FlagReader.scala
+++ b/core/src/main/scala/zio/bdd/mock/fixtures/FlagReader.scala
@@ -1,0 +1,24 @@
+package zio.bdd.mock.fixtures
+
+import zio.*
+import zio.bdd.gherkin.ScenarioMetadata
+
+/**
+ * Reads the feature flag that selects which mock a scenario deploys (see
+ * [[MockFixtures.byFlag]]). A narrow seam, deliberately free of any
+ * feature-flag SDK: zio-openfeature already depends on zio-bdd (its conformance
+ * suite), so zio-bdd must not depend back on it. An OpenFeature-backed reader
+ * lives in the zio-openfeature project and plugs in here; zio-bdd ships
+ * [[fromMetadata]].
+ */
+trait FlagReader:
+  /** The flag's string value, or `None` if it is not set. */
+  def getString(flag: String): UIO[Option[String]]
+
+object FlagReader:
+  /**
+   * Reads the value carried by the scenario's `@flags(k=v)` matrix tag
+   * (`meta.flagValues`) — the in-framework flag source, no SDK required.
+   */
+  def fromMetadata(meta: ScenarioMetadata): FlagReader = new FlagReader:
+    def getString(flag: String): UIO[Option[String]] = ZIO.succeed(meta.flagValues.get(flag))

--- a/core/src/main/scala/zio/bdd/mock/fixtures/MockFixtures.scala
+++ b/core/src/main/scala/zio/bdd/mock/fixtures/MockFixtures.scala
@@ -51,6 +51,39 @@ object MockFixtures:
       resolve(MockTag.extract(meta.tags), catalog).flatMap(provisionScoped).mapError(asThrowable)
     }
 
+  /**
+   * Flag-driven scenario fixtures: deploy the single catalog entry named by the
+   * value of `flag`, read through `reader` (e.g. [[FlagReader.fromMetadata]]
+   * over the scenario's `@flags(k=v)` matrix). Composes with the @flags
+   * expansion so one tagged scenario exercises each branch against its matching
+   * mock. Fresh per scenario and reverting; fails the scenario at setup if the
+   * flag is unset or its value names no catalog entry.
+   */
+  def byFlag(
+    reader: FlagReader,
+    flag: String,
+    catalog: Map[String, MockSource]
+  ): ZLayer[MockControl, Throwable, MockFixture] =
+    ZLayer.scoped {
+      resolveByFlag(reader, flag, catalog).flatMap(source => provisionScoped(List(source))).mapError(asThrowable)
+    }
+
+  private def resolveByFlag(
+    reader: FlagReader,
+    flag: String,
+    catalog: Map[String, MockSource]
+  ): IO[MockError, MockSource] =
+    reader.getString(flag).flatMap {
+      case None =>
+        // The reader returned no value — for FlagReader.fromMetadata that means no
+        // @flags($flag=...) tag; an external reader may have its own reason.
+        ZIO.fail(MockError.InvalidDefinition(s"flag '$flag' resolved to no value (e.g. no @flags($flag=...) tag)"))
+      case Some(value) =>
+        ZIO
+          .fromOption(catalog.get(value))
+          .orElseFail(MockError.InvalidDefinition(s"flag $flag=$value: no catalog entry named '$value'"))
+    }
+
   // Provision each source as its own scoped acquisition, so a failure partway
   // through still tears down the spaces already created (each registers its own
   // finalizer in the scope). The scope destroys ONLY these spaces — never a

--- a/core/src/test/scala/zio/bdd/mock/fixtures/FlagDrivenMockSpec.scala
+++ b/core/src/test/scala/zio/bdd/mock/fixtures/FlagDrivenMockSpec.scala
@@ -1,0 +1,150 @@
+package zio.bdd.mock.fixtures
+
+import zio.*
+import zio.bdd.core.step.ZIOSteps
+import zio.bdd.gherkin.*
+import zio.bdd.mock.*
+import zio.schema.{DeriveSchema, Schema}
+import zio.test.*
+
+object FlagDrivenMockSpec extends ZIOSpecDefault:
+
+  // A MockControl whose provisioned space is named after the source it deployed,
+  // so a test can read back WHICH catalog entry a flag selected. Tracks live and
+  // destroyed spaces to prove the fixture reverts.
+  private final case class TState(live: Set[String], destroyed: List[String])
+  private object TState:
+    val init: TState = TState(Set.empty, Nil)
+
+  private final class TestControl(ref: Ref[TState]) extends MockControl:
+    def backendName: String           = "test"
+    def capabilities: Set[Capability] = Set.empty
+
+    def provision(source: MockSource): IO[MockError, List[MockSpace]] =
+      source match
+        case MockSource.Json(name) =>
+          ref.update(s => s.copy(live = s.live + name)).as(List(MockSpace(s"mock://$name", identity, SpaceId(name))))
+        case other =>
+          ZIO.fail(MockError.InvalidDefinition(s"unsupported source: $other"))
+
+    def destroy(space: MockSpace): IO[MockError, Unit] =
+      ref.update(s => s.copy(live = s.live - space.id.value, destroyed = s.destroyed :+ space.id.value))
+
+    def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+      ZIO.fail(MockError.InvalidDefinition("n/a"))
+    def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] = ZIO.succeed(RuleId("r"))
+    def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit]                        = ZIO.unit
+    def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit]           = ZIO.unit
+    def received(space: MockSpace): IO[MockError, List[RecordedRequest]]                     = ZIO.succeed(Nil)
+    def faults: IO[Unsupported, Faults]                                                      = ZIO.fail(Unsupported(Capability.Faults, backendName))
+    def scenarios: IO[Unsupported, StatefulScenarios]                                        = ZIO.fail(Unsupported(Capability.StatefulScenarios, backendName))
+    def stateInspection: IO[Unsupported, StateInspection] =
+      ZIO.fail(Unsupported(Capability.StateInspection, backendName))
+    def scripting: IO[Unsupported, Scripting]     = ZIO.fail(Unsupported(Capability.Scripting, backendName))
+    def proxyRecord: IO[Unsupported, ProxyRecord] = ZIO.fail(Unsupported(Capability.ProxyRecord, backendName))
+    def templating: IO[Unsupported, Templating]   = ZIO.fail(Unsupported(Capability.Templating, backendName))
+
+  private val catalog: Map[String, MockSource] =
+    Map("stripe" -> MockSource.Json("stripe"), "adyen" -> MockSource.Json("adyen"))
+
+  private def meta(flags: (String, String)*): ScenarioMetadata =
+    ScenarioMetadata("scenario", Nil, None, None, flags.toMap)
+
+  // Deploy `reader`-selected fixture, returning (ids live during the scope, the
+  // full post-scope state) so a test sees both the selection and the revert.
+  private def deploy(
+    reader: FlagReader,
+    ref: Ref[TState]
+  ): ZIO[Any, Throwable, (List[String], TState)] =
+    for
+      during <- ZIO.scoped {
+                  (ZLayer.succeed[MockControl](TestControl(ref)) >>> MockFixtures.byFlag(
+                    reader,
+                    "payments.provider",
+                    catalog
+                  )).build
+                    .map(_.get[MockFixture].spaces.map(_.id.value))
+                }
+      after <- ref.get // read AFTER the scope closed, so the revert is visible
+    yield (during, after)
+
+  final case class TestState()
+  object TestState:
+    given Schema[TestState] = DeriveSchema.gen[TestState]
+
+  // A suite whose flag-aware setup deploys the mock the @flags(payments.provider=..)
+  // value selects. The hook records (this branch's flag value -> the backend it
+  // actually deployed), so the test pins the per-branch pairing — not just that
+  // both backends appeared (which a stripe<->adyen swap would still satisfy).
+  private class PaymentsSuite(control: MockControl, recorder: Ref[Set[(String, String)]])
+      extends ZIOSteps[MockFixture, TestState]:
+    override def flagLayer(meta: ScenarioMetadata, flags: Map[String, String]): ZLayer[Any, Throwable, MockFixture] =
+      ZLayer.succeed(control) >>> MockFixtures.byFlag(FlagReader.fromMetadata(meta), "payments.provider", catalog)
+
+    beforeScenario { (meta: ScenarioMetadata) =>
+      ZIO.serviceWithZIO[MockFixture](fx =>
+        recorder.update(_ + (meta.flagValues("payments.provider") -> fx.spaces.head.id.value))
+      )
+    }
+
+    When("the active payments mock is recorded")(ZIO.unit)
+
+  def spec = suite("FlagDrivenMock")(
+    test("byFlag deploys the catalog entry the flag value selects, then reverts on scope close") {
+      for
+        ref         <- Ref.make(TState.init)
+        result      <- deploy(FlagReader.fromMetadata(meta("payments.provider" -> "stripe")), ref)
+        (during, st) = result
+      yield assertTrue(
+        during == List("stripe"),      // selected the 'stripe' catalog entry, not 'adyen'
+        st.destroyed == List("stripe") // reverted exactly that space on scope close
+      )
+    },
+    test("byFlag reads through any FlagReader (an OpenFeature-style reader), not just metadata") {
+      // Stand-in for an OpenFeature getString-backed reader living in zio-openfeature.
+      val openFeatureStyle = new FlagReader:
+        private val backing                              = Map("payments.provider" -> "adyen")
+        def getString(flag: String): UIO[Option[String]] = ZIO.succeed(backing.get(flag))
+      for
+        ref         <- Ref.make(TState.init)
+        result      <- deploy(openFeatureStyle, ref)
+        (during, st) = result
+      yield assertTrue(during == List("adyen"), st.destroyed == List("adyen"))
+    },
+    test("byFlag fails when the flag is unset on the scenario") {
+      for
+        ref <- Ref.make(TState.init)
+        res <- deploy(FlagReader.fromMetadata(meta()), ref).either
+      yield assert(res.left.toOption.map(_.getMessage).getOrElse(""))(Assertion.containsString("resolved to no value"))
+    },
+    test("byFlag fails when the flag value names no catalog entry") {
+      for
+        ref <- Ref.make(TState.init)
+        res <- deploy(FlagReader.fromMetadata(meta("payments.provider" -> "paypal")), ref).either
+      yield assert(res.left.toOption.map(_.getMessage).getOrElse(""))(Assertion.containsString("no catalog entry"))
+    },
+    test("a single @flags(payments.provider=stripe)/@flags(...=adyen) scenario mocks each branch correctly") {
+      for
+        ref      <- Ref.make(TState.init)
+        recorder <- Ref.make(Set.empty[(String, String)])
+        suite     = new PaymentsSuite(TestControl(ref), recorder)
+        scenario = Scenario(
+                     "charge a payment",
+                     List("flags(payments.provider=stripe)", "flags(payments.provider=adyen)"),
+                     List(Step(StepType.WhenStep, "the active payments mock is recorded", None, None, None)),
+                     Some("payments.feature"),
+                     Some(1)
+                   )
+        results <- suite
+                     .run(List(Feature("Payments", Nil, List(scenario))))
+                     .provideEnvironment(ZEnvironment[MockFixture](MockFixture(Nil)))
+        deployed  <- recorder.get
+        destroyed <- ref.get.map(_.destroyed)
+      yield assertTrue(
+        results.head.scenarioResults.length == 2,        // the @flags matrix ran both branches
+        results.head.scenarioResults.forall(_.isPassed), // each branch passed
+        deployed == Set("stripe" -> "stripe", "adyen" -> "adyen"), // each branch deployed ITS OWN flag's backend
+        destroyed.sorted == List("adyen", "stripe") // and each reverted its own space
+      )
+    }
+  )


### PR DESCRIPTION
Flag-driven mock selection: read a feature flag in per-scenario setup and deploy the matching imposter/fixture, composing with the existing `@flags(k=v)` matrix.

- **`MockFixtures.byFlag(reader, flag, catalog)`** — a scoped `ZLayer[MockControl, Throwable, MockFixture]` that deploys the single catalog entry named by the flag's value (read via `reader.getString(flag)`). The flag-keyed sibling of `scenario(@mock tags)`: reuses `provisionScoped` (fresh per scenario, §5.9 destroy-only-own, log-and-continue teardown). Fails loudly if the flag is unset or its value names no catalog entry.
- **`FlagReader`** — a tiny SPI (`getString(flag): UIO[Option[String]]`). zio-bdd ships `FlagReader.fromMetadata(meta)` (reads the `@flags` value from `meta.flagValues`).

## No circular dependency
zio-openfeature's conformance suite already depends on `zio-bdd % Test`, so zio-bdd must **not** depend back on it. `FlagReader` is deliberately SDK-free — the OpenFeature-backed reader lives in the zio-openfeature repo and plugs in through this seam, keeping the dependency one-way.

## Testing
5 tests (Ref-backed `MockControl` whose space id = the deployed backend): byFlag selects the flag's entry + reverts; reads through an arbitrary (OpenFeature-style) `FlagReader` — proving the seam; fails on unset flag / unknown value. The acceptance is a real `ZIOSteps` suite — a scenario tagged `@flags(payments.provider=stripe)`+`@flags(...=adyen)` whose `flagLayer` deploys via byFlag; a `beforeScenario` hook records (flag value → deployed backend), asserting the **per-branch pairing** `{stripe→stripe, adyen→adyen}` (catches a swap, not just the set) and that each branch reverts its own space. A mutant that ignores the flag fails 4/5 tests.

Closes #120

Milestone: M1 (Epic B)