### PR TITLE
feat: MockControl TestAspects (withLatency/withImposter)

### DIFF
--- a/mock/src/main/scala/zio/bdd/mock/MockAspects.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockAspects.scala
@@ -1,0 +1,43 @@
+package zio.bdd.mock
+
+import zio.*
+import zio.test.{TestAspect, TestFailure, TestSuccess}
+
+/**
+ * `TestAspect`s that override a [[MockSpace]]'s behaviour for one test and
+ * auto-revert afterward, mirroring zio-openfeature's `TestFeatureProvider`
+ * delay/error aspects. Each is built on the scoped overlay ([[MockOverlay]],
+ * #116): rules are added at [[Priority.Overlay]] on enter and removed on exit,
+ * so the override is scoped to the aspected test — declare a base, override per
+ * scenario, auto-revert.
+ *
+ * Requires `MockControl & MockSpace` in the test environment.
+ */
+object MockAspects:
+
+  /** Add latency `d` to the space's responses for the duration of the test. */
+  def withLatency(d: Duration): TestAspect[Nothing, MockControl & MockSpace, Nothing, Any] =
+    overlay(MockRule(RequestMatch(), ResponseDef(delay = Some(d))))
+
+  /**
+   * Overlay `rules` (a scoped imposter) on the space for the duration of the
+   * test.
+   */
+  def withImposter(rules: MockRule*): TestAspect[Nothing, MockControl & MockSpace, Nothing, Any] =
+    overlay(rules*)
+
+  // Wrap the test in the scoped overlay: rules are added on enter and removed
+  // when the per-test scope closes. A setup failure becomes a defect so the
+  // aspect's error stays Nothing (and thus applies to any test).
+  private def overlay(rules: MockRule*): TestAspect[Nothing, MockControl & MockSpace, Nothing, Any] =
+    new TestAspect.PerTest[Nothing, MockControl & MockSpace, Nothing, Any]:
+      def perTest[R <: MockControl & MockSpace, E](
+        test: ZIO[R, TestFailure[E], TestSuccess]
+      )(implicit trace: Trace): ZIO[R, TestFailure[E], TestSuccess] =
+        ZIO.serviceWithZIO[MockSpace] { space =>
+          ZIO.scoped[R] {
+            MockOverlay
+              .scoped(space)(rules*)
+              .orDieWith(e => new RuntimeException(s"MockAspects setup failed: $e")) *> test
+          }
+        }

--- a/mock/src/test/scala/zio/bdd/mock/MockAspectsSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockAspectsSpec.scala
@@ -1,0 +1,112 @@
+package zio.bdd.mock
+
+import zio.*
+import zio.test.*
+
+object MockAspectsSpec extends ZIOSpecDefault:
+
+  // A MockControl recording each rule's id, definition, and priority on one
+  // space, so a test can read back what an aspect overlaid (and that it reverted).
+  private final case class RuleEntry(id: String, rule: MockRule, priority: Priority)
+  private final case class TState(nextId: Int, rules: List[RuleEntry])
+
+  private final class TestControl(ref: Ref[TState]) extends MockControl:
+    def backendName: String           = "test"
+    def capabilities: Set[Capability] = Set.empty
+
+    def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+      ref.modify { s =>
+        val id    = s"r${s.nextId}"
+        val entry = RuleEntry(id, rule, priority)
+        val rules = priority match
+          case Priority.Overlay => entry :: s.rules
+          case Priority.Base    => s.rules :+ entry
+        (RuleId(id), s.copy(nextId = s.nextId + 1, rules = rules))
+      }
+
+    def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit] =
+      ref.update(s => s.copy(rules = s.rules.filterNot(_.id == id.value)))
+
+    def provision(source: MockSource): IO[MockError, List[MockSpace]] = ZIO.succeed(Nil)
+    def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+      ZIO.fail(MockError.InvalidDefinition("n/a"))
+    def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit] = ZIO.unit
+    def destroy(space: MockSpace): IO[MockError, Unit]                             = ZIO.unit
+    def received(space: MockSpace): IO[MockError, List[RecordedRequest]]           = ZIO.succeed(Nil)
+    def faults: IO[Unsupported, Faults]                                            = ZIO.fail(Unsupported(Capability.Faults, backendName))
+    def scenarios: IO[Unsupported, StatefulScenarios]                              = ZIO.fail(Unsupported(Capability.StatefulScenarios, backendName))
+    def stateInspection: IO[Unsupported, StateInspection] =
+      ZIO.fail(Unsupported(Capability.StateInspection, backendName))
+    def scripting: IO[Unsupported, Scripting]     = ZIO.fail(Unsupported(Capability.Scripting, backendName))
+    def proxyRecord: IO[Unsupported, ProxyRecord] = ZIO.fail(Unsupported(Capability.ProxyRecord, backendName))
+    def templating: IO[Unsupported, Templating]   = ZIO.fail(Unsupported(Capability.Templating, backendName))
+
+  // Shared across a sub-suite (one control + space + the inspectable Ref) so a
+  // later test observes whether an earlier aspected test reverted. @@ sequential
+  // is load-bearing: without it the tests race on this shared Ref and the
+  // revert assertions become meaningless.
+  private def sharedFrom(init: TState): ZLayer[Any, Nothing, MockControl & MockSpace & Ref[TState]] =
+    ZLayer.fromZIOEnvironment {
+      Ref.make(init).map { ref =>
+        val space = MockSpace("mock://aspect", identity, SpaceId("aspect"))
+        ZEnvironment[MockControl](TestControl(ref)) ++ ZEnvironment(space) ++ ZEnvironment(ref)
+      }
+    }
+
+  private val rules: ZIO[Ref[TState], Nothing, List[RuleEntry]] = ZIO.serviceWithZIO[Ref[TState]](_.get).map(_.rules)
+
+  private val imposter  = MockRule(RequestMatch(path = PathMatch.Exact("/special")), ResponseDef(status = 503))
+  private val imposter2 = MockRule(RequestMatch(path = PathMatch.Exact("/other")), ResponseDef(status = 418))
+  private val baseRule  = MockRule(RequestMatch(path = PathMatch.Exact("/orders")), ResponseDef(status = 200))
+
+  def spec = suite("MockAspects")(
+    suite("scoped overlay on an empty base")(
+      test("withLatency overlays a catch-all delayed rule for the duration of the aspected test") {
+        for entries <- rules
+        yield assertTrue(
+          entries.exists(e =>
+            e.priority == Priority.Overlay &&
+              e.rule.`match` == RequestMatch() &&       // catch-all
+              e.rule.respond.delay.contains(200.millis) // the requested latency
+          )
+        )
+      } @@ MockAspects.withLatency(200.millis),
+      test("the latency rule is reverted after the aspected test (no latency leaks to the next)") {
+        for entries <- rules
+        yield assertTrue(entries.forall(_.rule.respond.delay.isEmpty)) // withLatency above reverted on exit
+      },
+      test("withImposter overlays all of the given rules for the duration of the aspected test") {
+        for entries <- rules
+        yield assertTrue(
+          entries.count(_.priority == Priority.Overlay) == 2,
+          entries.exists(_.rule == imposter),
+          entries.exists(_.rule == imposter2)
+        )
+      } @@ MockAspects.withImposter(imposter, imposter2),
+      test("the imposter rules are reverted after the aspected test") {
+        for entries <- rules
+        yield assertTrue(entries.isEmpty) // every overlay above reverted; back to the empty base
+      },
+      test("the overlay reverts even when the aspected test FAILS") {
+        for entries <- rules
+        yield assertTrue(entries.exists(_.rule == imposter)) && assertTrue(false) // deliberately fail under the aspect
+      } @@ MockAspects.withImposter(imposter) @@ TestAspect.failing,
+      test("a failing aspected test still reverted its overlay (revert is outcome-independent)") {
+        for entries <- rules
+        yield assertTrue(entries.isEmpty)
+      }
+    ).provideShared(sharedFrom(TState(0, Nil))) @@ TestAspect.sequential,
+    suite("scoped overlay on top of a base rule")(
+      test("the overlay shadows the base rule during the aspected test, base still present") {
+        for entries <- rules
+        yield assertTrue(
+          entries.exists(e => e.priority == Priority.Overlay && e.rule.respond.delay.contains(137.millis)),
+          entries.exists(_.rule == baseRule) // the declared base is untouched while overlaid
+        )
+      } @@ MockAspects.withLatency(137.millis),
+      test("after the aspected test the overlay is gone and exactly the base rule remains") {
+        for entries <- rules
+        yield assertTrue(entries.map(_.rule) == List(baseRule)) // reverted TO the base, not to empty
+      }
+    ).provideShared(sharedFrom(TState(1, List(RuleEntry("base0", baseRule, Priority.Base))))) @@ TestAspect.sequential
+  )


### PR DESCRIPTION
Scoped, auto-reverting `TestAspect`s for `MockControl`, mirroring zio-openfeature's `TestFeatureProvider` delay/error aspects — declare a base, override per scenario, auto-revert.

- **`MockAspects.withLatency(d)`** — overlays a catch-all delayed rule on the env's `MockSpace` for the aspected test.
- **`MockAspects.withImposter(rules*)`** — overlays the given rules (a scoped imposter) for the aspected test.

Both are `TestAspect[Nothing, MockControl & MockSpace, Nothing, Any]` built on the scoped overlay (#116): a `TestAspect.PerTest` wraps the test in `ZIO.scoped { MockOverlay.scoped(space)(rules*) *> test }`, so rules are added at `Priority.Overlay` on enter and removed when the per-test scope closes — reverting on **success or failure**. A setup failure is promoted to a defect so the aspect's error channel stays `Nothing` (applies to any test). No build change: zio-test is already a compile dependency of the mock module.

True latency-as-response-decoration is the Faults capability (M3, #128); this aspect's job is the scoped delay rule + revert.

## Testing
8 tests (Ref-backed `MockControl` recording id/rule/priority), two shared-control sub-suites under `@@ sequential`:
- empty base: latency present-during / reverted-after; multi-rule imposter present-during / reverted-after; **revert even when the aspected test FAILS** (`@@ failing`).
- on top of a base rule: the overlay shadows the base during the test; afterward exactly the base remains (reverted **to** the base, not to empty).

Closes #121

Milestone: M1 (Epic B)