### PR TITLE
feat: WireMock adapter (in-process) with Correlated isolation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val mimaSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .aggregate(core, gherkin, mock, rift)
+  .aggregate(core, gherkin, mock, rift, wiremock)
   .settings(
     name                  := "zio-bdd-root",
     description           := "A ZIO-based BDD testing framework for Scala 3",
@@ -149,6 +149,22 @@ lazy val rift = (project in file("rift"))
       "dev.zio"      %% "zio-http"                   % "3.2.0",
       "dev.zio"      %% "zio-json"                   % "0.7.3",
       "com.dimafeng" %% "testcontainers-scala-core"  % "0.41.4"
+    ),
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
+    mimaPreviousArtifacts := Set.empty
+  )
+
+// WireMock adapter (#122): the in-process, pure-JVM, zero-Docker provider with
+// Correlated isolation by default. Implements the portable MockControl SPI over
+// an embedded WireMockServer. Depends on `mock`, never the reverse.
+lazy val wiremock = (project in file("wiremock"))
+  .dependsOn(mock)
+  .settings(
+    name := "zio-bdd-wiremock",
+    libraryDependencies ++= commonDependencies,
+    libraryDependencies ++= Seq(
+      "org.wiremock" % "wiremock" % "3.9.2"
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     // Not yet published as a 1.x artifact — no binary-compat baseline to check against.

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMock.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMock.scala
@@ -1,0 +1,70 @@
+package zio.bdd.mock.wiremock
+
+import zio.*
+import zio.bdd.mock.*
+
+import com.github.tomakehurst.wiremock.client.WireMock as WM
+import com.github.tomakehurst.wiremock.matching.StringValuePattern
+
+/**
+ * How a Correlated space tags its requests and matches them on the shared
+ * server. [[value]] is what [[MockSpace.inject]] stamps; [[matcher]] is what
+ * the space's stubs require, so only requests carrying this space's tag can
+ * match.
+ */
+final case class Correlation(
+  header: String,
+  value: SpaceId => String,
+  matcher: SpaceId => StringValuePattern
+)
+
+object Correlation:
+  /** Default: a dedicated `X-Mock-Space: <spaceId>` header, exact-matched. */
+  val spaceHeader: Correlation =
+    Correlation("X-Mock-Space", id => id.value, id => WM.equalTo(id.value))
+
+  /**
+   * Correlate by the W3C trace context the SUT already propagates: `inject`
+   * stamps a `traceparent` carrying the space's trace-id, and stubs match that
+   * trace-id (the span-id may vary request to request).
+   */
+  val traceparent: Correlation =
+    Correlation(
+      "traceparent",
+      id => s"00-${traceId(id)}-0000000000000001-01",
+      id => WM.matching(s"00-${traceId(id)}-[0-9a-f]{16}-[0-9a-f]{2}")
+    )
+
+  // A stable, W3C-shaped 32-hex trace-id derived from the space id. Four
+  // salted hashes fill the 32 hex so distinct ids don't collapse to the same
+  // repeated chunk (sequential space ids stay distinct).
+  private def traceId(id: SpaceId): String =
+    (0 until 4).map(i => f"${(id.value + ":" + i).hashCode & 0xffffffffL}%08x").mkString
+
+/**
+ * The in-process WireMock provider (#122). Pick an isolation mode and provide a
+ * [[Provisioning]]:
+ * {{{PortAllocator.layer >>> Provisioning.layer >>> WireMock.correlated()}}}
+ * Swapping `WireMock.correlated()` for a Rift layer is the "one-line provider
+ * swap" the portable suite relies on.
+ */
+object WireMock:
+  enum Mode:
+    case Correlated(correlation: Correlation)
+    case PerInstance
+
+  /**
+   * Correlated isolation (default): one shared server, header-tagged spaces.
+   */
+  def correlated(correlation: Correlation = Correlation.spaceHeader): ZLayer[Provisioning, Throwable, MockControl] =
+    layer(Mode.Correlated(correlation))
+
+  /**
+   * PerInstance isolation: a fresh server per space (use when the cost is
+   * acceptable).
+   */
+  val perInstance: ZLayer[Provisioning, Throwable, MockControl] =
+    layer(Mode.PerInstance)
+
+  def layer(mode: Mode): ZLayer[Provisioning, Throwable, MockControl] =
+    ZLayer.scoped(WireMockControl.make(mode))

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
@@ -1,0 +1,272 @@
+package zio.bdd.mock.wiremock
+
+import zio.*
+import zio.bdd.mock.*
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+
+import scala.jdk.CollectionConverters.*
+
+/**
+ * The WireMock adapter: implements the portable [[MockControl]] core port over
+ * an embedded WireMockServer — pure-JVM, zero-Docker.
+ *
+ * Correlated isolation (the default): every space shares one server; each of a
+ * space's stubs carries an `X-Mock-Space: <spaceId>` header matcher and
+ * `inject` stamps that header on the SUT's requests, so a request can only
+ * match (and be `received` by) its own space. `destroy` removes exactly that
+ * space's stubs — never `server.resetAll`. A request without the header matches
+ * nothing and is recorded by no space.
+ *
+ * PerInstance isolation (option): each space owns a fresh server on its own
+ * port, `inject == identity`, and `destroy` stops that server.
+ */
+private[wiremock] final case class WireMockControl(
+  mode: WireMock.Mode,
+  shared: Option[WireMockServer],
+  provisioning: Provisioning,
+  spaces: Ref[Map[SpaceId, WireMockControl.SpaceState]],
+  ids: Ref[Int]
+) extends MockControl:
+
+  import WireMockControl.SpaceState
+
+  def backendName: String           = "wiremock"
+  def capabilities: Set[Capability] = Set.empty
+
+  def provision(source: MockSource): IO[MockError, List[MockSpace]] =
+    for
+      sources <- provisioning.normalize(source)
+      created <- Ref.make(List.empty[MockSpace])
+      // Tear down any spaces already stood up if a later one fails, so a partial
+      // batch never orphans a started server or leaves half a source registered.
+      spaces <-
+        ZIO
+          .foreach(sources)(src => serveSpace(src).tap(s => created.update(s :: _)))
+          .onError(_ =>
+            created.get.flatMap(
+              ZIO.foreachDiscard(_)(s =>
+                destroy(s).catchAllCause(c => ZIO.logWarningCause("WireMock provision rollback: destroy failed", c))
+              )
+            )
+          )
+    yield spaces
+
+  def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+    spec match
+      // A native WireMock stub defines its own matching, so it always gets its
+      // own server (PerInstance) — correlation can't be grafted onto it.
+      case NativeSpec.WireMock(stubMappingJson) =>
+        for
+          id       <- freshSpaceId("native")
+          stub     <- ZIO.attempt(StubMapping.buildFrom(stubMappingJson)).mapError(e => MockError.InvalidDefinition(msg(e)))
+          server   <- WireMockControl.startServer.mapError(e => MockError.ProvisionFailed(msg(e)))
+          rulesRef <- Ref.make(Vector.empty[(RuleId, StubMapping)])
+          ruleId   <- freshRuleId
+          // Stop the server we just started if registration/tracking fails or is
+          // interrupted before it lands in `spaces` — otherwise it leaks.
+          space <- (ZIO
+                     .attempt(server.addStubMapping(stub))
+                     .zipRight(rulesRef.set(Vector(ruleId -> stub)))
+                     .mapError(e => MockError.CommunicationError(msg(e)))
+                     .zipRight(spaces.update(_.updated(id, SpaceState(server, ownsServer = true, None, rulesRef))))
+                     .as(MockSpace(server.baseUrl(), identity, id)))
+                     .onError(_ => stop(server))
+        yield List(space)
+      case NativeSpec.Rift(_) =>
+        ZIO.fail(MockError.InvalidDefinition("the WireMock adapter cannot provision a Rift native spec"))
+
+  def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+    withSpace(space)(st => registerRule(st, space.id, rule, priority))
+
+  def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit] =
+    withSpace(space) { st =>
+      st.rules.get.flatMap(_.find(_._1 == id) match
+        case None => ZIO.fail(MockError.RuleNotFound(space.id, id))
+        case Some((_, stub)) =>
+          ZIO
+            .attempt(st.server.removeStubMapping(stub))
+            .mapError(e => MockError.CommunicationError(msg(e)))
+            .zipRight(st.rules.update(_.filterNot(_._1 == id)))
+      )
+    }
+
+  def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit] =
+    withSpace(space) { st =>
+      for
+        current <- st.rules.getAndSet(Vector.empty)
+        _       <- removeStubs(st.server, current.map(_._2))
+        _       <- ZIO.foreachDiscard(rules)(r => registerRule(st, space.id, r, Priority.Base))
+      yield ()
+    }
+
+  def destroy(space: MockSpace): IO[MockError, Unit] =
+    withSpace(space) { st =>
+      for
+        current <- st.rules.get
+        _       <- removeStubs(st.server, current.map(_._2))
+        _       <- ZIO.when(st.ownsServer)(stop(st.server))
+        _       <- spaces.update(_ - space.id)
+      yield ()
+    }
+
+  def received(space: MockSpace): IO[MockError, List[RecordedRequest]] =
+    withSpace(space) { st =>
+      // Only the backend call is wrapped — a defect in the pure translation below
+      // must stay a defect, not get relabelled as a communication error.
+      ZIO
+        .attempt(st.server.getAllServeEvents.asScala.toList)
+        .mapError(e => MockError.CommunicationError(msg(e)))
+        .map(_.reverse.flatMap { ev =>
+          val req = ev.getRequest
+          val keep = st.correlation match
+            case Some(c) => Option(req.getHeader(c.header)).exists(h => c.matcher(space.id).`match`(h).isExactMatch)
+            case None    => true
+          Option.when(keep)(
+            WireMockTranslation.recorded(
+              req.getMethod.getName,
+              req.getUrl,
+              req.getHeaders.all.asScala.map(h => h.key.toLowerCase -> h.firstValue).toMap,
+              Option(req.getBodyAsString).filter(_.nonEmpty)
+            )
+          )
+        })
+    }
+
+  def faults: IO[Unsupported, Faults]                   = unsupported(Capability.Faults)
+  def scenarios: IO[Unsupported, StatefulScenarios]     = unsupported(Capability.StatefulScenarios)
+  def stateInspection: IO[Unsupported, StateInspection] = unsupported(Capability.StateInspection)
+  def scripting: IO[Unsupported, Scripting]             = unsupported(Capability.Scripting)
+  def proxyRecord: IO[Unsupported, ProxyRecord]         = unsupported(Capability.ProxyRecord)
+  def templating: IO[Unsupported, Templating]           = unsupported(Capability.Templating)
+
+  // Stop every server this adapter still owns — the layer's scope finalizer.
+  private[wiremock] def stopAll: UIO[Unit] =
+    for
+      snap <- spaces.get
+      _    <- ZIO.foreachDiscard(snap.values.filter(_.ownsServer))(st => stop(st.server))
+      _    <- ZIO.foreachDiscard(shared.toList)(stop)
+    yield ()
+
+  // ---------------------------------------------------------------------------
+
+  private def serveSpace(src: NormalizedSource): IO[MockError, MockSpace] =
+    for
+      rules    <- rulesOf(src)
+      id       <- freshSpaceId(src.name)
+      rulesRef <- Ref.make(Vector.empty[(RuleId, StubMapping)])
+      corr      = correlationOf
+      server   <- serverFor(id)
+      st        = SpaceState(server, ownsServer = corr.isEmpty, corr, rulesRef)
+      // If a rule fails mid-batch the space is never tracked, so destroy can
+      // never reach it: undo its stubs (and stop its own server) here, or they
+      // orphan on the shared server.
+      _ <- ZIO
+             .foreachDiscard(rules)(r => registerRule(st, id, r, Priority.Base))
+             .onError(_ => cleanupSpace(st))
+      _ <- spaces.update(_.updated(id, st))
+    yield MockSpace(server.baseUrl(), injectFor(id, corr), id)
+
+  // Best-effort teardown of a half-built (untracked) space.
+  private def cleanupSpace(st: SpaceState): UIO[Unit] =
+    for
+      rs <- st.rules.get
+      _  <- removeStubs(st.server, rs.map(_._2)).ignore
+      _  <- ZIO.when(st.ownsServer)(stop(st.server))
+    yield ()
+
+  private def registerRule(st: SpaceState, id: SpaceId, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+    for
+      ruleId <- freshRuleId
+      stub    = WireMockTranslation.stub(id, rule.copy(id = Some(ruleId)), priority, st.correlation)
+      _ <- ZIO
+             .attempt(st.server.addStubMapping(stub))
+             .mapError(e => MockError.CommunicationError(msg(e)))
+      _ <- st.rules.update(v => if priority == Priority.Overlay then (ruleId, stub) +: v else v :+ (ruleId, stub))
+    yield ruleId
+
+  private def removeStubs(server: WireMockServer, stubs: Vector[StubMapping]): IO[MockError, Unit] =
+    ZIO
+      .attempt(stubs.foreach(server.removeStubMapping))
+      .mapError(e => MockError.CommunicationError(msg(e)))
+
+  private def rulesOf(src: NormalizedSource): IO[MockError, List[MockRule]] =
+    src.payload match
+      case SourcePayload.Rules(rules) => ZIO.succeed(rules)
+      case SourcePayload.Raw(_) =>
+        ZIO.fail(
+          MockError.InvalidDefinition(
+            "a raw/native WireMock source must go through provisionNative(NativeSpec.WireMock)"
+          )
+        )
+
+  private def correlationOf: Option[Correlation] = mode match
+    case WireMock.Mode.Correlated(c) => Some(c)
+    case WireMock.Mode.PerInstance   => None
+
+  private def serverFor(id: SpaceId): IO[MockError, WireMockServer] = mode match
+    case WireMock.Mode.Correlated(_) => ZIO.succeed(shared.get)
+    case WireMock.Mode.PerInstance   => WireMockControl.startServer.mapError(e => MockError.ProvisionFailed(msg(e)))
+
+  private def injectFor(id: SpaceId, corr: Option[Correlation]): HttpRequest => HttpRequest =
+    corr match
+      case Some(c) => req => req.copy(headers = req.headers + (c.header -> c.value(id)))
+      case None    => identity
+
+  private def stop(server: WireMockServer): UIO[Unit] =
+    ZIO
+      .attempt(server.stop())
+      .catchAllCause(c => ZIO.logWarningCause("WireMock server stop failed", c))
+
+  private def freshRuleId: UIO[RuleId]                 = ids.updateAndGet(_ + 1).map(n => RuleId(s"r$n"))
+  private def freshSpaceId(name: String): UIO[SpaceId] = ids.updateAndGet(_ + 1).map(n => SpaceId(s"$name-$n"))
+
+  private def withSpace[A](space: MockSpace)(f: SpaceState => IO[MockError, A]): IO[MockError, A] =
+    spaces.get.flatMap(_.get(space.id) match
+      case Some(st) => f(st)
+      case None     => ZIO.fail(MockError.SpaceNotFound(space.id))
+    )
+
+  private def unsupported[A](c: Capability): IO[Unsupported, A] = ZIO.fail(Unsupported(c, backendName))
+
+  private def msg(t: Throwable): String =
+    def render(x: Throwable): String =
+      Option(x.getMessage).filter(_.nonEmpty).fold(x.getClass.getSimpleName)(m => s"${x.getClass.getSimpleName}: $m")
+    // Keep the root cause — WireMock/JVM faults wrap the actionable detail
+    // (e.g. a BindException behind a generic startup error).
+    val cause = Option(t.getCause).filter(_ ne t).fold("")(c => s" (cause: ${render(c)})")
+    s"${render(t)}$cause"
+
+private[wiremock] object WireMockControl:
+  final case class SpaceState(
+    server: WireMockServer,
+    ownsServer: Boolean,
+    correlation: Option[Correlation],
+    rules: Ref[Vector[(RuleId, StubMapping)]]
+  )
+
+  /**
+   * Build the adapter for `mode`, starting the shared server in Correlated mode
+   * and registering a scope finalizer that stops every server it owns.
+   */
+  def make(mode: WireMock.Mode): ZIO[Provisioning & Scope, Throwable, MockControl] =
+    for
+      prov   <- ZIO.service[Provisioning]
+      spaces <- Ref.make(Map.empty[SpaceId, SpaceState])
+      ids    <- Ref.make(0)
+      shared <- mode match
+                  case WireMock.Mode.Correlated(_) => startServer.map(Some(_))
+                  case WireMock.Mode.PerInstance   => ZIO.none
+      control = WireMockControl(mode, shared, prov, spaces, ids)
+      _      <- ZIO.addFinalizer(control.stopAll)
+    yield control
+
+  // Create and start an embedded server on an OS-assigned port.
+  private def startServer: Task[WireMockServer] =
+    ZIO.attempt {
+      val server = new WireMockServer(options().dynamicPort())
+      server.start()
+      server
+    }

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockTranslation.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockTranslation.scala
@@ -1,0 +1,84 @@
+package zio.bdd.mock.wiremock
+
+import zio.bdd.mock.*
+
+import com.github.tomakehurst.wiremock.client.{MappingBuilder, ResponseDefinitionBuilder, WireMock as WM}
+import com.github.tomakehurst.wiremock.matching.StringValuePattern
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+
+import java.util.UUID
+
+/**
+ * Translates the backend-neutral [[MockRule]] model to WireMock stub mappings.
+ */
+private[wiremock] object WireMockTranslation:
+
+  /**
+   * Build the stub for `rule` on space `id`. In Correlated mode `correlation`
+   * stamps the matcher (header == this space) onto the request pattern so only
+   * requests carrying the space's tag can match it; in PerInstance mode it is
+   * `None` (the space owns its server outright).
+   */
+  def stub(id: SpaceId, rule: MockRule, priority: Priority, correlation: Option[Correlation]): StubMapping =
+    val base = methodAndUrl(rule.`match`)
+    rule.`match`.headers.foreach((k, v) => base.withHeader(k, valuePattern(v)))
+    rule.`match`.query.foreach((k, v) => base.withQueryParam(k, valuePattern(v)))
+    rule.`match`.body.foreach(b => base.withRequestBody(bodyPattern(b)))
+    correlation.foreach(c => base.withHeader(c.header, c.matcher(id)))
+    base.atPriority(priority match
+      case Priority.Overlay => 1
+      case Priority.Base    => 10
+    )
+    base.withId(UUID.randomUUID())
+    base.willReturn(response(rule.respond)).build()
+
+  private def methodAndUrl(m: RequestMatch): MappingBuilder =
+    val url = m.path match
+      case PathMatch.Any         => WM.anyUrl()
+      case PathMatch.Exact(p)    => WM.urlPathEqualTo(p)
+      case PathMatch.Regex(p)    => WM.urlPathMatching(p)
+      case PathMatch.Template(t) => WM.urlPathTemplate(t)
+    m.method match
+      case Some(method) => WM.request(method.toString.toUpperCase, url)
+      case None         => WM.any(url)
+
+  private def valuePattern(v: ValueMatch): StringValuePattern = v match
+    case ValueMatch.Equals(value)   => WM.equalTo(value)
+    case ValueMatch.Contains(value) => WM.containing(value)
+    case ValueMatch.Matches(regex)  => WM.matching(regex)
+
+  private def bodyPattern(b: BodyMatch): StringValuePattern = b match
+    case BodyMatch.Equals(value)   => WM.equalTo(value)
+    case BodyMatch.Contains(value) => WM.containing(value)
+    case BodyMatch.Matches(regex)  => WM.matching(regex)
+    case BodyMatch.JsonPath(path, expected) =>
+      expected.fold(WM.matchingJsonPath(path))(e => WM.matchingJsonPath(path, WM.equalTo(e)))
+    case BodyMatch.XPath(path, expected) =>
+      expected.fold(WM.matchingXPath(path))(e => WM.matchingXPath(path, WM.equalTo(e)))
+
+  private def response(r: ResponseDef): ResponseDefinitionBuilder =
+    val rb = WM.aResponse().withStatus(r.status)
+    r.headers.foreach((k, v) => rb.withHeader(k, v))
+    r.body match
+      case Body.Empty     => ()
+      case Body.Text(v)   => rb.withBody(v)
+      case Body.Json(v)   => rb.withBody(v)
+      case Body.Base64(v) => rb.withBase64Body(v)
+    r.delay.foreach(d => rb.withFixedDelay(d.toMillis.toInt))
+    rb
+
+  /** A [[RecordedRequest]] from a WireMock logged request. */
+  def recorded(method: String, url: String, headers: Map[String, String], body: Option[String]): RecordedRequest =
+    RecordedRequest(parseMethod(method), url, headers, body)
+
+  private def parseMethod(name: String): Method = name.toUpperCase match
+    case "GET"     => Method.Get
+    case "POST"    => Method.Post
+    case "PUT"     => Method.Put
+    case "DELETE"  => Method.Delete
+    case "PATCH"   => Method.Patch
+    case "HEAD"    => Method.Head
+    case "OPTIONS" => Method.Options
+    case "TRACE"   => Method.Trace
+    case "CONNECT" => Method.Connect
+    case other     => Method.Get

--- a/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
+++ b/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
@@ -1,0 +1,199 @@
+package zio.bdd.mock.wiremock
+
+import zio.*
+import zio.bdd.mock.*
+import zio.test.*
+
+import java.net.{URI, http as jhttp}
+
+object WireMockControlSpec extends ZIOSpecDefault:
+
+  private val pingRule =
+    MockRule(
+      RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+      ResponseDef(status = 200, body = Body.Text("pong"))
+    )
+  private val healthRule =
+    MockRule(
+      RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/health")),
+      ResponseDef(status = 200, body = Body.Text("ok"))
+    )
+  private val pingSource = MockSource.Dsl(MockSpec(List(pingRule)))
+
+  private val baseHealth = MockRule(
+    RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/h")),
+    ResponseDef(status = 200, body = Body.Text("base"))
+  )
+  private val overlayHealth = MockRule(
+    RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/h")),
+    ResponseDef(status = 200, body = Body.Text("overlay"))
+  )
+  private val slowSource =
+    MockSource.Dsl(
+      MockSpec(
+        List(
+          MockRule(
+            RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/slow")),
+            ResponseDef(status = 200, body = Body.Text("slow"), delay = Some(300.millis))
+          )
+        )
+      )
+    )
+  private val nativeStubJson =
+    """{"request":{"method":"GET","url":"/native"},"response":{"status":201,"body":"native!"}}"""
+
+  private val correlated  = PortAllocator.layer >>> Provisioning.layer >>> WireMock.correlated()
+  private val perInstance = PortAllocator.layer >>> Provisioning.layer >>> WireMock.perInstance
+  private val traceparent = PortAllocator.layer >>> Provisioning.layer >>> WireMock.correlated(Correlation.traceparent)
+
+  private def die[A](z: IO[MockError, A]): UIO[A] = z.orDieWith(e => new RuntimeException(e.toString))
+
+  // Send straight to a base URI with no inject (and an optional raw header), to
+  // model a SUT that did NOT carry the space tag.
+  private def rawGet(url: String, header: Option[(String, String)] = None): IO[Throwable, Int] =
+    ZIO.attemptBlocking {
+      val b   = jhttp.HttpRequest.newBuilder(URI.create(url)).GET()
+      val req = header.fold(b)((k, v) => b.header(k, v)).build()
+      jhttp.HttpClient.newHttpClient().send(req, jhttp.HttpResponse.BodyHandlers.ofString()).statusCode
+    }
+
+  def spec = suite("WireMockControl")(
+    suite("Correlated (default)")(
+      test("provision serves a portable rule, records the injected request, and destroy removes the space's stubs") {
+        for
+          control <- ZIO.service[MockControl]
+          spaces  <- die(control.provision(pingSource))
+          space    = spaces.head
+          resp    <- SutClient.make(space).send(Method.Get, "/ping").orDie
+          recv    <- die(control.received(space))
+          _       <- die(control.destroy(space))
+          after   <- SutClient.make(space).send(Method.Get, "/ping").orDie
+        yield assertTrue(
+          spaces.size == 1,
+          resp.status == 200,
+          resp.body == "pong",
+          recv.map(r => (r.method, r.uri)) == List((Method.Get, "/ping")),
+          after.status == 404 // the space's stub is gone after destroy
+        )
+      },
+      test("destroy(A) removes only A's stubs — B still serves and records") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          b       <- die(control.provision(pingSource)).map(_.head)
+          _       <- SutClient.make(b).send(Method.Get, "/ping").orDie
+          _       <- die(control.destroy(a))
+          rb      <- die(control.received(b))
+          respB   <- SutClient.make(b).send(Method.Get, "/ping").orDie
+          respA   <- SutClient.make(a).send(Method.Get, "/ping").orDie
+        yield assertTrue(rb.nonEmpty, respB.status == 200, respA.status == 404)
+      },
+      test("a request WITHOUT the space header gets 404 and leaks into NO Correlated space") {
+        for
+          control  <- ZIO.service[MockControl]
+          a        <- die(control.provision(pingSource)).map(_.head)
+          withResp <- SutClient.make(a).send(Method.Get, "/ping").orDie // inject stamps X-Mock-Space
+          rawResp  <- rawGet(a.baseUri + "/ping").orDie                 // no header
+          recv     <- die(control.received(a))
+        yield assertTrue(
+          withResp.status == 200,
+          rawResp == 404,                   // unmatched without the space tag
+          recv.count(_.uri == "/ping") == 1 // only the injected request, never the raw one
+        )
+      },
+      test("addRule serves a new rule; removeRule stops it") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          rid     <- die(control.addRule(a, healthRule, Priority.Overlay))
+          r1      <- SutClient.make(a).send(Method.Get, "/health").orDie
+          _       <- die(control.removeRule(a, rid))
+          r2      <- SutClient.make(a).send(Method.Get, "/health").orDie
+        yield assertTrue(r1.status == 200, r1.body == "ok", r2.status == 404)
+      },
+      test("replaceRules swaps the space's whole rule set") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          _       <- die(control.replaceRules(a, List(healthRule)))
+          ping    <- SutClient.make(a).send(Method.Get, "/ping").orDie
+          health  <- SutClient.make(a).send(Method.Get, "/health").orDie
+        yield assertTrue(ping.status == 404, health.status == 200, health.body == "ok")
+      },
+      test("removeRule of an unknown id fails RuleNotFound") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          res     <- control.removeRule(a, RuleId("ghost")).either
+        yield assertTrue(res == Left(MockError.RuleNotFound(a.id, RuleId("ghost"))))
+      },
+      test("an Overlay rule shadows a Base rule on the same path") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(MockSource.Dsl(MockSpec(List(baseHealth))))).map(_.head)
+          _       <- die(control.addRule(a, overlayHealth, Priority.Overlay))
+          resp    <- SutClient.make(a).send(Method.Get, "/h").orDie
+        yield assertTrue(resp.status == 200, resp.body == "overlay") // higher priority (atPriority 1) wins
+      },
+      test("the response delay is applied to served responses") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(slowSource)).map(_.head)
+          start   <- Clock.nanoTime
+          resp    <- SutClient.make(a).send(Method.Get, "/slow").orDie
+          elapsed <- Clock.nanoTime.map(_ - start)
+        yield assertTrue(resp.status == 200, elapsed >= 250.millis.toNanos) // ~300ms fixed delay
+      } @@ TestAspect.withLiveClock,
+      test("provisionNative(WireMock) serves a raw stub on its own server; a Rift spec is rejected") {
+        for
+          control <- ZIO.service[MockControl]
+          spaces  <- die(control.provisionNative(NativeSpec.WireMock(nativeStubJson)))
+          a        = spaces.head
+          resp    <- rawGet(a.baseUri + "/native").orDie // its own server, no space header needed
+          rift    <- control.provisionNative(NativeSpec.Rift("{}")).either
+        yield assertTrue(resp == 201, rift.isLeft)
+      }
+    ).provide(correlated),
+    test("PerInstance gives each space its own server (distinct ports, inject identity), destroy stops only that one") {
+      for
+        control <- ZIO.service[MockControl]
+        a       <- die(control.provision(pingSource)).map(_.head)
+        b       <- die(control.provision(pingSource)).map(_.head)
+        ra      <- SutClient.make(a).send(Method.Get, "/ping").orDie
+        _       <- die(control.destroy(a))
+        rb      <- SutClient.make(b).send(Method.Get, "/ping").orDie
+        aGone   <- rawGet(a.baseUri + "/ping").either
+      yield assertTrue(
+        a.baseUri != b.baseUri, // a fresh server (port) per space
+        ra.status == 200,
+        rb.status == 200, // B's server is untouched by destroy(A)
+        aGone.isLeft      // A's server was stopped — connection refused
+      )
+    }.provide(perInstance),
+    suite("traceparent correlation")(
+      test("inject stamps a traceparent; a foreign trace-id does not reach the space") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          resp    <- SutClient.make(a).send(Method.Get, "/ping").orDie
+          recv    <- die(control.received(a))
+          foreign <- rawGet(
+                       a.baseUri + "/ping",
+                       Some("traceparent" -> "00-ffffffffffffffffffffffffffffffff-0000000000000001-01")
+                     ).orDie
+        yield assertTrue(resp.status == 200, recv.nonEmpty, foreign == 404)
+      },
+      test("a request reusing the space's trace-id but a DIFFERENT span-id still matches") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          _       <- SutClient.make(a).send(Method.Get, "/ping").orDie // records the space's traceparent
+          recv    <- die(control.received(a))
+          tp       = recv.head.headers("traceparent")                  // 00-<traceId>-<span>-01
+          traceId  = tp.split("-")(1)
+          // same trace-id, a span-id the space never injected
+          varied <- rawGet(a.baseUri + "/ping", Some("traceparent" -> s"00-$traceId-ffffffffffffffff-01")).orDie
+        yield assertTrue(varied == 200) // matched by trace-id; the span-id is free to vary
+      }
+    ).provide(traceparent)
+  )


### PR DESCRIPTION
The in-process, pure-JVM, zero-Docker provider (#122) — a new `zio-bdd-wiremock` module implementing the portable `MockControl` SPI over an embedded `WireMockServer`, with **Correlated isolation as the default**.

- **Correlated (default)** — one shared server; each space's stubs carry an `X-Mock-Space: <spaceId>` header matcher; `MockSpace.inject` stamps that header on the SUT's outbound requests; `received` filters serve events by it; `destroy` removes only that space's mappings (never `resetAll`). A request without the header matches nothing and is recorded by no space.
- **PerInstance (option)** — a fresh `WireMockServer` per space (`inject == identity`, `destroy` stops it).
- **traceparent (option)** — correlate by the W3C trace-id the SUT already propagates (span-id free to vary).
- `WireMock.correlated()` / `WireMock.perInstance` layers — swapping for a Rift layer is the one-line provider swap.

Mirrors the Rift adapter (`Provisioning` reuse, per-space tracked rule ids, atomic provision with rollback, space-local destroy). The MockRule→StubMapping translation covers method/path/query/header/body matchers, priority, and response status/headers/body/delay.

## Testing
12 tests against **real in-process servers** (sending via `SutClient`, which applies `inject`):
- Correlated contract: provision/serve/record/destroy; destroy(A) leaves B; **no-leak** (a header-less request gets 404 and is in no space's `received` — mutant-killed by removing the matcher); addRule/removeRule; replaceRules; RuleNotFound; overlay-shadows-base; response delay; `provisionNative(WireMock)` + Rift-spec rejection.
- PerInstance: distinct ports, `inject` identity, destroy stops only that server.
- traceparent: foreign trace-id → 404; same trace-id with a varying span-id still matches.

## Scope notes
- AC1 ("same suite on both adapters") is proven structurally here; the cross-adapter **conformance matrix runner is #124**. The Rift side is covered by `RiftMockControlSpec`.
- Known limitation: `parseMethod` maps an unrecognized HTTP method to `Get` (the `Method` enum is closed at the 9 standard methods); a `Method.Other(raw)` model addition belongs in #125.

Closes #122

Milestone: M2 (Epic C)