### PR TITLE
test: MockControl conformance harness + matrix runner

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val mimaSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .aggregate(core, gherkin, mock, rift, wiremock)
+  .aggregate(core, gherkin, mock, rift, wiremock, conformance)
   .settings(
     name                  := "zio-bdd-root",
     description           := "A ZIO-based BDD testing framework for Scala 3",
@@ -168,6 +168,19 @@ lazy val wiremock = (project in file("wiremock"))
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
+    mimaPreviousArtifacts := Set.empty
+  )
+
+// Conformance harness + matrix runner (#124): the executable definition of
+// "implements MockControl". The only module that depends on BOTH adapters, so it
+// can run one feature set across Rift + WireMock and emit the pass/skip/fail matrix.
+lazy val conformance = (project in file("conformance"))
+  .dependsOn(core, rift, wiremock)
+  .settings(
+    name := "zio-bdd-conformance",
+    libraryDependencies ++= commonDependencies,
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    publish / skip        := true, // a test harness, not a published artifact
     mimaPreviousArtifacts := Set.empty
   )
 

--- a/conformance/src/main/scala/zio/bdd/mock/conformance/ConformanceHarness.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/ConformanceHarness.scala
@@ -1,0 +1,131 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+
+/**
+ * A backend registered in the conformance matrix. `layer` is a fully self-wired
+ * [[MockControl]]; `capabilities`/`isolation` are what it advertises
+ * (#118/#123). `available = false` parks the whole column as SKIPPED — e.g. the
+ * Rift backend when Docker isn't present (gated by `RIFT_IT`), so the matrix
+ * still runs WireMock in-process.
+ */
+final case class MockBackendUnderTest(
+  name: String,
+  layer: ZLayer[Any, Throwable, MockControl],
+  capabilities: Set[Capability],
+  isolation: Isolation,
+  available: Boolean = true
+)
+
+/**
+ * One portable conformance scenario: a `check` programmed against the neutral
+ * [[MockControl]] (never a concrete backend), gated by the capabilities it
+ * needs. A scenario requiring a capability the backend doesn't advertise is
+ * SKIPPED, never FAILED — that is a negotiated gap, not a conformance breach.
+ */
+final case class ConformanceScenario(
+  name: String,
+  requires: Set[Capability],
+  check: MockControl => ZIO[Scope, Throwable, Unit]
+)
+
+enum Outcome:
+  case Pass, Skip, Fail
+
+final case class Cell(scenario: String, backend: String, outcome: Outcome, detail: Option[String] = None)
+
+/** The pass/skip/fail matrix — one cell per (scenario, backend). */
+final case class Matrix(backends: List[MockBackendUnderTest], scenarios: List[ConformanceScenario], cells: List[Cell]):
+
+  def cell(scenario: String, backend: String): Option[Cell] =
+    cells.find(c => c.scenario == scenario && c.backend == backend)
+
+  /**
+   * A column is conformant iff it has zero FAIL and every SKIP is justified —
+   * the backend was unavailable, or the scenario required a capability the
+   * backend does not advertise (the acceptance condition "SKIPs equal the
+   * un-advertised capabilities").
+   */
+  def conformant(backend: MockBackendUnderTest): Boolean =
+    cells.filter(_.backend == backend.name).forall { c =>
+      c.outcome match
+        case Outcome.Fail => false
+        case Outcome.Pass => true
+        case Outcome.Skip =>
+          !backend.available ||
+          scenarios.find(_.name == c.scenario).exists(!_.requires.subsetOf(backend.capabilities))
+    }
+
+  /** A compact P/S/F grid, one row per scenario, one column per backend. */
+  def render: String =
+    val nameW = (scenarios.map(_.name.length) :+ 8).max
+    val head  = "scenario".padTo(nameW, ' ') + "  " + backends.map(_.name).mkString("  ")
+    val rows = scenarios.map { s =>
+      val marks = backends.map(b => cell(s.name, b.name).map(mark).getOrElse("?").padTo(b.name.length, ' '))
+      s.name.padTo(nameW, ' ') + "  " + marks.mkString("  ")
+    }
+    (head +: rows).mkString("\n")
+
+  private def mark(c: Cell): String = c.outcome match
+    case Outcome.Pass => "PASS"
+    case Outcome.Skip => "SKIP"
+    case Outcome.Fail => "FAIL"
+
+/** Runs each scenario against each backend and assembles the [[Matrix]]. */
+object ConformanceHarness:
+
+  def run(backends: List[MockBackendUnderTest], scenarios: List[ConformanceScenario]): UIO[Matrix] =
+    ZIO
+      .foreach(backends)(b => runBackend(b, scenarios))
+      .map(rows => Matrix(backends, scenarios, rows.flatten))
+
+  // Stand the backend up once and run every scenario against it (each provisions
+  // and tears down its own spaces). A backend that can't even *build* fails every
+  // scenario; an unavailable backend (e.g. Rift with no Docker) skips them all.
+  // The all-FAIL mapping is scoped to `build`, so a later teardown failure can't
+  // rewrite already-computed cells; interruption propagates (it is not a verdict).
+  private def runBackend(backend: MockBackendUnderTest, scenarios: List[ConformanceScenario]): UIO[List[Cell]] =
+    if !backend.available then
+      ZIO.succeed(scenarios.map(s => Cell(s.name, backend.name, Outcome.Skip, Some("backend unavailable"))))
+    else
+      ZIO.scoped {
+        backend.layer.build.foldCauseZIO(
+          cause =>
+            if cause.isInterruptedOnly then ZIO.failCause(cause.stripFailures)
+            else
+              ZIO.succeed(
+                scenarios.map(s =>
+                  Cell(s.name, backend.name, Outcome.Fail, Some(s"backend setup failed: ${detailOf(cause)}"))
+                )
+              )
+          ,
+          env => ZIO.foreach(scenarios)(s => cellFor(env.get[MockControl], backend, s))
+        )
+      }
+
+  private def cellFor(control: MockControl, backend: MockBackendUnderTest, scenario: ConformanceScenario): UIO[Cell] =
+    if !scenario.requires.subsetOf(backend.capabilities) then
+      val missing = (scenario.requires -- backend.capabilities).map(_.toString).mkString(", ")
+      ZIO.succeed(Cell(scenario.name, backend.name, Outcome.Skip, Some(s"requires $missing")))
+    else
+      ZIO
+        .scoped(scenario.check(control))
+        .foldCauseZIO(
+          // A failed or DIED check is a verdict (Fail cell); interruption is not — propagate it.
+          cause =>
+            if cause.isInterruptedOnly then ZIO.failCause(cause.stripFailures)
+            else ZIO.succeed(Cell(scenario.name, backend.name, Outcome.Fail, Some(detailOf(cause)))),
+          _ => ZIO.succeed(Cell(scenario.name, backend.name, Outcome.Pass))
+        )
+
+  // A failure carries its message; a DEFECT (a harness/check bug, not a backend
+  // verdict) is labelled so a reader can tell "the backend misbehaved" from "the
+  // check threw". Total — never throws on an empty cause.
+  private def detailOf(cause: Cause[Throwable]): String =
+    cause.failureOption
+      .map(_.getMessage)
+      .orElse(cause.dieOption.map(d => s"[harness defect] ${d.getClass.getName}: ${d.getMessage}"))
+      .filter(_ != null)
+      .getOrElse(cause.prettyPrint.linesIterator.nextOption.getOrElse("<no detail>"))
+      .take(300)

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceHarnessSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceHarnessSpec.scala
@@ -1,0 +1,103 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+import zio.test.*
+
+/**
+ * Pure + synthetic tests that lock the runner's classification contract — the
+ * FAIL and unjustified-SKIP branches of `conformant` that the live WireMock
+ * matrix never exercises (it only ever produces PASS/justified-SKIP). No
+ * Docker, no real server.
+ */
+object ConformanceHarnessSpec extends ZIOSpecDefault:
+
+  // A no-op backend: the predicate/render tests never run its layer; the harness
+  // tests run a scenario that ignores the control.
+  private val stub: MockControl = new MockControl:
+    def backendName: String           = "stub"
+    def capabilities: Set[Capability] = Set.empty
+    def provision(source: MockSource): IO[MockError, List[MockSpace]] =
+      ZIO.succeed(List(MockSpace("stub://x", identity, SpaceId("x"))))
+    def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+      ZIO.fail(MockError.InvalidDefinition("n/a"))
+    def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] = ZIO.succeed(RuleId("r"))
+    def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit]                        = ZIO.unit
+    def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit]           = ZIO.unit
+    def destroy(space: MockSpace): IO[MockError, Unit]                                       = ZIO.unit
+    def received(space: MockSpace): IO[MockError, List[RecordedRequest]]                     = ZIO.succeed(Nil)
+    def faults: IO[Unsupported, Faults]                                                      = ZIO.fail(Unsupported(Capability.Faults, "stub"))
+    def scenarios: IO[Unsupported, StatefulScenarios]                                        = ZIO.fail(Unsupported(Capability.StatefulScenarios, "stub"))
+    def stateInspection: IO[Unsupported, StateInspection]                                    = ZIO.fail(Unsupported(Capability.StateInspection, "stub"))
+    def scripting: IO[Unsupported, Scripting]                                                = ZIO.fail(Unsupported(Capability.Scripting, "stub"))
+    def proxyRecord: IO[Unsupported, ProxyRecord]                                            = ZIO.fail(Unsupported(Capability.ProxyRecord, "stub"))
+    def templating: IO[Unsupported, Templating]                                              = ZIO.fail(Unsupported(Capability.Templating, "stub"))
+
+  // capabilities = empty -> a Faults-requiring scenario is justifiably skipped.
+  private val backend  = MockBackendUnderTest("b", ZLayer.succeed(stub), Set.empty, Isolation.PerInstance)
+  private val basic    = ConformanceScenario("basic", Set.empty, _ => ZIO.unit) // requires nothing
+  private val needsCap = ConformanceScenario("needs-faults", Set(Capability.Faults), _ => ZIO.unit)
+
+  private def matrixOf(scenarios: List[ConformanceScenario], cells: Cell*): Matrix =
+    Matrix(List(backend), scenarios, cells.toList)
+
+  def spec = suite("ConformanceHarness")(
+    suite("conformant predicate")(
+      test("a FAIL cell makes the column non-conformant") {
+        assertTrue(!matrixOf(List(basic), Cell("basic", "b", Outcome.Fail)).conformant(backend))
+      },
+      test("an UNJUSTIFIED skip (a runnable scenario skipped) makes the column non-conformant") {
+        // 'basic' requires nothing and the backend is available, so a Skip is unjustified.
+        assertTrue(!matrixOf(List(basic), Cell("basic", "b", Outcome.Skip)).conformant(backend))
+      },
+      test("a JUSTIFIED skip (un-advertised capability) keeps the column conformant") {
+        assertTrue(matrixOf(List(needsCap), Cell("needs-faults", "b", Outcome.Skip)).conformant(backend))
+      },
+      test("an all-PASS column is conformant") {
+        assertTrue(matrixOf(List(basic), Cell("basic", "b", Outcome.Pass)).conformant(backend))
+      },
+      test("an unavailable backend's all-SKIP column is (vacuously) conformant") {
+        val down = backend.copy(available = false)
+        assertTrue(Matrix(List(down), List(basic), List(Cell("basic", "b", Outcome.Skip))).conformant(down))
+      }
+    ),
+    test("render shows the P/S/F grid with scenario names and outcomes") {
+      val m = Matrix(
+        List(backend),
+        List(basic, needsCap),
+        List(Cell("basic", "b", Outcome.Pass), Cell("needs-faults", "b", Outcome.Skip))
+      )
+      val r = m.render
+      assertTrue(
+        r.contains("basic"),
+        r.contains("needs-faults"),
+        r.contains("PASS"),
+        r.contains("SKIP"),
+        r.contains("b")
+      )
+    },
+    suite("runner classifies failures")(
+      test("a failing scenario produces a FAIL cell and a non-conformant column") {
+        val boom = ConformanceScenario("boom", Set.empty, _ => ZIO.fail(new RuntimeException("boom")))
+        for matrix <- ConformanceHarness.run(List(backend), List(boom))
+        yield assertTrue(
+          matrix.cell("boom", "b").map(_.outcome).contains(Outcome.Fail),
+          !matrix.conformant(backend)
+        )
+      },
+      test("a backend whose layer cannot build fails every scenario") {
+        val broken = MockBackendUnderTest(
+          "broken",
+          ZLayer.fail(new RuntimeException("no backend")),
+          Set.empty,
+          Isolation.PerInstance
+        )
+        for matrix <- ConformanceHarness.run(List(broken), List(basic, needsCap))
+        yield assertTrue(
+          matrix.cell("basic", "broken").map(_.outcome).contains(Outcome.Fail),
+          matrix.cell("needs-faults", "broken").map(_.outcome).contains(Outcome.Fail),
+          !matrix.conformant(broken)
+        )
+      }
+    )
+  )

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
@@ -1,0 +1,120 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.rift.Rift
+import zio.bdd.mock.wiremock.WireMock
+import zio.http.Client
+import zio.test.*
+
+/**
+ * The conformance matrix (#124): one portable scenario set run against every
+ * registered backend, emitting pass/skip/fail. WireMock runs in-process always;
+ * the Rift container backend is gated behind `RIFT_IT` (like
+ * RiftContainerSpec), so `sbt test` stays Docker-free and CI runs the real
+ * cross-adapter matrix.
+ */
+object ConformanceMatrixSpec extends ZIOSpecDefault:
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+  private def ensure(cond: Boolean, msg: => String): IO[Throwable, Unit] =
+    ZIO.unless(cond)(ZIO.fail(new AssertionError(msg))).unit
+
+  private val pingSource =
+    MockSource.Dsl(
+      MockSpec(
+        List(
+          MockRule(
+            RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+            ResponseDef(status = 200, body = Body.Text("pong"))
+          )
+        )
+      )
+    )
+
+  // ---- the portable scenarios (programmed against MockControl, never a backend) ----
+
+  private val provisionServeRecord = "provision, serve, and record a request"
+  private val isolationReceived    = "isolation: received(A) returns only A's traffic"
+  private val injectFault          = "inject a fault"
+
+  private val scenarios = List(
+    ConformanceScenario(
+      provisionServeRecord,
+      Set.empty,
+      control =>
+        for
+          spaces <- control.provision(pingSource).mapError(asT)
+          space   = spaces.head
+          resp   <- SutClient.make(space).send(Method.Get, "/ping")
+          recv   <- control.received(space).mapError(asT)
+          _      <- control.destroy(space).mapError(asT)
+          _ <- ensure(
+                 resp.status == 200 && resp.body == "pong" && recv.exists(_.uri == "/ping"),
+                 s"basic: status=${resp.status} body=${resp.body} recv=$recv"
+               )
+        yield ()
+    ),
+    ConformanceScenario(
+      isolationReceived,
+      Set.empty,
+      // Portable across modes: PerInstance (two ports) and Correlated (one server,
+      // header-filtered) both yield received(A) = only A's traffic.
+      control =>
+        for
+          a  <- control.provision(pingSource).mapError(asT).map(_.head)
+          b  <- control.provision(pingSource).mapError(asT).map(_.head)
+          _  <- SutClient.make(a).send(Method.Get, "/ping")
+          _  <- SutClient.make(b).send(Method.Get, "/ping")
+          _  <- SutClient.make(b).send(Method.Get, "/ping")
+          ra <- control.received(a).mapError(asT)
+          rb <- control.received(b).mapError(asT)
+          _  <- control.destroy(a).mapError(asT)
+          _  <- control.destroy(b).mapError(asT)
+          _  <- ensure(ra.size == 1 && rb.size == 2, s"isolation: ra=${ra.size} rb=${rb.size}")
+        yield ()
+    ),
+    // Requires Faults — neither adapter advertises it yet (M3), so it must SKIP, never FAIL.
+    ConformanceScenario(
+      injectFault,
+      Set(Capability.Faults),
+      control => control.faults.mapError(u => new RuntimeException(u.toString)).unit
+    )
+  )
+
+  // ---- the backends ----
+
+  private val wiremock =
+    MockBackendUnderTest("wiremock", Provisioning.live >>> WireMock.correlated(), Set.empty, Isolation.Correlated)
+
+  private val riftEnabled = sys.env.contains("RIFT_IT")
+  private val rift =
+    MockBackendUnderTest(
+      "rift",
+      (Client.default ++ Provisioning.live) >>> Rift.managed().mapError(asT),
+      Set.empty,
+      Isolation.PerInstance,
+      available = riftEnabled
+    )
+
+  def spec = suite("ConformanceMatrix")(
+    test("runs the portable scenario set across backends and emits a conformant matrix") {
+      for
+        matrix <- ConformanceHarness.run(List(wiremock, rift), scenarios)
+        _      <- ZIO.logInfo(s"conformance matrix:\n${matrix.render}")
+      yield assertTrue(
+        // WireMock (in-process, always available)
+        matrix.cell(provisionServeRecord, "wiremock").map(_.outcome).contains(Outcome.Pass),
+        matrix.cell(isolationReceived, "wiremock").map(_.outcome).contains(Outcome.Pass),
+        matrix
+          .cell(injectFault, "wiremock")
+          .map(_.outcome)
+          .contains(Outcome.Skip),   // Faults un-advertised → SKIP, not FAIL
+        matrix.conformant(wiremock), // zero FAIL, skip justified by capability
+        // Rift: conformant when available (CI with RIFT_IT), else the column is SKIPPED-unavailable (local, no Docker)
+        if riftEnabled then matrix.conformant(rift)
+        else matrix.cell(provisionServeRecord, "rift").map(_.outcome).contains(Outcome.Skip),
+        matrix.render.contains("wiremock")
+      )
+    } @@ TestAspect.withLiveClock
+  )


### PR DESCRIPTION
The conformance harness + matrix runner (#124) — the executable definition of "implements `MockControl`", modeling OpenFeature's `conformance-zio-bdd`. A new `zio-bdd-conformance` module (the only one that depends on **both** adapters) runs one portable scenario set across Rift + WireMock and emits a pass/skip/fail matrix.

- **`MockBackendUnderTest(name, layer, capabilities, isolation, available)`** registry + **`ConformanceHarness.run`** — builds each backend once, runs every scenario, and classifies: capability-gated → **Skip**; check fail/die → **Fail** (a verdict); backend can't build → all-**Fail**; unavailable (e.g. Rift, no Docker) → all-**Skip**; **interruption propagates** (never a verdict).
- **`Matrix.conformant`** — a column is conformant iff zero FAIL and every SKIP is justified (backend unavailable, or the scenario needs an un-advertised capability). `Matrix.render` emits the grid.
- Portable scenarios programmed against the neutral `MockControl` (Caller = `SutClient`): provision/serve/record; isolation `received(A)=A-only` (portable across PerInstance + Correlated); inject-fault (requires `Faults` → SKIP, since neither adapter advertises it yet — M3).

## Gating
WireMock runs **in-process always**; the Rift container backend is gated behind **`RIFT_IT`** (like `RiftContainerSpec`), so `sbt test` stays Docker-free and CI runs the real two-backend matrix.

## Testing (+10)
- `ConformanceMatrixSpec` — the live matrix (WireMock PASS/PASS/SKIP; Rift gated), `conformant(wiremock)`.
- `ConformanceHarnessSpec` — pure + synthetic tests that lock the runner's classification contract (FAIL → non-conformant, **unjustified-Skip → non-conformant**, justified-Skip → conformant, all-Pass → conformant, unavailable → conformant, render grid, a failing scenario → Fail cell, a layer-build failure → all-Fail). A mutant disabling the capability gate flips the matrix to FAIL.

## Scope
#124 is the **machine** + a small representative scenario set; the **full** conformance feature set lands in **#125–#127**, which run on this harness. (Wiring CI's `rift-it` job to also run `ConformanceMatrixSpec` under `RIFT_IT=1` can ride with #125 or a separate CI tweak.)

Closes #124

Milestone: M2 (Epic C)