### PR TITLE
feat: Rift Correlated isolation (shared imposter via correlation-id) — port-pressure scale option

### DIFF
--- a/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
@@ -1,10 +1,45 @@
 package zio.bdd.mock.rift
 
 import zio.*
-import zio.bdd.mock.{MockControl, MockError, Provisioning}
+import zio.bdd.mock.{MockControl, MockError, Provisioning, SpaceId}
 import zio.http.Client
 import com.dimafeng.testcontainers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
+
+/**
+ * How a Correlated space tags its requests on the shared imposter. `header` is
+ * the correlation header (Rift's `flowIdSource = header:<header>` gates stubs +
+ * recorded requests by it natively); `value` is what `MockSpace.inject` stamps
+ * on each request — and the `flowId` the adapter scopes stubs/teardown under.
+ */
+final case class Correlation(header: String, value: SpaceId => String)
+
+object Correlation:
+  /** Default: a dedicated `X-Mock-Space: <spaceId>` header. */
+  val spaceHeader: Correlation = Correlation("X-Mock-Space", id => id.value)
+
+  /**
+   * Correlate by the W3C trace context the SUT already propagates. NOTE: Rift's
+   * flow-id is the whole header value, so `inject` stamps a fixed traceparent
+   * per space — the SUT cannot vary the span-id (unlike the WireMock adapter,
+   * which matches by trace-id).
+   */
+  val traceparent: Correlation =
+    Correlation("traceparent", id => s"00-${traceId(id)}-0000000000000001-01")
+
+  private def traceId(id: SpaceId): String =
+    (0 until 4).map(i => f"${(id.value + ":" + i).hashCode & 0xffffffffL}%08x").mkString
+
+/**
+ * Rift isolation mode (#156). PerInstance (own port per space) is the default.
+ */
+enum RiftMode:
+  case PerInstance
+  case Correlated(correlation: Correlation)
+
+object RiftMode:
+  /** Correlated isolation with the default `X-Mock-Space` correlation. */
+  val correlated: RiftMode = Correlated(Correlation.spaceHeader)
 
 /**
  * Entry points for the Rift adapter — the default, zero-native-artifact
@@ -33,10 +68,11 @@ object Rift:
    */
   def connect(
     adminBase: String,
-    imposterPorts: List[Int]
+    imposterPorts: List[Int],
+    mode: RiftMode = RiftMode.PerInstance
   )(hostFor: Int => String): URLayer[Client & Provisioning, MockControl] =
-    ZLayer {
-      RiftEndpoint.pooled(adminBase, imposterPorts)(hostFor).flatMap(RiftMockControl.make)
+    ZLayer.scoped {
+      RiftEndpoint.pooled(adminBase, imposterPorts)(hostFor).flatMap(RiftMockControl.make(_, mode))
     }
 
   /**
@@ -54,7 +90,8 @@ object Rift:
     image: String = DefaultImage,
     poolSize: Int = DefaultPoolSize,
     adminPort: Int = DefaultAdminPort,
-    imposterBasePort: Int = DefaultImposterBase
+    imposterBasePort: Int = DefaultImposterBase,
+    mode: RiftMode = RiftMode.PerInstance
   ): ZLayer[Client & Provisioning, MockError, MockControl] =
     ZLayer.scoped {
       val imposterPorts = (0 until poolSize).map(imposterBasePort + _).toList
@@ -74,7 +111,7 @@ object Rift:
         host      = container.host
         admin     = s"http://$host:${container.mappedPort(adminPort)}"
         endpoint <- RiftEndpoint.pooled(admin, imposterPorts)(p => s"http://$host:${container.mappedPort(p)}")
-        control  <- RiftMockControl.make(endpoint)
+        control  <- RiftMockControl.make(endpoint, mode)
       yield control
     }
 

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -6,123 +6,101 @@ import zio.json.*
 import zio.json.ast.Json
 import zio.http.{Body, Client, Header, MediaType, Request, URL, Method as HttpMethod}
 
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
+
 /**
  * The Rift adapter: implements the portable [[MockControl]] core port by
  * driving Rift's Mountebank-compatible admin API over zio-http.
  *
- * PerInstance isolation: each [[MockSpace]] is one imposter on its own port and
- * `inject == identity`. `destroy` deletes exactly that imposter (`DELETE
- * /imposters/:port`) — never the global `DELETE /imposters` reset, so tearing
- * down one space never touches another (#113 AC2).
+ * Two isolation modes ([[RiftMode]]):
  *
- * Rule identity: Mountebank addresses stubs by positional index, which shifts
- * as stubs are inserted/removed. The adapter therefore hands out stable opaque
- * [[RuleId]]s and tracks their current order per imposter, translating an id to
- * its live index on removal — so a [[RuleId]] never silently points at the
- * wrong stub after an overlay insert.
+ *   - PerInstance (default): each [[MockSpace]] is one imposter on its own
+ *     port, `inject == identity`. `destroy` deletes exactly that imposter —
+ *     never the global reset, so tearing down one space never touches another
+ *     (#113 AC2).
  *
- * Capabilities are intentionally empty here: the optional capability
- * *interfaces* (faults, scenarios, …) are fleshed out in M3, so this adapter
- * advertises none and every accessor fails fast with [[Unsupported]].
+ *   - Correlated (#156): all spaces share ONE imposter whose `flowIdSource` is
+ *     `header:<correlation>`; each space's stubs are registered under its
+ *     flowId (`POST /imposters/:port/spaces/:flowId/stubs`, rift#223), `inject`
+ *     stamps the correlation header, `received` filters by it (rift#201), and
+ *     `destroy` tears down exactly that space (`DELETE
+ *     /imposters/:port/spaces/:flowId`). Trades a port-per-space for one shared
+ *     imposter — for heavy parallelism.
+ *
+ * A native imposter ([[provisionNative]]) always gets its own port regardless
+ * of mode (full-fidelity), so the two space kinds coexist; per-space operations
+ * dispatch by which space a [[MockSpace]] belongs to, not by the active mode.
+ *
+ * rift#223 exposes only whole-space teardown (no per-stub-in-space delete), so
+ * a Correlated `removeRule`/`replaceRules` (and an `Overlay` `addRule`, which
+ * must be first-match) rebuilds the space: it re-registers the tracked stubs
+ * after a space teardown — which also clears that space's recorded requests +
+ * flow state. Benign because mutations happen at scenario boundaries (overlay
+ * release after `received` is read; `replaceRules` at setup before any
+ * requests).
  */
 private[rift] final case class RiftMockControl(
   endpoint: RiftEndpoint,
   client: Client,
   provisioning: Provisioning,
+  mode: RiftMode,
   spaces: Ref[Map[SpaceId, RiftMockControl.Imposter]],
+  correlated: Ref[Map[SpaceId, RiftMockControl.CorrSpace]],
+  sharedPort: Ref.Synchronized[Option[Int]],
   ids: Ref[Int]
 ) extends MockControl:
 
+  import RiftMockControl.{CorrSpace, Imposter}
+
   def backendName: String           = "rift"
   def capabilities: Set[Capability] = Set.empty
+
+  override def isolation: Isolation = mode match
+    case RiftMode.Correlated(_) => Isolation.Correlated
+    case RiftMode.PerInstance   => Isolation.PerInstance
 
   def provision(source: MockSource): IO[MockError, List[MockSpace]] =
     for
       sources <- provisioning.normalize(source)
       created <- Ref.make(List.empty[MockSpace])
-      // Provision atomically: tear down any spaces already stood up if a later
-      // space in the same source fails, so a partial batch never orphans
-      // imposters/ports the caller can't reach.
+      // Provision atomically: if a later source fails, best-effort tear down the
+      // spaces already stood up. The original failure propagates; a cleanup
+      // failure is logged (not surfaced) rather than masking it.
       spaces <- ZIO
                   .foreach(sources)(src => serveSpace(src).tap(s => created.update(s :: _)))
-                  .onError(_ => created.get.flatMap(ZIO.foreachDiscard(_)(s => destroy(s).ignore)))
+                  .onError(_ =>
+                    created.get.flatMap(
+                      ZIO.foreachDiscard(_)(s =>
+                        destroy(s).catchAllCause(c => ZIO.logWarningCause(s"rollback: destroy ${s.id} failed", c))
+                      )
+                    )
+                  )
     yield spaces
 
   def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
     spec match
-      // A native Rift imposter goes through the same serveSpace machinery as a
-      // portable Raw source (pool port, `_rift`/stub passthrough, tracking), so
-      // the resulting space participates in destroy/received/overlays/isolation
-      // exactly like a portable one.
+      // A native imposter always gets its own port (PerInstance), full-fidelity,
+      // regardless of the active isolation mode.
       case NativeSpec.Rift(imposterJson) =>
-        serveSpace(NormalizedSource("native", SourcePayload.Raw(imposterJson), None)).map(List(_))
+        serveImposter(NormalizedSource("native", SourcePayload.Raw(imposterJson), None)).map(List(_))
       case NativeSpec.WireMock(_) =>
         ZIO.fail(MockError.InvalidDefinition("the Rift adapter cannot provision a WireMock native spec"))
 
   def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
-    withImposter(space) { imp =>
-      for
-        ruleId <- freshId
-        // First match wins in Mountebank, so an overlay rule goes on top
-        // (index 0) and a base rule is appended after the existing stubs.
-        index <- priority match
-                   case Priority.Overlay => ZIO.succeed(0)
-                   case Priority.Base    => imp.stubs.get.map(_.size)
-        u   <- url(s"/imposters/${imp.port}/stubs")
-        res <- send(jsonRequest(HttpMethod.POST, u, RiftProtocol.addStubBody(index, rule)))
-        _   <- expectSuccess(s"add rule to imposter ${imp.port}", res)
-        _   <- imp.stubs.update(v => if priority == Priority.Overlay then ruleId +: v else v :+ ruleId)
-      yield ruleId
-    }
+    dispatch(space)(cs => corrAddRule(cs, rule, priority))(imp => piAddRule(imp, rule, priority))
 
   def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit] =
-    withImposter(space) { imp =>
-      imp.stubs.get.flatMap { ordered =>
-        ordered.indexOf(id) match
-          case -1 => ZIO.fail(MockError.RuleNotFound(space.id, id))
-          case idx =>
-            for
-              u   <- url(s"/imposters/${imp.port}/stubs/$idx")
-              res <- send(Request(method = HttpMethod.DELETE, url = u))
-              _   <- expectSuccess(s"remove rule from imposter ${imp.port}", res)
-              _   <- imp.stubs.update(_.patch(idx, Nil, 1))
-            yield ()
-      }
-    }
+    dispatch(space)(cs => corrRemoveRule(cs, space.id, id))(imp => piRemoveRule(imp, space.id, id))
 
   def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit] =
-    withImposter(space) { imp =>
-      for
-        ruleIds <- freshIds(rules.size)
-        u       <- url(s"/imposters/${imp.port}/stubs")
-        res     <- send(jsonRequest(HttpMethod.PUT, u, RiftProtocol.replaceStubsBody(rules)))
-        _       <- expectSuccess(s"replace rules on imposter ${imp.port}", res)
-        _       <- imp.stubs.set(ruleIds)
-      yield ()
-    }
+    dispatch(space)(cs => corrReplaceRules(cs, rules))(imp => piReplaceRules(imp, rules))
 
   def destroy(space: MockSpace): IO[MockError, Unit] =
-    withImposter(space) { imp =>
-      for
-        u   <- url(s"/imposters/${imp.port}")
-        res <- send(Request(method = HttpMethod.DELETE, url = u))
-        // A 404 means the imposter is already gone — destroy is idempotent.
-        _ <- ZIO.unless(res._1 == 404)(expectSuccess(s"destroy imposter ${imp.port}", res))
-        _ <- endpoint.releasePort(imp.port)
-        _ <- spaces.update(_ - space.id)
-      yield ()
-    }
+    dispatch(space)(cs => corrDestroy(space.id, cs))(imp => piDestroy(space, imp))
 
   def received(space: MockSpace): IO[MockError, List[RecordedRequest]] =
-    withImposter(space) { imp =>
-      for
-        u    <- url(s"/imposters/${imp.port}")
-        res  <- send(Request(method = HttpMethod.GET, url = u))
-        body <- expectSuccess(s"read imposter ${imp.port}", res)
-        // A malformed view is a backend/protocol fault, not a bad user definition.
-        recs <- ZIO.fromEither(RiftProtocol.parseRecorded(body)).mapError(MockError.CommunicationError(_))
-      yield recs
-    }
+    dispatch(space)(corrReceived)(piReceived)
 
   def faults: IO[Unsupported, Faults]                   = unsupported(Capability.Faults)
   def scenarios: IO[Unsupported, StatefulScenarios]     = unsupported(Capability.StatefulScenarios)
@@ -134,6 +112,27 @@ private[rift] final case class RiftMockControl(
   // ---------------------------------------------------------------------------
 
   private def serveSpace(src: NormalizedSource): IO[MockError, MockSpace] =
+    mode match
+      case RiftMode.Correlated(corr) => serveCorrelatedSpace(src, corr)
+      case RiftMode.PerInstance      => serveImposter(src)
+
+  // A space's operations follow the space, not the mode: a Correlated portable
+  // space, or a PerInstance/native imposter space.
+  private def dispatch[A](space: MockSpace)(onCorr: CorrSpace => IO[MockError, A])(
+    onImp: Imposter => IO[MockError, A]
+  ): IO[MockError, A] =
+    correlated.get.flatMap(_.get(space.id) match
+      case Some(cs) => onCorr(cs)
+      case None =>
+        spaces.get.flatMap(_.get(space.id) match
+          case Some(imp) => onImp(imp)
+          case None      => ZIO.fail(MockError.SpaceNotFound(space.id))
+        )
+    )
+
+  // ===== PerInstance — one imposter per space =====================================
+
+  private def serveImposter(src: NormalizedSource): IO[MockError, MockSpace] =
     endpoint.acquirePort.flatMap { port =>
       val stand =
         for
@@ -144,12 +143,62 @@ private[rift] final case class RiftMockControl(
           stubs        <- Ref.make(ruleIds)
           id            = SpaceId(s"${src.name}-$port")
           space         = MockSpace(endpoint.baseUriFor(port), identity, id)
-          _            <- spaces.update(_.updated(id, RiftMockControl.Imposter(port, stubs)))
+          _            <- spaces.update(_.updated(id, Imposter(port, stubs)))
         yield space
-      // Release the port back to the pool on *any* failure after acquiring it
-      // (malformed source, POST rejected, …) so a bad provision can't leak slots.
       stand.onError(_ => endpoint.releasePort(port))
     }
+
+  private def piAddRule(imp: Imposter, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+    for
+      ruleId <- freshId
+      // First match wins in Mountebank: overlay on top (index 0), base appended.
+      index <- priority match
+                 case Priority.Overlay => ZIO.succeed(0)
+                 case Priority.Base    => imp.stubs.get.map(_.size)
+      u   <- url(s"/imposters/${imp.port}/stubs")
+      res <- send(jsonRequest(HttpMethod.POST, u, RiftProtocol.addStubBody(index, rule)))
+      _   <- expectSuccess(s"add rule to imposter ${imp.port}", res)
+      _   <- imp.stubs.update(v => if priority == Priority.Overlay then ruleId +: v else v :+ ruleId)
+    yield ruleId
+
+  private def piRemoveRule(imp: Imposter, spaceId: SpaceId, id: RuleId): IO[MockError, Unit] =
+    imp.stubs.get.flatMap { ordered =>
+      ordered.indexOf(id) match
+        case -1 => ZIO.fail(MockError.RuleNotFound(spaceId, id))
+        case idx =>
+          for
+            u   <- url(s"/imposters/${imp.port}/stubs/$idx")
+            res <- send(Request(method = HttpMethod.DELETE, url = u))
+            _   <- expectSuccess(s"remove rule from imposter ${imp.port}", res)
+            _   <- imp.stubs.update(_.patch(idx, Nil, 1))
+          yield ()
+    }
+
+  private def piReplaceRules(imp: Imposter, rules: List[MockRule]): IO[MockError, Unit] =
+    for
+      ruleIds <- freshIds(rules.size)
+      u       <- url(s"/imposters/${imp.port}/stubs")
+      res     <- send(jsonRequest(HttpMethod.PUT, u, RiftProtocol.replaceStubsBody(rules)))
+      _       <- expectSuccess(s"replace rules on imposter ${imp.port}", res)
+      _       <- imp.stubs.set(ruleIds)
+    yield ()
+
+  private def piDestroy(space: MockSpace, imp: Imposter): IO[MockError, Unit] =
+    for
+      u   <- url(s"/imposters/${imp.port}")
+      res <- send(Request(method = HttpMethod.DELETE, url = u))
+      _   <- ZIO.unless(res._1 == 404)(expectSuccess(s"destroy imposter ${imp.port}", res))
+      _   <- endpoint.releasePort(imp.port)
+      _   <- spaces.update(_ - space.id)
+    yield ()
+
+  private def piReceived(imp: Imposter): IO[MockError, List[RecordedRequest]] =
+    for
+      u    <- url(s"/imposters/${imp.port}")
+      res  <- send(Request(method = HttpMethod.GET, url = u))
+      body <- expectSuccess(s"read imposter ${imp.port}", res)
+      recs <- ZIO.fromEither(RiftProtocol.parseRecorded(body)).mapError(MockError.CommunicationError(_))
+    yield recs
 
   private def imposterBody(port: Int, src: NormalizedSource): IO[MockError, (Json, Int)] =
     src.payload match
@@ -158,6 +207,114 @@ private[rift] final case class RiftMockControl(
       case SourcePayload.Raw(text) =>
         ZIO.fromEither(RiftProtocol.imposterFromRaw(port, src.name, text)).mapError(MockError.InvalidDefinition(_))
 
+  // ===== Correlated — one shared imposter, spaces by flowId =======================
+
+  private def serveCorrelatedSpace(src: NormalizedSource, corr: Correlation): IO[MockError, MockSpace] =
+    for
+      rules  <- rulesOf(src)
+      port   <- ensureSharedImposter(corr)
+      id     <- freshSpaceId(src.name)
+      flowId  = corr.value(id)
+      tagged <- tagRules(rules)
+      // Mirror serveImposter's release-on-error: if a stub POST fails partway, tear
+      // the half-built flow down so it can't orphan stubs on the shared imposter.
+      _        <- registerStubs(port, flowId, tagged).onError(_ => deleteSpace(port, flowId).ignore)
+      rulesRef <- Ref.make(tagged)
+      _        <- correlated.update(_.updated(id, CorrSpace(port, flowId, corr.header, rulesRef)))
+    yield MockSpace(endpoint.baseUriFor(port), req => req.copy(headers = req.headers + (corr.header -> flowId)), id)
+
+  // Create the one shared imposter on first Correlated provision (race-safe).
+  private def ensureSharedImposter(corr: Correlation): IO[MockError, Int] =
+    sharedPort.modifyZIO {
+      case existing @ Some(p) => ZIO.succeed((p, existing))
+      case None =>
+        endpoint.acquirePort.flatMap { p =>
+          postImposter(p, RiftProtocol.correlatedImposter(p, "correlated", corr.header))
+            .as((p, Some(p)))
+            .onError(_ => endpoint.releasePort(p))
+        }
+    }
+
+  private def corrAddRule(cs: CorrSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+    freshId.flatMap { ruleId =>
+      val tagged = (ruleId, rule)
+      // Server-first, then commit tracking — so a failed admin call never leaves
+      // `cs.rules` claiming a stub the server didn't accept (mirrors PerInstance).
+      val act = priority match
+        // Base appends (Rift's space POST appends).
+        case Priority.Base =>
+          postSpaceStub(cs.port, cs.flowId, rule.copy(id = Some(ruleId))) *> cs.rules.update(_ :+ tagged)
+        // Overlay must be first-match — rebuild with the prepended set.
+        case Priority.Overlay =>
+          cs.rules.get.flatMap(cur => rebuildSpaceWith(cs, tagged +: cur) *> cs.rules.set(tagged +: cur))
+      act.as(ruleId)
+    }
+
+  private def corrRemoveRule(cs: CorrSpace, spaceId: SpaceId, id: RuleId): IO[MockError, Unit] =
+    cs.rules.get.flatMap { v =>
+      if !v.exists(_._1 == id) then ZIO.fail(MockError.RuleNotFound(spaceId, id))
+      else
+        val next = v.filterNot(_._1 == id)
+        rebuildSpaceWith(cs, next) *> cs.rules.set(next) // commit tracking only on success
+    }
+
+  private def corrReplaceRules(cs: CorrSpace, rules: List[MockRule]): IO[MockError, Unit] =
+    tagRules(rules).flatMap(next => rebuildSpaceWith(cs, next) *> cs.rules.set(next))
+
+  private def corrDestroy(spaceId: SpaceId, cs: CorrSpace): IO[MockError, Unit] =
+    deleteSpace(cs.port, cs.flowId) *> correlated.update(_ - spaceId)
+
+  private def corrReceived(cs: CorrSpace): IO[MockError, List[RecordedRequest]] =
+    for
+      u    <- url(s"/imposters/${cs.port}/requests?match=${enc(s"header:${cs.header}=${cs.flowId}")}")
+      res  <- send(Request(method = HttpMethod.GET, url = u))
+      body <- expectSuccess(s"read filtered requests for space ${cs.flowId}", res)
+      recs <- ZIO.fromEither(RiftProtocol.parseRequestsArray(body)).mapError(MockError.CommunicationError(_))
+    yield recs
+
+  // rift#223 has no per-stub-in-space delete: re-register `rules` as the space's
+  // stubs after a whole-space teardown. Server-first — the caller commits
+  // tracking only on success. A mid-rebuild failure leaves the space's *server*
+  // stubs partial (surfaced as a CommunicationError); tracking is left unchanged.
+  // (A successful rebuild also clears the space's recorded requests + flow state
+  // — benign at scenario boundaries; see the class doc.)
+  private def rebuildSpaceWith(cs: CorrSpace, rules: Vector[(RuleId, MockRule)]): IO[MockError, Unit] =
+    deleteSpace(cs.port, cs.flowId) *> registerStubs(cs.port, cs.flowId, rules)
+
+  // Assign each rule a fresh id, keyed for tracking + re-registration under a space.
+  private def tagRules(rules: List[MockRule]): UIO[Vector[(RuleId, MockRule)]] =
+    freshIds(rules.size).map(ids => rules.zip(ids).map((r, rid) => (rid, r)).toVector)
+
+  private def registerStubs(port: Int, flowId: String, rules: Vector[(RuleId, MockRule)]): IO[MockError, Unit] =
+    ZIO.foreachDiscard(rules)((rid, rule) => postSpaceStub(port, flowId, rule.copy(id = Some(rid))))
+
+  private def postSpaceStub(port: Int, flowId: String, rule: MockRule): IO[MockError, Unit] =
+    for
+      u   <- url(s"/imposters/$port/spaces/${enc(flowId)}/stubs")
+      res <- send(jsonRequest(HttpMethod.POST, u, RiftProtocol.stub(rule)))
+      _   <- expectSuccess(s"add space stub to $flowId", res)
+    yield ()
+
+  private def deleteSpace(port: Int, flowId: String): IO[MockError, Unit] =
+    for
+      u   <- url(s"/imposters/$port/spaces/${enc(flowId)}")
+      res <- send(Request(method = HttpMethod.DELETE, url = u))
+      // A 404 means the space is already gone — teardown is idempotent.
+      _ <- ZIO.unless(res._1 == 404)(expectSuccess(s"teardown space $flowId", res))
+    yield ()
+
+  private def rulesOf(src: NormalizedSource): IO[MockError, List[MockRule]] =
+    src.payload match
+      case SourcePayload.Rules(rules) => ZIO.succeed(rules)
+      case SourcePayload.Raw(_) =>
+        ZIO.fail(
+          MockError.InvalidDefinition(
+            "Correlated mode needs portable rule sources; provision a raw Rift imposter via provisionNative"
+          )
+        )
+
+  // ===== shared admin plumbing =====================================================
+
   private def postImposter(port: Int, body: Json): IO[MockError, Unit] =
     for
       u   <- url("/imposters")
@@ -165,17 +322,34 @@ private[rift] final case class RiftMockControl(
       _   <- expectSuccess(s"create imposter on port $port", res)
     yield ()
 
+  // Best-effort teardown of the shared Correlated imposter — the one imposter no
+  // single space owns (PerInstance leaves `sharedPort` empty, so this is a no-op).
+  // Registered as a scope finalizer in `make` so it is reclaimed in `connect`
+  // mode too, not only when `managed` stops the container.
+  private[rift] def teardownShared: UIO[Unit] =
+    sharedPort.get.flatMap {
+      case Some(p) =>
+        (deleteImposter(p) *> endpoint.releasePort(p))
+          .catchAllCause(c => ZIO.logWarningCause("shared Correlated imposter teardown failed", c))
+      case None => ZIO.unit
+    }
+
+  private def deleteImposter(port: Int): IO[MockError, Unit] =
+    for
+      u   <- url(s"/imposters/$port")
+      res <- send(Request(method = HttpMethod.DELETE, url = u))
+      _   <- ZIO.unless(res._1 == 404)(expectSuccess(s"delete shared imposter $port", res))
+    yield ()
+
   private def freshId: UIO[RuleId] = ids.updateAndGet(_ + 1).map(n => RuleId(s"r$n"))
 
   private def freshIds(n: Int): UIO[Vector[RuleId]] = ZIO.foreach(0 until n)(_ => freshId).map(_.toVector)
 
-  private def withImposter[A](space: MockSpace)(f: RiftMockControl.Imposter => IO[MockError, A]): IO[MockError, A] =
-    spaces.get.flatMap(_.get(space.id) match
-      case Some(imp) => f(imp)
-      case None      => ZIO.fail(MockError.SpaceNotFound(space.id))
-    )
+  private def freshSpaceId(name: String): UIO[SpaceId] = ids.updateAndGet(_ + 1).map(n => SpaceId(s"$name-s$n"))
 
   private def unsupported[A](c: Capability): IO[Unsupported, A] = ZIO.fail(Unsupported(c, backendName))
+
+  private def enc(s: String): String = URLEncoder.encode(s, UTF_8)
 
   private def url(path: String): IO[MockError, URL] =
     ZIO
@@ -203,15 +377,21 @@ private[rift] final case class RiftMockControl(
 
 private[rift] object RiftMockControl:
   final case class Imposter(port: Int, stubs: Ref[Vector[RuleId]])
+  final case class CorrSpace(port: Int, flowId: String, header: String, rules: Ref[Vector[(RuleId, MockRule)]])
 
   /**
-   * Build an adapter against an endpoint, taking the zio-http [[Client]] and
-   * [[Provisioning]] from the environment.
+   * Build an adapter against an endpoint in the given isolation `mode`, taking
+   * the zio-http [[Client]] and [[Provisioning]] from the environment. Scoped:
+   * the shared Correlated imposter is torn down when the scope closes.
    */
-  def make(endpoint: RiftEndpoint): URIO[Client & Provisioning, MockControl] =
+  def make(endpoint: RiftEndpoint, mode: RiftMode): URIO[Client & Provisioning & Scope, MockControl] =
     for
-      client <- ZIO.service[Client]
-      prov   <- ZIO.service[Provisioning]
-      spaces <- Ref.make(Map.empty[SpaceId, Imposter])
-      ids    <- Ref.make(0)
-    yield RiftMockControl(endpoint, client, prov, spaces, ids)
+      client     <- ZIO.service[Client]
+      prov       <- ZIO.service[Provisioning]
+      spaces     <- Ref.make(Map.empty[SpaceId, Imposter])
+      correlated <- Ref.make(Map.empty[SpaceId, CorrSpace])
+      sharedPort <- Ref.Synchronized.make(Option.empty[Int])
+      ids        <- Ref.make(0)
+      control     = RiftMockControl(endpoint, client, prov, mode, spaces, correlated, sharedPort, ids)
+      _          <- ZIO.addFinalizer(control.teardownShared)
+    yield control

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -28,6 +28,24 @@ private[rift] object RiftProtocol:
       "stubs"          -> Json.Arr(rules.map(stub)*)
     )
 
+  /**
+   * The shared imposter for Correlated isolation (#156): empty stubs (added per
+   * space via `POST /imposters/:port/spaces/:flowId/stubs`) and a flow-id
+   * source of `header:<correlationHeader>`, so Rift partitions stubs + recorded
+   * requests by that header natively (rift#223).
+   */
+  def correlatedImposter(port: Int, name: String, correlationHeader: String): Json =
+    Json.Obj(
+      "port"           -> Json.Num(port),
+      "protocol"       -> Json.Str("http"),
+      "name"           -> Json.Str(name),
+      "recordRequests" -> Json.Bool(true),
+      "stubs"          -> Json.Arr(),
+      "flowState" -> Json.Obj(
+        "mountebankStateMapping" -> Json.Obj("flowIdSource" -> Json.Str(s"header:$correlationHeader"))
+      )
+    )
+
   /** A single Mountebank stub: predicates (ANDed) + one response. */
   def stub(rule: MockRule): Json =
     val idField = rule.id.map(id => "id" -> Json.Str(id.value)).toList
@@ -103,16 +121,18 @@ private[rift] object RiftProtocol:
 
   /** Parse the `requests[]` of a `GET /imposters/:port` view. */
   def parseRecorded(viewJson: String): Either[String, List[RecordedRequest]] =
-    viewJson.fromJson[WireView].map { v =>
-      v.requests.getOrElse(Nil).map { r =>
-        RecordedRequest(
-          method = methodFromWire(r.method),
-          uri = r.path,
-          headers = r.headers.getOrElse(Map.empty),
-          body = r.body
-        )
-      }
-    }
+    viewJson.fromJson[WireView].map(_.requests.getOrElse(Nil).map(toRecorded))
+
+  /**
+   * Parse the bare JSON array returned by `GET
+   * /imposters/:port/requests?match=…` — the header/flow-id-filtered recorded
+   * requests (rift#201), used by Correlated `received`.
+   */
+  def parseRequestsArray(arrayJson: String): Either[String, List[RecordedRequest]] =
+    arrayJson.fromJson[List[WireReq]].map(_.map(toRecorded))
+
+  private def toRecorded(r: WireReq): RecordedRequest =
+    RecordedRequest(methodFromWire(r.method), r.path, r.headers.getOrElse(Map.empty), r.body)
 
   // ---------------------------------------------------------------------------
   // helpers

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -31,8 +31,11 @@ private[rift] object RiftProtocol:
   /**
    * The shared imposter for Correlated isolation (#156): empty stubs (added per
    * space via `POST /imposters/:port/spaces/:flowId/stubs`) and a flow-id
-   * source of `header:<correlationHeader>`, so Rift partitions stubs + recorded
-   * requests by that header natively (rift#223).
+   * source of `header:<correlationHeader>`, so Rift resolves each request's
+   * flow + gates stubs/recorded requests by that header natively (rift#223).
+   * The flow-state config is a backend-native extension, so it lives under
+   * `_rift.flowState`
+   * (`imposter.config.rift.flowState.mountebankStateMapping.flowIdSource`).
    */
   def correlatedImposter(port: Int, name: String, correlationHeader: String): Json =
     Json.Obj(
@@ -41,8 +44,12 @@ private[rift] object RiftProtocol:
       "name"           -> Json.Str(name),
       "recordRequests" -> Json.Bool(true),
       "stubs"          -> Json.Arr(),
-      "flowState" -> Json.Obj(
-        "mountebankStateMapping" -> Json.Obj("flowIdSource" -> Json.Str(s"header:$correlationHeader"))
+      "_rift" -> Json.Obj(
+        "flowState" -> Json.Obj(
+          "backend"                -> Json.Str("inmemory"),
+          "ttlSeconds"             -> Json.Num(300),
+          "mountebankStateMapping" -> Json.Obj("flowIdSource" -> Json.Str(s"header:$correlationHeader"))
+        )
       )
     )
 

--- a/rift/src/test/scala/zio/bdd/mock/rift/FakeRift.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/FakeRift.scala
@@ -9,14 +9,20 @@ import zio.json.ast.Json
  * adapter makes and serves canned imposter views, so the adapter's protocol and
  * isolation behaviour can be unit-tested with no Docker and no real backend.
  *
- * It deliberately does NOT serve imposter traffic — "serving" is the real
- * container's job, proven by the tagged [[RiftContainerSpec]].
+ * It deliberately does NOT serve imposter traffic, nor does it actually filter
+ * recorded requests — "serving" and the real header/flow-id filter are the real
+ * container's job, proven by the tagged [[RiftContainerSpec]]. Here we assert
+ * the adapter *issues* the right space-scoped calls.
  */
 final case class FakeRift(
   posted: Ref[Chunk[String]],
   deletedPorts: Ref[Chunk[Int]],
   globalDeletes: Ref[Int],
   stubCalls: Ref[Chunk[String]],
+  spaceStubs: Ref[Chunk[String]],
+  spaceDeletes: Ref[Chunk[String]],
+  requestMatches: Ref[Chunk[String]],
+  filtered: Ref[String],
   views: Ref[Map[Int, String]],
   failProvision: Ref[Boolean]
 ):
@@ -24,6 +30,11 @@ final case class FakeRift(
    * Preset the `GET /imposters/:port` view (e.g. to inject recorded requests).
    */
   def setView(port: Int, json: String): UIO[Unit] = views.update(_.updated(port, json))
+
+  /**
+   * Preset the body returned by `GET /imposters/:port/requests?match=…` (#201).
+   */
+  def setFiltered(json: String): UIO[Unit] = filtered.set(json)
 
   val routes: Routes[Any, Response] =
     Routes(
@@ -41,6 +52,23 @@ final case class FakeRift(
                 ZIO.succeed(Response(status = Status.Created, body = Body.fromString(s"""{"port":$port}""")))
           }
         }
+      },
+      // Space-scoped stubs (rift#223): POST /imposters/:port/spaces/:flowId/stubs
+      Method.POST / "imposters" / int("port") / "spaces" / string("flowId") / "stubs" -> handler {
+        (port: Int, flowId: String, req: Request) =>
+          req.body.asString.orDie
+            .flatMap(b => spaceStubs.update(_ :+ s"$port/$flowId $b"))
+            .as(Response(status = Status.Created, body = Body.fromString(s"""{"space":"$flowId","stubs":[]}""")))
+      },
+      // Per-space teardown (rift#223): DELETE /imposters/:port/spaces/:flowId
+      Method.DELETE / "imposters" / int("port") / "spaces" / string("flowId") -> handler {
+        (port: Int, flowId: String, _: Request) =>
+          spaceDeletes.update(_ :+ s"$port/$flowId").as(Response.ok)
+      },
+      // Header/flow-id-filtered recorded requests (rift#201): GET /imposters/:port/requests?match=…
+      Method.GET / "imposters" / int("port") / "requests" -> handler { (_: Int, req: Request) =>
+        val m = req.url.queryParams.queryParam("match").getOrElse("")
+        (requestMatches.update(_ :+ m) *> filtered.get).map(f => Response(body = Body.fromString(f)))
       },
       Method.GET / "imposters" / int("port") -> handler { (port: Int, _: Request) =>
         views.get.map(m => Response(body = Body.fromString(m.getOrElse(port, FakeRift.emptyView(port)))))
@@ -68,13 +96,17 @@ object FakeRift:
 
   def make: UIO[FakeRift] =
     for
-      a <- Ref.make(Chunk.empty[String])
-      b <- Ref.make(Chunk.empty[Int])
-      c <- Ref.make(0)
-      d <- Ref.make(Chunk.empty[String])
-      e <- Ref.make(Map.empty[Int, String])
-      f <- Ref.make(false)
-    yield FakeRift(a, b, c, d, e, f)
+      a  <- Ref.make(Chunk.empty[String])
+      b  <- Ref.make(Chunk.empty[Int])
+      c  <- Ref.make(0)
+      d  <- Ref.make(Chunk.empty[String])
+      ss <- Ref.make(Chunk.empty[String])
+      sd <- Ref.make(Chunk.empty[String])
+      rm <- Ref.make(Chunk.empty[String])
+      fl <- Ref.make("[]")
+      e  <- Ref.make(Map.empty[Int, String])
+      f  <- Ref.make(false)
+    yield FakeRift(a, b, c, d, ss, sd, rm, fl, e, f)
 
   def portOf(body: String): Option[Int] =
     import zio.json.*

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
@@ -88,6 +88,41 @@ object RiftContainerSpec extends ZIOSpecDefault:
     }
   ).provideSome[Client](Provisioning.live, riftBackend) @@ TestAspect.sequential @@ TestAspect.withLiveClock
 
+  // Correlated isolation (#156): one shared imposter, spaces told apart by the
+  // X-Mock-Space header. The SAME checks pass with a one-line layer swap (AC1),
+  // and received(A) returns only A's traffic on the shared imposter (AC2).
+  private val correlatedSuite = suite("RiftContainerSpec — Correlated (shared imposter)")(
+    test("provision/serve/record/destroy pass on correlated() too (the one-line swap)") {
+      for
+        control <- ZIO.service[MockControl]
+        space   <- control.provision(pingSource).map(_.head)
+        resp    <- SutClient.make(space).send(Method.Get, "/ping").retry(upWithin) // inject stamps X-Mock-Space
+        recv    <- control.received(space)
+        _       <- control.destroy(space)
+      yield assertTrue(
+        control.isolation == Isolation.Correlated,
+        resp.status == 200 && resp.body == "pong",                   // serves via inject
+        recv.exists(r => r.method == Method.Get && r.uri == "/ping") // records (header-filtered)
+      )
+    },
+    test("received(A) returns only A's traffic on the shared imposter (rift#201 filter)") {
+      for
+        control <- ZIO.service[MockControl]
+        a       <- control.provision(pingSource).map(_.head)
+        b       <- control.provision(pingSource).map(_.head)
+        _       <- SutClient.make(a).send(Method.Get, "/ping").retry(upWithin)
+        _       <- SutClient.make(b).send(Method.Get, "/ping").retry(upWithin)
+        _       <- SutClient.make(b).send(Method.Get, "/ping")
+        ra      <- control.received(a)
+        rb      <- control.received(b)
+      yield assertTrue(
+        a.baseUri == b.baseUri, // one shared imposter
+        ra.size == 1,           // only A's request
+        rb.size == 2            // only B's
+      )
+    }
+  ).provideSome[Client](Provisioning.live, correlatedBackend) @@ TestAspect.sequential @@ TestAspect.withLiveClock
+
   // Two ways to reach a real Rift: testcontainers spins one up (default), or —
   // when RIFT_ADMIN points at an already-running Rift admin URL whose imposter
   // ports are mapped 1:1 to localhost — connect to it directly. The latter
@@ -98,6 +133,13 @@ object RiftContainerSpec extends ZIOSpecDefault:
       case Some(admin) => Rift.connect(admin, (4545 until 4561).toList)(p => s"http://localhost:$p")
       case None        => Rift.managed()
 
+  private def correlatedBackend: ZLayer[Client & Provisioning, MockError, MockControl] =
+    sys.env.get("RIFT_ADMIN") match
+      case Some(admin) =>
+        Rift.connect(admin, (4545 until 4561).toList, RiftMode.correlated)(p => s"http://localhost:$p")
+      case None => Rift.managed(mode = RiftMode.correlated)
+
   def spec =
-    if sys.env.contains("RIFT_IT") then realSuite.provideShared(Client.default)
+    if sys.env.contains("RIFT_IT") then
+      suite("Rift container ITs")(realSuite, correlatedSuite).provideShared(Client.default)
     else suite("RiftContainerSpec (skipped — set RIFT_IT=1 to run against a real Rift container)")()

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -363,6 +363,7 @@ object RiftMockControlSpec extends ZIOSpecDefault:
             control.isolation == Isolation.Correlated,
             posted.size == 1,                                                 // ONE shared imposter for both spaces
             posted.head.contains("\"flowIdSource\":\"header:X-Mock-Space\""), // Rift gates by the header natively
+            posted.head.contains("\"_rift\""),                                // flow-state lives under _rift (native ext), not top-level
             a.baseUri == b.baseUri,                                           // shared imposter -> shared baseUri
             stubs.exists(_.contains(s"/${a.id.value} ")),                     // A's stub scoped under A's flowId
             stubs.exists(_.contains(s"/${b.id.value} ")),

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -27,7 +27,7 @@ object RiftMockControlSpec extends ZIOSpecDefault:
    * Set up a fresh fake admin server + a Rift adapter (with the given imposter
    * port pool) bound to it, in a scope.
    */
-  private def withAdapterPool(ports: List[Int])(
+  private def withAdapterPool(ports: List[Int], mode: RiftMode = RiftMode.PerInstance)(
     use: (MockControl, FakeRift) => UIO[TestResult]
   ): ZIO[Client & Provisioning, Throwable, TestResult] =
     ZIO.scoped {
@@ -35,7 +35,7 @@ object RiftMockControlSpec extends ZIOSpecDefault:
         adminAndFake <- FakeRift.started
         (admin, fake) = adminAndFake
         endpoint     <- RiftEndpoint.pooled(admin, ports)(p => s"http://localhost:$p")
-        control      <- RiftMockControl.make(endpoint)
+        control      <- RiftMockControl.make(endpoint, mode)
         result       <- use(control, fake)
       yield result
     }
@@ -44,6 +44,16 @@ object RiftMockControlSpec extends ZIOSpecDefault:
     use: (MockControl, FakeRift) => UIO[TestResult]
   ): ZIO[Client & Provisioning, Throwable, TestResult] =
     withAdapterPool((4545 until 4600).toList)(use)
+
+  private def withCorrelated(
+    use: (MockControl, FakeRift) => UIO[TestResult]
+  ): ZIO[Client & Provisioning, Throwable, TestResult] =
+    withAdapterPool((4545 until 4600).toList, RiftMode.correlated)(use)
+
+  private def withCorrelatedTraceparent(
+    use: (MockControl, FakeRift) => UIO[TestResult]
+  ): ZIO[Client & Provisioning, Throwable, TestResult] =
+    withAdapterPool((4545 until 4600).toList, RiftMode.Correlated(Correlation.traceparent))(use)
 
   def spec = suite("RiftMockControl (adapter vs fake admin API)")(
     test("the Rift adapter's isolation model is PerInstance (own port, identity inject)") {
@@ -333,6 +343,164 @@ object RiftMockControlSpec extends ZIOSpecDefault:
             case _                                 => false
           }
         )
+      }
+    },
+    test(
+      "Correlated: provision uses ONE shared imposter (flowIdSource header) with space-scoped stubs; inject stamps the header"
+    ) {
+      withCorrelated { (control, fake) =>
+        for
+          aE     <- control.provision(pingSource).either
+          bE     <- control.provision(pingSource).either
+          posted <- fake.posted.get
+          stubs  <- fake.spaceStubs.get
+        yield
+          val a   = aE.toOption.get.head
+          val b   = bE.toOption.get.head
+          val req = HttpRequest(Method.Get, "http://sut/x")
+          assertTrue(
+            aE.isRight && bE.isRight,
+            control.isolation == Isolation.Correlated,
+            posted.size == 1,                                                 // ONE shared imposter for both spaces
+            posted.head.contains("\"flowIdSource\":\"header:X-Mock-Space\""), // Rift gates by the header natively
+            a.baseUri == b.baseUri,                                           // shared imposter -> shared baseUri
+            stubs.exists(_.contains(s"/${a.id.value} ")),                     // A's stub scoped under A's flowId
+            stubs.exists(_.contains(s"/${b.id.value} ")),
+            a.inject(req).headers.get("X-Mock-Space").contains(a.id.value), // inject routes the request to A
+            a.inject(req).headers.get("X-Mock-Space") != b.inject(req).headers.get("X-Mock-Space")
+          )
+      }
+    },
+    test(
+      "Correlated: destroy(A) tears down only A's space (DELETE /spaces/:flowId) — never the imposter or a global reset"
+    ) {
+      withCorrelated { (control, fake) =>
+        for
+          aE       <- control.provision(pingSource).either
+          bE       <- control.provision(pingSource).either
+          a         = aE.toOption.get.head
+          b         = bE.toOption.get.head
+          destroyE <- control.destroy(a).either
+          spaceDel <- fake.spaceDeletes.get
+          ports    <- fake.deletedPorts.get
+          globals  <- fake.globalDeletes.get
+          recvB    <- control.received(b).either
+          recvA    <- control.received(a).either
+        yield assertTrue(
+          destroyE.isRight,
+          spaceDel.exists(_.endsWith(s"/${a.id.value}")),  // A's space torn down
+          !spaceDel.exists(_.endsWith(s"/${b.id.value}")), // B's untouched
+          ports.isEmpty,                                   // the shared imposter is NOT deleted
+          globals == 0,                                    // never DELETE /imposters
+          recvB.isRight,
+          recvA == Left(MockError.SpaceNotFound(a.id)) // A is gone from the adapter
+        )
+      }
+    },
+    test("Correlated: received(A) reads the header-filtered requests endpoint (rift#201) and parses the array") {
+      withCorrelated { (control, fake) =>
+        for
+          sE      <- control.provision(pingSource).either
+          s        = sE.toOption.get.head
+          _       <- fake.setFiltered("""[{"method":"GET","path":"/ping","headers":{},"body":null}]""")
+          recvE   <- control.received(s).either
+          matches <- fake.requestMatches.get
+        yield assertTrue(
+          recvE == Right(List(RecordedRequest(Method.Get, "/ping", Map.empty, None))),
+          matches.exists(_.contains(s"header:X-Mock-Space=${s.id.value}")) // filtered by THIS space's flowId
+        )
+      }
+    },
+    test("Correlated: addRule(Base) appends a space-scoped stub") {
+      withCorrelated { (control, fake) =>
+        for
+          sE     <- control.provision(pingSource).either
+          s       = sE.toOption.get.head
+          before <- fake.spaceStubs.get
+          addE   <- control.addRule(s, pingRule, Priority.Base).either
+          after  <- fake.spaceStubs.get
+        yield assertTrue(addE.isRight, after.size == before.size + 1, after.exists(_.contains(s"/${s.id.value} ")))
+      }
+    },
+    test("Correlated: replaceRules rebuilds the space (DELETE /spaces/:flowId then re-POSTs the new set)") {
+      withCorrelated { (control, fake) =>
+        for
+          sE         <- control.provision(pingSource).either // posts 1 stub under the flowId
+          s           = sE.toOption.get.head
+          delsBefore <- fake.spaceDeletes.get
+          replE      <- control.replaceRules(s, List(pingRule, pingRule)).either
+          dels       <- fake.spaceDeletes.get
+          stubs      <- fake.spaceStubs.get
+        yield assertTrue(
+          replE.isRight,
+          delsBefore.isEmpty,
+          dels.exists(_.endsWith(s"/${s.id.value}")),      // rebuilt via space teardown
+          stubs.count(_.contains(s"/${s.id.value} ")) == 3 // 1 (provision) + 2 (re-POST after delete)
+        )
+      }
+    },
+    test("Correlated: addRule(Overlay) rebuilds the space so the overlay is first-match") {
+      withCorrelated { (control, fake) =>
+        for
+          sE    <- control.provision(pingSource).either // 1 base stub
+          s      = sE.toOption.get.head
+          ovE   <- control.addRule(s, pingRule, Priority.Overlay).either
+          dels  <- fake.spaceDeletes.get
+          stubs <- fake.spaceStubs.get
+        yield assertTrue(
+          ovE.isRight,
+          dels.exists(_.endsWith(s"/${s.id.value}")),      // overlay triggers a rebuild
+          stubs.count(_.contains(s"/${s.id.value} ")) == 3 // 1 (provision) + 2 (rebuild: overlay + base)
+        )
+      }
+    },
+    test("Correlated: removeRule rebuilds; an unknown id fails RuleNotFound without touching the server") {
+      withCorrelated { (control, fake) =>
+        for
+          sE      <- control.provision(pingSource).either
+          s        = sE.toOption.get.head
+          addE    <- control.addRule(s, pingRule, Priority.Base).either
+          rmE     <- ZIO.fromEither(addE).flatMap(id => control.removeRule(s, id)).either // rebuild
+          dels    <- fake.spaceDeletes.get
+          ghostE  <- control.removeRule(s, RuleId("ghost")).either
+          delsEnd <- fake.spaceDeletes.get
+        yield assertTrue(
+          addE.isRight,
+          rmE.isRight,
+          dels.exists(_.endsWith(s"/${s.id.value}")), // removeRule rebuilt the space
+          ghostE == Left(MockError.RuleNotFound(s.id, RuleId("ghost"))),
+          delsEnd.size == dels.size // a failed removeRule never hit the server
+        )
+      }
+    },
+    test(
+      "Correlated(traceparent): shared imposter uses flowIdSource header:traceparent; inject stamps a distinct traceparent per space"
+    ) {
+      withCorrelatedTraceparent { (control, fake) =>
+        for
+          aE     <- control.provision(pingSource).either
+          bE     <- control.provision(pingSource).either
+          posted <- fake.posted.get
+        yield
+          val a   = aE.toOption.get.head
+          val b   = bE.toOption.get.head
+          val req = HttpRequest(Method.Get, "http://sut/")
+          val ta  = a.inject(req).headers.get("traceparent")
+          assertTrue(
+            aE.isRight && bE.isRight,
+            posted.head.contains("\"flowIdSource\":\"header:traceparent\""),
+            ta.exists(_.matches("00-[0-9a-f]{32}-[0-9a-f]{16}-01")), // W3C traceparent shape
+            ta != b.inject(req).headers.get("traceparent")           // distinct per space
+          )
+      }
+    },
+    test("Correlated: a raw (non-portable) source is rejected with InvalidDefinition (use provisionNative)") {
+      withCorrelated { (control, _) =>
+        for e <- control.provision(MockSource.Json("""{"port":1,"protocol":"http","stubs":[]}""")).either
+        yield assertTrue(e.swap.toOption.exists {
+          case MockError.InvalidDefinition(_) => true
+          case _                              => false
+        })
       }
     }
   ).provide(Client.default, Provisioning.live) @@ TestAspect.withLiveClock


### PR DESCRIPTION
Adds a **Correlated** isolation mode to the Rift adapter (`Rift.managed(mode = RiftMode.correlated)` / `Rift.connect(..., RiftMode.correlated)`), mirroring the WireMock `Mode` split: one shared imposter, spaces told apart by an `X-Mock-Space` (or `traceparent`) correlation header. `PerInstance` (port-per-space) stays the default. Built on **rift#223** (space-scoped stubs + per-space teardown) and **rift#201** (header-filtered recorded requests), both shipped in rift v0.4.0.

- `inject` stamps the correlation header; stubs register under the space (`POST /imposters/:port/spaces/:flowId/stubs`); `received` filters via the rift#201 `?match=header:…` endpoint; `destroy` tears down exactly that space (`DELETE /imposters/:port/spaces/:flowId`).
- Per-space ops dispatch by which space a `MockSpace` belongs to, so native imposters (own port) coexist with Correlated spaces.
- `removeRule`/`replaceRules` (and an `Overlay` `addRule`) rebuild the space — rift#223 has no per-stub-in-space delete — server-first so tracking never claims a ruleset the server didn't accept. The shared imposter is reclaimed by a scope finalizer (no leak in `connect` mode).

## Acceptance
- **AC1** — a suite swaps `perInstance` ↔ `correlated()` with a one-line layer change and passes either way.
- **AC2** — Correlated `received(A)` returns only A's traffic on the shared imposter, verified against a real Rift container (rift#201 filter).

## Verification
800 tests pass (9 new fake-admin Correlated unit tests). AC2's end-to-end proof + the AC1 swap run under the `RIFT_IT`-gated `RiftContainerSpec` against a real container in CI (local testcontainers can't resolve the Docker socket from the sandbox). Mutants confirm the gate: dropping the rebuild `DELETE` flips all 3 rebuild tests; dropping `flowIdSource` flips the provision test.

Closes #156
Milestone: M2