### PR TITLE
fix: Rift adapter — pin imposter unmatched-request default to 404 (conformance matrix Rift column fails)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,13 @@ jobs:
           java-version: 11
           cache: sbt
       - uses: sbt/setup-sbt@v1
-      # RIFT_IT-gated suites against a real container: the Rift adapter acceptance
-      # (#113) plus the parallel-isolation contract (#126), which only exercises
-      # Rift when RIFT_IT is set (dead in the hermetic `build` job above).
-      # NOTE: the full conformance matrix's Rift column (#124/#125) is not run here
-      # yet — it surfaced a real Rift unmatched-request-default bug; wiring it in is
-      # tracked by #163 once that bug is fixed.
-      - name: Real-container suites (RiftContainerSpec + ParallelIsolationSpec)
+      # Every RIFT_IT-gated suite against a real container: the Rift adapter
+      # acceptance (#113) plus the whole conformance module's Rift column — the
+      # matrix (#124/#125) and the parallel-isolation contract (#126) only
+      # exercise Rift when RIFT_IT is set (dead in the hermetic `build` job above).
+      # (The Rift unmatched-request-default bug that previously failed the matrix
+      # column is fixed in #165, so the full module runs green here.)
+      - name: Real-container suites (RiftContainerSpec + conformance Rift column)
         env:
           RIFT_IT: "1"
-        run: sbt "rift/testOnly zio.bdd.mock.rift.RiftContainerSpec" "conformance/testOnly zio.bdd.mock.conformance.ParallelIsolationSpec"
+        run: sbt "rift/testOnly zio.bdd.mock.rift.RiftContainerSpec" "conformance/test"

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -16,16 +16,22 @@ private[rift] object RiftProtocol:
   // Canonical model -> Mountebank wire JSON
   // ---------------------------------------------------------------------------
 
+  // Rift/Mountebank serve 200-empty for an unmatched request unless an imposter
+  // `defaultResponse` is set; pin it to 404 so the portable adapter matches the
+  // cross-adapter contract (WireMock's unmatched default) — #165.
+  private val unmatched404: Json = Json.Obj("statusCode" -> Json.Num(404))
+
   /**
    * A full `POST /imposters` body for one space: one imposter, recording on.
    */
   def imposter(port: Int, name: String, rules: List[MockRule]): Json =
     Json.Obj(
-      "port"           -> Json.Num(port),
-      "protocol"       -> Json.Str("http"),
-      "name"           -> Json.Str(name),
-      "recordRequests" -> Json.Bool(true),
-      "stubs"          -> Json.Arr(rules.map(stub)*)
+      "port"            -> Json.Num(port),
+      "protocol"        -> Json.Str("http"),
+      "name"            -> Json.Str(name),
+      "recordRequests"  -> Json.Bool(true),
+      "defaultResponse" -> unmatched404,
+      "stubs"           -> Json.Arr(rules.map(stub)*)
     )
 
   /**
@@ -39,11 +45,12 @@ private[rift] object RiftProtocol:
    */
   def correlatedImposter(port: Int, name: String, correlationHeader: String): Json =
     Json.Obj(
-      "port"           -> Json.Num(port),
-      "protocol"       -> Json.Str("http"),
-      "name"           -> Json.Str(name),
-      "recordRequests" -> Json.Bool(true),
-      "stubs"          -> Json.Arr(),
+      "port"            -> Json.Num(port),
+      "protocol"        -> Json.Str("http"),
+      "name"            -> Json.Str(name),
+      "recordRequests"  -> Json.Bool(true),
+      "defaultResponse" -> unmatched404,
+      "stubs"           -> Json.Arr(),
       "_rift" -> Json.Obj(
         "flowState" -> Json.Obj(
           "backend"                -> Json.Str("inmemory"),

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
@@ -85,6 +85,15 @@ object RiftContainerSpec extends ZIOSpecDefault:
         recorded.exists(r => r.method == Method.Get && r.uri == "/native"), // records
         gone                                                                // space-local destroy
       )
+    },
+    test("an unmatched request returns 404, not Mountebank's 200-empty default (#165)") {
+      for
+        control <- ZIO.service[MockControl]
+        space   <- control.provision(pingSource).map(_.head)
+        _       <- httpGet(space.baseUri, "/ping").retry(upWithin) // ensure the imposter is up
+        miss    <- httpGet(space.baseUri, "/no-such-path")
+        _       <- control.destroy(space)
+      yield assertTrue(miss._1 == 404)
     }
   ).provideSome[Client](Provisioning.live, riftBackend) @@ TestAspect.sequential @@ TestAspect.withLiveClock
 
@@ -120,6 +129,15 @@ object RiftContainerSpec extends ZIOSpecDefault:
         ra.size == 1,           // only A's request
         rb.size == 2            // only B's
       )
+    },
+    test("an unmatched request returns 404 on the shared imposter (#165)") {
+      for
+        control <- ZIO.service[MockControl]
+        space   <- control.provision(pingSource).map(_.head)
+        _       <- SutClient.make(space).send(Method.Get, "/ping").retry(upWithin)
+        miss    <- SutClient.make(space).send(Method.Get, "/no-such-path") // injected, but no stub matches
+        _       <- control.destroy(space)
+      yield assertTrue(miss.status == 404)
     }
   ).provideSome[Client](Provisioning.live, correlatedBackend) @@ TestAspect.sequential @@ TestAspect.withLiveClock
 

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -75,6 +75,7 @@ object RiftMockControlSpec extends ZIOSpecDefault:
             spaces.size == 1,
             posted.size == 1,
             posted.head.contains("\"recordRequests\":true"),
+            posted.head.contains("\"defaultResponse\":{\"statusCode\":404}"), // unmatched -> 404 (#165)
             FakeRift.portOf(posted.head).contains(portOf(space.baseUri)),
             space.baseUri == s"http://localhost:${portOf(space.baseUri)}",
             space.inject(req) == req
@@ -364,6 +365,7 @@ object RiftMockControlSpec extends ZIOSpecDefault:
             posted.size == 1,                                                 // ONE shared imposter for both spaces
             posted.head.contains("\"flowIdSource\":\"header:X-Mock-Space\""), // Rift gates by the header natively
             posted.head.contains("\"_rift\""),                                // flow-state lives under _rift (native ext), not top-level
+            posted.head.contains("\"defaultResponse\":{\"statusCode\":404}"), // unmatched -> 404 (#165)
             a.baseUri == b.baseUri,                                           // shared imposter -> shared baseUri
             stubs.exists(_.contains(s"/${a.id.value} ")),                     // A's stub scoped under A's flowId
             stubs.exists(_.contains(s"/${b.id.value} ")),


### PR DESCRIPTION
Rift/Mountebank serve **HTTP 200 empty** for a request matching no stub unless the imposter has a `defaultResponse` (confirmed in rift v0.4.0 `handler.rs`). WireMock returns 404, so the cross-adapter conformance contract "unmatched → 404 on both adapters" held for WireMock but failed on Rift — which `#126`'s CI change first exposed (it ran `ConformanceMatrixSpec`'s Rift column against a real container for the first time; every `miss → 404` scenario FAILed on Rift).

## Fix
`RiftProtocol.imposter` and `RiftProtocol.correlatedImposter` now emit `"defaultResponse": {"statusCode": 404}` (a shared `unmatched404` val), so an unmatched request returns 404 like WireMock. Native/raw imposters (`provisionNative`, `imposterFromRaw`) are intentionally **not** touched — they pass the user's document through verbatim (the #119 escape hatch).

## Tests
- `RiftMockControlSpec` (fake-admin unit, always runs): both provision paths assert the posted imposter JSON carries `"defaultResponse":{"statusCode":404}`.
- `RiftContainerSpec` (RIFT_IT, real container): an unmatched request returns 404 on a PerInstance imposter **and** the Correlated shared imposter.
- `.github/workflows/ci.yml`: the `rift-it` job is re-broadened to run `conformance/test` under `RIFT_IT`, so the matrix Rift column now executes against a real container (it goes green with the fix).

## Acceptance
- A request matching no stub on a Rift imposter returns 404 (real container). ✓
- `ConformanceMatrixSpec`'s Rift column passes all 25 core scenarios under RIFT_IT — verified by the `rift-it` CI job (a dozen scenarios assert `miss == 404`, so it's a genuine regression gate).

807 tests pass locally; the real-container behaviour + matrix Rift column are verified by the `rift-it` job. A mutant dropping `defaultResponse` flips the unit assertion red.

Also filed rift#234 (docs: the handler's "…or 404" comment is misleading — the no-default path returns 200; no Rift code change needed).

Closes #165
Closes #163
Milestone: M2