### PR TITLE
test: capability-negotiation + native-escape-hatch + error-semantics features

### DIFF
--- a/conformance/src/main/scala/zio/bdd/mock/conformance/NegotiationErrorScenarios.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/NegotiationErrorScenarios.scala
@@ -1,0 +1,128 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+
+/**
+ * The capability-negotiation and error-semantics conformance features (#127):
+ * portable scenarios programmed against the neutral [[MockControl]], so they
+ * run identically on every adapter via the matrix. (The native-escape-hatch
+ * feature is per-adapter — each adapter needs its own native snippet — so it
+ * lives in `NativeEscapeHatchSpec`, not here.)
+ */
+object NegotiationErrorScenarios:
+
+  lazy val all: List[ConformanceScenario] = negotiation ++ errorSemantics
+
+  // ---- helpers ------------------------------------------------------------------
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+
+  private def ensure(cond: Boolean, msg: => String): IO[Throwable, Unit] =
+    ZIO.unless(cond)(ZIO.fail(new AssertionError(msg))).unit
+
+  private def srcOf(rules: MockRule*): MockSource = MockSource.Dsl(MockSpec(rules.toList))
+
+  private def rule(path: String, body: String): MockRule =
+    MockRule(RequestMatch(path = PathMatch.Exact(path)), ResponseDef(status = 200, body = Body.Text(body)))
+
+  private def scen(name: String)(check: MockControl => ZIO[Scope, Throwable, Unit]): ConformanceScenario =
+    ConformanceScenario(name, Set.empty, check)
+
+  private def space(control: MockControl, rules: MockRule*): ZIO[Scope, Throwable, MockSpace] =
+    ZIO.acquireRelease(control.provision(srcOf(rules*)).mapError(asT).map(_.head))(s => control.destroy(s).ignoreLogged)
+
+  // ---- capability-negotiation ---------------------------------------------------
+
+  private val negotiation = List(
+    scen("negotiation: capabilities are honest — each accessor matches what's advertised") { control =>
+      val accessors: List[(Capability, IO[Unsupported, Any])] = List(
+        Capability.Faults            -> control.faults,
+        Capability.StatefulScenarios -> control.scenarios,
+        Capability.StateInspection   -> control.stateInspection,
+        Capability.Scripting         -> control.scripting,
+        Capability.ProxyRecord       -> control.proxyRecord,
+        Capability.Templating        -> control.templating
+      )
+      for
+        outcomes <- ZIO.foreach(accessors)((cap, acc) => acc.either.map(cap -> _))
+        _ <- ensure(
+               // the check must cover EVERY capability, so a future one can't escape it,
+               outcomes.map(_._1).toSet == Capability.values.toSet &&
+                 // advertised => the accessor succeeds; un-advertised => fails fast with Unsupported(cap, backend).
+                 outcomes.forall { (cap, e) =>
+                   if control.capabilities.contains(cap) then e.isRight
+                   else e == Left(Unsupported(cap, control.backendName))
+                 },
+               s"capabilities not honest: caps=${control.capabilities} outcomes=$outcomes"
+             )
+      yield ()
+    },
+    scen("negotiation: require fails at wiring naming the gap (and the backend)") { control =>
+      for
+        emptyOk <- control.require().either // requiring nothing always succeeds
+        _ <- Capability.values.find(c => !control.capabilities.contains(c)) match
+               // an un-advertised capability: require must fail naming THAT gap + the backend.
+               case Some(gap) =>
+                 control
+                   .require(gap)
+                   .either
+                   .flatMap(gapE =>
+                     ensure(
+                       emptyOk.isRight && gapE == Left(Unsupported(gap, control.backendName)),
+                       s"require gap: empty=$emptyOk gap=$gap gapE=$gapE"
+                     )
+                   )
+               // a fully-capable adapter has no gap: requiring everything it advertises must succeed.
+               case None =>
+                 control
+                   .require(Capability.values*)
+                   .either
+                   .flatMap(allE => ensure(emptyOk.isRight && allE.isRight, s"require all: empty=$emptyOk all=$allE"))
+      yield ()
+    }
+  )
+
+  // ---- error-semantics ----------------------------------------------------------
+
+  private val errorSemantics = List(
+    scen("error: a malformed source fails fast with a typed MockError (no hang)") { control =>
+      for
+        // .timeout proves it doesn't hang: a completed effect is Some(...), a hang is None.
+        result <- control.provision(MockSource.Json("this is not json")).either.timeout(5.seconds)
+        _ <- ensure(
+               result.exists(_.swap.toOption.exists {
+                 case MockError.InvalidDefinition(_) => true
+                 case _                              => false
+               }),
+               s"malformed source: $result"
+             )
+      yield ()
+    },
+    scen("error: removeRule of an unknown id fails with RuleNotFound") { control =>
+      for
+        s <- space(control, rule("/p", "x"))
+        e <- control.removeRule(s, RuleId("ghost")).either
+        _ <- ensure(e == Left(MockError.RuleNotFound(s.id, RuleId("ghost"))), s"removeRule unknown: $e")
+      yield ()
+    },
+    // (ops on a destroyed space -> defined MockError is covered by CoreConformanceScenarios #125,
+    //  "operations on a destroyed space fail with SpaceNotFound" — all four ops, every adapter.)
+    scen(
+      "error: adding the same rule twice yields distinct ids with precise, non-aliased removal (duplicate-id behaviour)"
+    ) { control =>
+      val dup = rule("/dup", "dup")
+      for
+        s       <- space(control, rule("/keep", "keep"))
+        id1     <- control.addRule(s, dup, Priority.Base).mapError(asT) // identical rules...
+        id2     <- control.addRule(s, dup, Priority.Base).mapError(asT) // ...get distinct managed ids
+        _       <- control.removeRule(s, id1).mapError(asT)
+        rm2     <- control.removeRule(s, id2).either                    // the twin is still removable (not aliased to id1)
+        rmGhost <- control.removeRule(s, id1).either                    // re-removing the gone id -> RuleNotFound
+        _ <- ensure(
+               id1 != id2 && rm2.isRight && rmGhost == Left(MockError.RuleNotFound(s.id, id1)),
+               s"rule ids: id1=$id1 id2=$id2 rm2=$rm2 rmGhost=$rmGhost"
+             )
+      yield ()
+    }
+  )

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
@@ -123,7 +123,7 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         matrix <- ConformanceHarness.run(List(wiremock, rift), all)
         _      <- ZIO.logInfo(s"core conformance matrix:\n${matrix.render}")
         // Surface any non-Pass cell's detail so a failure is debuggable from the log.
-        wmFails   = nonPass(matrix, "wiremock")
+        wmFails   = nonPass(matrix, "wiremock", all)
         _        <- ZIO.logInfo(s"wiremock non-pass: $wmFails").when(wmFails.nonEmpty)
         riftCells = all.flatMap(s => matrix.cell(s.name, "rift").map(_.outcome))
       yield assertTrue(
@@ -139,11 +139,27 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip),
         matrix.conformant(wiremock)
       )
+    } @@ TestAspect.withLiveClock,
+    test("capability-negotiation + error-semantics features pass on every adapter (#127)") {
+      val all = NegotiationErrorScenarios.all
+      for
+        matrix   <- ConformanceHarness.run(List(wiremock, rift), all)
+        _        <- ZIO.logInfo(s"negotiation/error matrix:\n${matrix.render}")
+        wmFails   = nonPass(matrix, "wiremock", all)
+        _        <- ZIO.logInfo(s"wiremock non-pass: $wmFails").when(wmFails.nonEmpty)
+        riftCells = all.flatMap(s => matrix.cell(s.name, "rift").map(_.outcome))
+      yield assertTrue(
+        all.nonEmpty,
+        all.forall(s => matrix.cell(s.name, "wiremock").exists(_.outcome == Outcome.Pass)),
+        matrix.cells.count(_.backend == "wiremock") == all.size,
+        if riftEnabled then all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Pass))
+        else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
+      )
     } @@ TestAspect.withLiveClock
   )
 
-  private def nonPass(matrix: Matrix, backend: String): List[String] =
-    CoreConformanceScenarios.all.flatMap { s =>
+  private def nonPass(matrix: Matrix, backend: String, scenarios: List[ConformanceScenario]): List[String] =
+    scenarios.flatMap { s =>
       matrix
         .cell(s.name, backend)
         .filter(_.outcome != Outcome.Pass)

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/NativeEscapeHatchSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/NativeEscapeHatchSpec.scala
@@ -1,0 +1,108 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.rift.Rift
+import zio.bdd.mock.wiremock.WireMock
+import zio.http.Client
+import zio.test.*
+
+/**
+ * The native-escape-hatch conformance feature (#127/#119): a
+ * natively-provisioned space honors the core contract (serve + record +
+ * space-local destroy) on every adapter — but each adapter speaks its OWN
+ * native dialect, so this is per-adapter with its own snippet (it can't be a
+ * portable `MockControl`-only scenario).
+ *
+ * WireMock runs in-process always; the Rift backend is gated behind `RIFT_IT`
+ * (the `rift-it` CI job runs the conformance module under it), so the Rift
+ * container isn't built in the default Docker-free lane.
+ */
+object NativeEscapeHatchSpec extends ZIOSpecDefault:
+
+  private def asT(e: MockError): Throwable      = new RuntimeException(s"MockError: $e")
+  private val upWithin: Schedule[Any, Any, Any] = Schedule.recurs(20) && Schedule.spaced(100.millis)
+
+  // Each adapter's own native dialect, both serving GET /native with "native!".
+  private val riftNative =
+    """{"port":9999,"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/native"}}],"responses":[{"is":{"statusCode":200,"body":"native!"}}]}]}"""
+  private val wmNative =
+    """{"request":{"method":"GET","url":"/native"},"response":{"status":201,"body":"native!"}}"""
+
+  private final case class NativeBackend(
+    name: String,
+    layer: ZLayer[Any, Throwable, MockControl],
+    provisionNative: MockControl => IO[MockError, List[MockSpace]],
+    status: Int,
+    body: String
+  )
+
+  private def hatchSuite(b: NativeBackend) =
+    suite(b.name)(
+      test("a natively-provisioned space serves + records its full-fidelity contract; destroy is space-local") {
+        ZIO.scoped {
+          for
+            control <- ZIO.service[MockControl]
+            a <- ZIO.acquireRelease(b.provisionNative(control).mapError(asT).map(_.head))(s =>
+                   control.destroy(s).ignoreLogged
+                 )
+            other <- ZIO.acquireRelease(b.provisionNative(control).mapError(asT).map(_.head))(s =>
+                       control.destroy(s).ignoreLogged
+                     )
+            served <- SutClient.make(a).send(Method.Get, "/native").retry(upWithin)
+            recv   <- control.received(a).mapError(asT)
+            // a native space honors rule mutation (overlays) like a portable one (NativeSpec contract)
+            ovId <- control
+                      .addRule(
+                        a,
+                        MockRule(
+                          RequestMatch(path = PathMatch.Exact("/native")),
+                          ResponseDef(status = 200, body = Body.Text("overlaid"))
+                        ),
+                        Priority.Overlay
+                      )
+                      .mapError(asT)
+            overlaid <- SutClient.make(a).send(Method.Get, "/native")
+            _        <- control.removeRule(a, ovId).mapError(asT)
+            reverted <- SutClient.make(a).send(Method.Get, "/native")
+            _        <- control.destroy(a).mapError(asT)
+            aGone    <- control.received(a).either // ops on a destroyed space
+            bAfter   <- SutClient.make(other).send(Method.Get, "/native").retry(upWithin)
+          yield assertTrue(
+            served.status == b.status, // native serves its own full-fidelity response
+            served.body == b.body,
+            recv.exists(r => r.method == Method.Get && r.uri == "/native"), // records
+            overlaid.status == 200 && overlaid.body == "overlaid",          // overlay shadows the native rule
+            reverted.status == b.status && reverted.body == b.body,         // removeRule reverts to the native rule
+            aGone == Left(MockError.SpaceNotFound(a.id)),                   // destroyed-space op -> defined MockError
+            bAfter.status == b.status                                       // space-local: B unaffected by A's destroy
+          )
+        }
+      }
+    ).provideShared(b.layer) @@ TestAspect.sequential
+
+  private val riftEnabled = sys.env.contains("RIFT_IT")
+
+  private val wiremockBackend =
+    NativeBackend(
+      "wiremock-native",
+      Provisioning.live >>> WireMock.perInstance,
+      _.provisionNative(NativeSpec.WireMock(wmNative)),
+      201,
+      "native!"
+    )
+
+  // Excluded from the list (not just ignored) when RIFT_IT is unset, so its
+  // container is never built in the Docker-free lane.
+  private val riftBackend =
+    NativeBackend(
+      "rift-native",
+      (Client.default ++ Provisioning.live) >>> Rift.managed().mapError(asT),
+      _.provisionNative(NativeSpec.Rift(riftNative)),
+      200,
+      "native!"
+    )
+
+  private val backends = wiremockBackend :: (if riftEnabled then List(riftBackend) else Nil)
+
+  def spec = suite("NativeEscapeHatch")(backends.map(hatchSuite)*) @@ TestAspect.withLiveClock


### PR DESCRIPTION
The final M2 (Epic C) conformance issue — three feature areas added to the #124 harness.

## NegotiationErrorScenarios (portable, run by the matrix on both adapters)
- **capability-negotiation**: `capabilities` are honest (every one of the 6 accessors matches what's advertised — advertised → succeeds, un-advertised → `Unsupported(cap, backend)`, with a guard that the check covers every `Capability`); `require` fails at wiring naming the gap + the backend (and handles a fully-capable adapter).
- **error-semantics**: a malformed source fails fast with a typed `MockError` (within a `.timeout` to prove no hang); `removeRule` of an unknown id → `RuleNotFound`; adding the same rule twice yields distinct managed ids with precise, non-aliased removal (duplicate-id behaviour). (Ops on a destroyed space → `MockError` is already covered by #125's lifecycle scenarios.)

## NativeEscapeHatchSpec (per-adapter, each with its OWN native snippet)
A natively-provisioned space (Rift imposter JSON `/native`→200; WireMock stub JSON `/native`→201) serves its full-fidelity response, records, **honors overlays** (`addRule`/`removeRule` shadow then revert), and destroy is space-local (received(A) after destroy → `SpaceNotFound`, a second native space still serves). The Rift backend is excluded from the list when `RIFT_IT` is unset, so its container isn't built in the Docker-free lane.

## Verification
809 tests pass; the WireMock columns + wiremock-native run locally, and the Rift columns + rift-native suite run against a real container in the `rift-it` CI job (no CI change — it runs `conformance/test` under RIFT_IT since #165). A mutant weakening the `require` check flips the matrix red.

This is the last M2 issue — after merge the epic is ready for the M2 → master acceptance gate.

Closes #127
Milestone: M2