### PR TITLE
build: bump rift-proxy image to v0.3.0

### DIFF
--- a/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
@@ -17,10 +17,10 @@ import org.testcontainers.containers.wait.strategy.Wait
  */
 object Rift:
 
-  // Pinned to v0.2.0: the first release where DELETE /imposters/:port tears down
-  // existing keep-alive connections, so a destroyed imposter stops serving even
-  // a pooled client (EtaCassiopeia/rift#207).
-  val DefaultImage: String     = "zainalpour/rift-proxy:v0.2.0"
+  // Pinned to v0.3.0. Floor is v0.2.0: the first release where DELETE
+  // /imposters/:port tears down existing keep-alive connections, so a destroyed
+  // imposter stops serving even a pooled client (EtaCassiopeia/rift#207).
+  val DefaultImage: String     = "zainalpour/rift-proxy:v0.3.0"
   val DefaultAdminPort: Int    = 2525
   val DefaultImposterBase: Int = 4545
   val DefaultPoolSize: Int     = 16


### PR DESCRIPTION
Bumps the pinned Rift adapter image from `zainalpour/rift-proxy:v0.2.0` to `v0.3.0` (single source of truth: `Rift.DefaultImage`; CI's `rift-it` job stands up `Rift.managed()` which uses this constant).

- v0.2.0 stays the documented floor (rift#207: `DELETE /imposters/:port` tears down keep-alive connections, so a destroyed imposter stops serving even a pooled client). v0.3.0 is a superset.
- The v0.3.0 image pulls cleanly and the module compiles; the 29 non-container rift tests pass and `RiftContainerSpec` stays gated behind `RIFT_IT=1`.

## Verification
The real-container behaviour against v0.3.0 is verified by the **`rift-it` CI job** (ubuntu, real Docker socket). Local `RIFT_IT=1` couldn't run it — testcontainers can't resolve the Docker Desktop socket from the sandboxed JVM (`Could not find a valid Docker environment`), which is environmental and version-independent (the image itself pulls fine).