### PR TITLE
build: bump rift-proxy image to v0.4.0

### DIFF
--- a/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
@@ -17,10 +17,10 @@ import org.testcontainers.containers.wait.strategy.Wait
  */
 object Rift:
 
-  // Pinned to v0.3.0. Floor is v0.2.0: the first release where DELETE
+  // Pinned to v0.4.0. Floor is v0.2.0: the first release where DELETE
   // /imposters/:port tears down existing keep-alive connections, so a destroyed
   // imposter stops serving even a pooled client (EtaCassiopeia/rift#207).
-  val DefaultImage: String     = "zainalpour/rift-proxy:v0.3.0"
+  val DefaultImage: String     = "zainalpour/rift-proxy:v0.4.0"
   val DefaultAdminPort: Int    = 2525
   val DefaultImposterBase: Int = 4545
   val DefaultPoolSize: Int     = 16


### PR DESCRIPTION
Bumps the pinned Rift adapter image from `v0.3.0` to `v0.4.0` (single source of truth: `Rift.DefaultImage`; CI's `rift-it` job and the conformance matrix's Rift column both resolve this constant via `Rift.managed()`).

- v0.2.0 stays the documented floor (rift#207: `DELETE /imposters/:port` tears down keep-alive connections). v0.4.0 is a superset.
- The v0.4.0 image pulls cleanly; the module compiles; the 30 non-container rift tests + the 9 conformance tests pass with `RiftContainerSpec` gated behind `RIFT_IT`.

## Verification
The real-container behaviour against v0.4.0 is verified by the **`rift-it` CI job** (ubuntu, real Docker socket) — `RiftContainerSpec` plus, once the job is wired to run it under `RIFT_IT`, the conformance matrix's Rift column. Local `RIFT_IT=1` can't run it (testcontainers can't resolve the Docker Desktop socket from the sandbox — environmental, version-independent; the image itself pulls fine).

Base: the M2 epic (active line) so the epic's CI uses v0.4.0 immediately; `master` receives it at the M2 promotion gate.