### PR TITLE
feat: isolation model + per-adapter defaults (PerInstance/Correlated)

### DIFF
--- a/mock/src/main/scala/zio/bdd/mock/Capability.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Capability.scala
@@ -15,8 +15,9 @@ enum Capability:
  *   - Correlated: a shared base URI partitioned by a correlation header (e.g.
  *     WireMock).
  *
- * Marker type only at this stage; the per-adapter behaviour lands with the
- * isolation model in M2 (#123).
+ * The behaviour itself lives in [[MockSpace.inject]] (which hides the mode from
+ * the Gherkin); an adapter reports its mode via [[MockControl.isolation]]
+ * (#123).
  */
 enum Isolation:
   case PerInstance, Correlated

--- a/mock/src/main/scala/zio/bdd/mock/MockControl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockControl.scala
@@ -52,6 +52,16 @@ trait MockControl:
   def capabilities: Set[Capability]
 
   /**
+   * The isolation model this control operates in (#123).
+   * [[Isolation.PerInstance]] is the default — a unique `baseUri` per space
+   * with `inject == identity`; a Correlated adapter (one shared `baseUri`,
+   * `inject` stamps a correlation header) overrides it. Steps never read this:
+   * [[MockSpace.inject]] already hides the mode from the Gherkin. It is exposed
+   * for diagnostics and the suite-override path where an adapter supports both.
+   */
+  def isolation: Isolation = Isolation.PerInstance
+
+  /**
    * Fail-fast capability negotiation: declare what a suite needs up front.
    * Succeeds when every required capability is advertised; otherwise fails with
    * the first missing one (in argument order), naming it and the backend.

--- a/mock/src/main/scala/zio/bdd/mock/SutClient.scala
+++ b/mock/src/main/scala/zio/bdd/mock/SutClient.scala
@@ -17,6 +17,11 @@ final case class SutResponse(status: Int, body: String, headers: Map[String, Str
  *
  * Provide it per scenario via [[SutClient.layer]] — never a process-wide env
  * var — so parallel scenarios each target their own space with no cross-talk.
+ *
+ * This is the canonical *Caller* of the isolation model (#123): it always sends
+ * `space.inject(req)` to `space.baseUri` and never branches on PerInstance vs
+ * Correlated — the whole difference lives in `space.inject`, so steps stay
+ * isolation-agnostic. See [[MockControl.isolation]] for an adapter's mode.
  */
 trait SutClient:
   /**

--- a/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
@@ -118,6 +118,9 @@ object MockControlModelSpec extends ZIOSpecDefault:
     test("Isolation enum has both isolation modes") {
       assertTrue(Isolation.values.toSet == Set(Isolation.PerInstance, Isolation.Correlated))
     },
+    test("MockControl.isolation defaults to PerInstance for an adapter that does not override it") {
+      assertTrue(StubMockControl("stub", Set.empty).isolation == Isolation.PerInstance)
+    },
     test("NativeSpec is backend-tagged and carries its raw payload") {
       // The type ascriptions are the real assertion: they only compile because
       // each case is pinned to its backend tag (Rift / WireMock).

--- a/mock/src/test/scala/zio/bdd/mock/SutClientSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/SutClientSpec.scala
@@ -119,6 +119,22 @@ object SutClientSpec extends ZIOSpecDefault:
         }
       }
     },
+    test("the Caller is isolation-agnostic: one send path reaches a PerInstance AND a Correlated space") {
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          // PerInstance: own baseUri, inject == identity. Correlated: shared baseUri, inject adds the
+          // header. The SutClient call is identical for both — it never branches on the mode.
+          val perInstance = dep.perInstanceSpace("pi")
+          val correlated  = dep.correlatedSpace("co")
+          for
+            _     <- SutClient.make(perInstance).send(Method.Get, "/x")
+            _     <- SutClient.make(correlated).send(Method.Get, "/y")
+            recPi <- dep.received("pi")
+            recCo <- dep.received("co")
+          yield assertTrue(recPi == List(("GET", "/x")), recCo == List(("GET", "/y")))
+        }
+      }
+    },
     test("concurrent SUT calls via per-space clients don't cross-talk (PerInstance)") {
       ZIO.scoped {
         dependency.flatMap { dep =>

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -46,6 +46,11 @@ object RiftMockControlSpec extends ZIOSpecDefault:
     withAdapterPool((4545 until 4600).toList)(use)
 
   def spec = suite("RiftMockControl (adapter vs fake admin API)")(
+    test("the Rift adapter's isolation model is PerInstance (own port, identity inject)") {
+      withAdapter { (control, _) =>
+        ZIO.succeed(assertTrue(control.isolation == Isolation.PerInstance))
+      }
+    },
     test("provision creates one recording imposter per space; baseUri reflects its port; inject is identity") {
       withAdapter { (control, fake) =>
         for

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
@@ -36,6 +36,10 @@ private[wiremock] final case class WireMockControl(
   def backendName: String           = "wiremock"
   def capabilities: Set[Capability] = Set.empty
 
+  override def isolation: Isolation = mode match
+    case WireMock.Mode.Correlated(_) => Isolation.Correlated
+    case WireMock.Mode.PerInstance   => Isolation.PerInstance
+
   def provision(source: MockSource): IO[MockError, List[MockSpace]] =
     for
       sources <- provisioning.normalize(source)

--- a/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
+++ b/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
@@ -152,8 +152,26 @@ object WireMockControlSpec extends ZIOSpecDefault:
           resp    <- rawGet(a.baseUri + "/native").orDie // its own server, no space header needed
           rift    <- control.provisionNative(NativeSpec.Rift("{}")).either
         yield assertTrue(resp == 201, rift.isLeft)
+      },
+      test("the Correlated adapter reports Correlated isolation") {
+        ZIO.serviceWith[MockControl](c => assertTrue(c.isolation == Isolation.Correlated))
+      },
+      test("received(A) returns only A's traffic when A and B share one server") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          b       <- die(control.provision(pingSource)).map(_.head)
+          _       <- SutClient.make(a).send(Method.Get, "/ping").orDie
+          _       <- SutClient.make(b).send(Method.Get, "/ping").orDie
+          _       <- SutClient.make(b).send(Method.Get, "/ping").orDie
+          ra      <- die(control.received(a))
+          rb      <- die(control.received(b))
+        yield assertTrue(ra.size == 1, rb.size == 2) // received filters by space header on the shared server
       }
     ).provide(correlated),
+    test("the PerInstance-mode adapter reports PerInstance isolation") {
+      ZIO.serviceWith[MockControl](c => assertTrue(c.isolation == Isolation.PerInstance))
+    }.provide(perInstance),
     test("PerInstance gives each space its own server (distinct ports, inject identity), destroy stops only that one") {
       for
         control <- ZIO.service[MockControl]


### PR DESCRIPTION
The isolation model that hides PerInstance vs Correlated from the Gherkin (#123). Lean scope: build the model, keep each adapter's natural mechanism.

- **`MockControl.isolation: Isolation`** — a concrete (non-breaking) default `PerInstance`; each adapter's isolation model. Rift inherits PerInstance (its natural port-based model, unchanged); WireMock overrides to report its configured Mode (Correlated by default, or PerInstance). Steps never read it — exposed for diagnostics and the suite-override path.
- **`SutClient` (#117) formalized as the canonical Caller** — always `space.inject(req)` → `space.baseUri`, never branches on the mode (and structurally *cannot*: `MockSpace` carries no isolation field). The whole difference lives in `space.inject`.
- Per-adapter defaults + suite override (WireMock's `correlated()`/`perInstance` from #122) — no Rift changes.

## Testing (+6)
- AC1 (Caller never branches): one `SutClient` send path reaches both a PerInstance space (identity inject) and a Correlated space (header inject) against one in-process server.
- AC2 (Correlated `received(A)` = A-only on a shared server): two Correlated spaces on the shared WireMock server; send 1× to A, 2× to B; `received(A).size == 1`, `received(B).size == 2` — the asymmetric counts kill both the drop-filter and swap mutants.
- Per-adapter defaults: WireMock reports Correlated / PerInstance per mode; Rift reports PerInstance; the trait default is locked by a bare-stub test.

## Scope note
Rift-Correlated (shared imposter via correlation-id, for port-pressure at scale) is a deferred follow-up — **#156** — gated on rift#201 (✅ in v0.3.0) + rift#223. Portability comes from the isolation *model* here, not per-adapter feature parity.

Closes #123

Milestone: M2 (Epic C)