### PR TITLE
M2: WireMock adapter + portable isolation + cross-adapter conformance suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,13 @@ jobs:
           java-version: 11
           cache: sbt
       - uses: sbt/setup-sbt@v1
-      - name: RiftContainerSpec against a real Rift container (testcontainers)
+      # RIFT_IT-gated suites against a real container: the Rift adapter acceptance
+      # (#113) plus the parallel-isolation contract (#126), which only exercises
+      # Rift when RIFT_IT is set (dead in the hermetic `build` job above).
+      # NOTE: the full conformance matrix's Rift column (#124/#125) is not run here
+      # yet — it surfaced a real Rift unmatched-request-default bug; wiring it in is
+      # tracked by #163 once that bug is fixed.
+      - name: Real-container suites (RiftContainerSpec + ParallelIsolationSpec)
         env:
           RIFT_IT: "1"
-        run: sbt "rift/testOnly zio.bdd.mock.rift.RiftContainerSpec"
+        run: sbt "rift/testOnly zio.bdd.mock.rift.RiftContainerSpec" "conformance/testOnly zio.bdd.mock.conformance.ParallelIsolationSpec"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,13 @@ jobs:
           java-version: 11
           cache: sbt
       - uses: sbt/setup-sbt@v1
-      # RIFT_IT-gated suites against a real container: the Rift adapter acceptance
-      # (#113) plus the parallel-isolation contract (#126), which only exercises
-      # Rift when RIFT_IT is set (dead in the hermetic `build` job above).
-      # NOTE: the full conformance matrix's Rift column (#124/#125) is not run here
-      # yet — it surfaced a real Rift unmatched-request-default bug; wiring it in is
-      # tracked by #163 once that bug is fixed.
-      - name: Real-container suites (RiftContainerSpec + ParallelIsolationSpec)
+      # Every RIFT_IT-gated suite against a real container: the Rift adapter
+      # acceptance (#113) plus the whole conformance module's Rift column — the
+      # matrix (#124/#125) and the parallel-isolation contract (#126) only
+      # exercise Rift when RIFT_IT is set (dead in the hermetic `build` job above).
+      # (The Rift unmatched-request-default bug that previously failed the matrix
+      # column is fixed in #165, so the full module runs green here.)
+      - name: Real-container suites (RiftContainerSpec + conformance Rift column)
         env:
           RIFT_IT: "1"
-        run: sbt "rift/testOnly zio.bdd.mock.rift.RiftContainerSpec" "conformance/testOnly zio.bdd.mock.conformance.ParallelIsolationSpec"
+        run: sbt "rift/testOnly zio.bdd.mock.rift.RiftContainerSpec" "conformance/test"

--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val mimaSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .aggregate(core, gherkin, mock, rift, wiremock)
+  .aggregate(core, gherkin, mock, rift, wiremock, conformance)
   .settings(
     name                  := "zio-bdd-root",
     description           := "A ZIO-based BDD testing framework for Scala 3",
@@ -168,6 +168,19 @@ lazy val wiremock = (project in file("wiremock"))
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
+    mimaPreviousArtifacts := Set.empty
+  )
+
+// Conformance harness + matrix runner (#124): the executable definition of
+// "implements MockControl". The only module that depends on BOTH adapters, so it
+// can run one feature set across Rift + WireMock and emit the pass/skip/fail matrix.
+lazy val conformance = (project in file("conformance"))
+  .dependsOn(core, rift, wiremock)
+  .settings(
+    name := "zio-bdd-conformance",
+    libraryDependencies ++= commonDependencies,
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    publish / skip        := true, // a test harness, not a published artifact
     mimaPreviousArtifacts := Set.empty
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val mimaSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .aggregate(core, gherkin, mock, rift)
+  .aggregate(core, gherkin, mock, rift, wiremock)
   .settings(
     name                  := "zio-bdd-root",
     description           := "A ZIO-based BDD testing framework for Scala 3",
@@ -149,6 +149,22 @@ lazy val rift = (project in file("rift"))
       "dev.zio"      %% "zio-http"                   % "3.2.0",
       "dev.zio"      %% "zio-json"                   % "0.7.3",
       "com.dimafeng" %% "testcontainers-scala-core"  % "0.41.4"
+    ),
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
+    mimaPreviousArtifacts := Set.empty
+  )
+
+// WireMock adapter (#122): the in-process, pure-JVM, zero-Docker provider with
+// Correlated isolation by default. Implements the portable MockControl SPI over
+// an embedded WireMockServer. Depends on `mock`, never the reverse.
+lazy val wiremock = (project in file("wiremock"))
+  .dependsOn(mock)
+  .settings(
+    name := "zio-bdd-wiremock",
+    libraryDependencies ++= commonDependencies,
+    libraryDependencies ++= Seq(
+      "org.wiremock" % "wiremock" % "3.9.2"
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     // Not yet published as a 1.x artifact — no binary-compat baseline to check against.

--- a/conformance/src/main/scala/zio/bdd/mock/conformance/ConformanceHarness.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/ConformanceHarness.scala
@@ -1,0 +1,131 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+
+/**
+ * A backend registered in the conformance matrix. `layer` is a fully self-wired
+ * [[MockControl]]; `capabilities`/`isolation` are what it advertises
+ * (#118/#123). `available = false` parks the whole column as SKIPPED — e.g. the
+ * Rift backend when Docker isn't present (gated by `RIFT_IT`), so the matrix
+ * still runs WireMock in-process.
+ */
+final case class MockBackendUnderTest(
+  name: String,
+  layer: ZLayer[Any, Throwable, MockControl],
+  capabilities: Set[Capability],
+  isolation: Isolation,
+  available: Boolean = true
+)
+
+/**
+ * One portable conformance scenario: a `check` programmed against the neutral
+ * [[MockControl]] (never a concrete backend), gated by the capabilities it
+ * needs. A scenario requiring a capability the backend doesn't advertise is
+ * SKIPPED, never FAILED — that is a negotiated gap, not a conformance breach.
+ */
+final case class ConformanceScenario(
+  name: String,
+  requires: Set[Capability],
+  check: MockControl => ZIO[Scope, Throwable, Unit]
+)
+
+enum Outcome:
+  case Pass, Skip, Fail
+
+final case class Cell(scenario: String, backend: String, outcome: Outcome, detail: Option[String] = None)
+
+/** The pass/skip/fail matrix — one cell per (scenario, backend). */
+final case class Matrix(backends: List[MockBackendUnderTest], scenarios: List[ConformanceScenario], cells: List[Cell]):
+
+  def cell(scenario: String, backend: String): Option[Cell] =
+    cells.find(c => c.scenario == scenario && c.backend == backend)
+
+  /**
+   * A column is conformant iff it has zero FAIL and every SKIP is justified —
+   * the backend was unavailable, or the scenario required a capability the
+   * backend does not advertise (the acceptance condition "SKIPs equal the
+   * un-advertised capabilities").
+   */
+  def conformant(backend: MockBackendUnderTest): Boolean =
+    cells.filter(_.backend == backend.name).forall { c =>
+      c.outcome match
+        case Outcome.Fail => false
+        case Outcome.Pass => true
+        case Outcome.Skip =>
+          !backend.available ||
+          scenarios.find(_.name == c.scenario).exists(!_.requires.subsetOf(backend.capabilities))
+    }
+
+  /** A compact P/S/F grid, one row per scenario, one column per backend. */
+  def render: String =
+    val nameW = (scenarios.map(_.name.length) :+ 8).max
+    val head  = "scenario".padTo(nameW, ' ') + "  " + backends.map(_.name).mkString("  ")
+    val rows = scenarios.map { s =>
+      val marks = backends.map(b => cell(s.name, b.name).map(mark).getOrElse("?").padTo(b.name.length, ' '))
+      s.name.padTo(nameW, ' ') + "  " + marks.mkString("  ")
+    }
+    (head +: rows).mkString("\n")
+
+  private def mark(c: Cell): String = c.outcome match
+    case Outcome.Pass => "PASS"
+    case Outcome.Skip => "SKIP"
+    case Outcome.Fail => "FAIL"
+
+/** Runs each scenario against each backend and assembles the [[Matrix]]. */
+object ConformanceHarness:
+
+  def run(backends: List[MockBackendUnderTest], scenarios: List[ConformanceScenario]): UIO[Matrix] =
+    ZIO
+      .foreach(backends)(b => runBackend(b, scenarios))
+      .map(rows => Matrix(backends, scenarios, rows.flatten))
+
+  // Stand the backend up once and run every scenario against it (each provisions
+  // and tears down its own spaces). A backend that can't even *build* fails every
+  // scenario; an unavailable backend (e.g. Rift with no Docker) skips them all.
+  // The all-FAIL mapping is scoped to `build`, so a later teardown failure can't
+  // rewrite already-computed cells; interruption propagates (it is not a verdict).
+  private def runBackend(backend: MockBackendUnderTest, scenarios: List[ConformanceScenario]): UIO[List[Cell]] =
+    if !backend.available then
+      ZIO.succeed(scenarios.map(s => Cell(s.name, backend.name, Outcome.Skip, Some("backend unavailable"))))
+    else
+      ZIO.scoped {
+        backend.layer.build.foldCauseZIO(
+          cause =>
+            if cause.isInterruptedOnly then ZIO.failCause(cause.stripFailures)
+            else
+              ZIO.succeed(
+                scenarios.map(s =>
+                  Cell(s.name, backend.name, Outcome.Fail, Some(s"backend setup failed: ${detailOf(cause)}"))
+                )
+              )
+          ,
+          env => ZIO.foreach(scenarios)(s => cellFor(env.get[MockControl], backend, s))
+        )
+      }
+
+  private def cellFor(control: MockControl, backend: MockBackendUnderTest, scenario: ConformanceScenario): UIO[Cell] =
+    if !scenario.requires.subsetOf(backend.capabilities) then
+      val missing = (scenario.requires -- backend.capabilities).map(_.toString).mkString(", ")
+      ZIO.succeed(Cell(scenario.name, backend.name, Outcome.Skip, Some(s"requires $missing")))
+    else
+      ZIO
+        .scoped(scenario.check(control))
+        .foldCauseZIO(
+          // A failed or DIED check is a verdict (Fail cell); interruption is not — propagate it.
+          cause =>
+            if cause.isInterruptedOnly then ZIO.failCause(cause.stripFailures)
+            else ZIO.succeed(Cell(scenario.name, backend.name, Outcome.Fail, Some(detailOf(cause)))),
+          _ => ZIO.succeed(Cell(scenario.name, backend.name, Outcome.Pass))
+        )
+
+  // A failure carries its message; a DEFECT (a harness/check bug, not a backend
+  // verdict) is labelled so a reader can tell "the backend misbehaved" from "the
+  // check threw". Total — never throws on an empty cause.
+  private def detailOf(cause: Cause[Throwable]): String =
+    cause.failureOption
+      .map(_.getMessage)
+      .orElse(cause.dieOption.map(d => s"[harness defect] ${d.getClass.getName}: ${d.getMessage}"))
+      .filter(_ != null)
+      .getOrElse(cause.prettyPrint.linesIterator.nextOption.getOrElse("<no detail>"))
+      .take(300)

--- a/conformance/src/main/scala/zio/bdd/mock/conformance/CoreConformanceScenarios.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/CoreConformanceScenarios.scala
@@ -1,0 +1,434 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+
+/**
+ * The MUST-pass core conformance scenarios (#125): matching, response fidelity,
+ * rule precedence, lifecycle isolation, and verification. Each is programmed
+ * against the neutral [[MockControl]] (never a concrete backend) and asserts
+ * via a real [[SutClient]] round-trip, so it must pass identically on every
+ * adapter.
+ *
+ * Scope is deliberately the cross-adapter intersection both Rift and WireMock
+ * translate faithfully. Two model limits keep multi-value-header scenarios out:
+ * `ResponseDef.headers`/`RecordedRequest.headers` are `Map[String, String]`
+ * (single value per key), and WireMock records only the first value +
+ * lowercases recorded header keys — so scenarios use single-value headers and
+ * never assert a recorded request-header by exact case. (Multi-value headers
+ * need a model change — a follow-up, not #125.)
+ */
+object CoreConformanceScenarios:
+
+  // lazy: the group vals below initialise after this declaration in source order.
+  lazy val all: List[ConformanceScenario] =
+    matching ++ responseFidelity ++ precedence ++ lifecycle ++ verification
+
+  // ---- helpers ------------------------------------------------------------------
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+
+  private def ensure(cond: Boolean, msg: => String): IO[Throwable, Unit] =
+    ZIO.unless(cond)(ZIO.fail(new AssertionError(msg))).unit
+
+  private def srcOf(rules: MockRule*): MockSource = MockSource.Dsl(MockSpec(rules.toList))
+
+  private def text(status: Int, body: String): ResponseDef = ResponseDef(status = status, body = Body.Text(body))
+
+  /**
+   * A GET-exact-path rule returning `body` with status 200 — the common shape.
+   */
+  private def rule(path: String, body: String): MockRule =
+    MockRule(RequestMatch(path = PathMatch.Exact(path)), text(200, body))
+
+  private def scen(name: String)(check: MockControl => ZIO[Scope, Throwable, Unit]): ConformanceScenario =
+    ConformanceScenario(name, Set.empty, check)
+
+  /**
+   * Provision a space serving `rules`, torn down when the scenario's scope
+   * closes.
+   */
+  // ignoreLogged (not bare ignore): teardown must not override the verdict, but a
+  // leak into the shared backend used by later scenarios should be diagnosable.
+  private def space(control: MockControl, rules: MockRule*): ZIO[Scope, Throwable, MockSpace] =
+    ZIO.acquireRelease(control.provision(srcOf(rules*)).mapError(asT).map(_.head))(s => control.destroy(s).ignoreLogged)
+
+  private def countMatching(reqs: List[RecordedRequest], method: Method, path: String): Int =
+    reqs.count(r => r.method == method && r.uri == path)
+
+  // ---- core-matching: matching fires only on a full match (partial does not) ----
+
+  private val matching = List(
+    scen("matching: method (POST-only rule; a GET does not fire)") { control =>
+      for
+        s <- space(
+               control,
+               MockRule(RequestMatch(method = Some(Method.Post), path = PathMatch.Exact("/m")), text(200, "ok"))
+             )
+        miss <- SutClient.make(s).send(Method.Get, "/m")
+        hit  <- SutClient.make(s).send(Method.Post, "/m")
+        _ <- ensure(
+               miss.status == 404 && hit.status == 200 && hit.body == "ok",
+               s"method: miss=${miss.status} hit=${hit.status}/${hit.body}"
+             )
+      yield ()
+    },
+    scen("matching: path Exact") { control =>
+      for
+        s    <- space(control, MockRule(RequestMatch(path = PathMatch.Exact("/exact")), text(200, "ok")))
+        hit  <- SutClient.make(s).send(Method.Get, "/exact")
+        miss <- SutClient.make(s).send(Method.Get, "/exact/extra")
+        _    <- ensure(hit.status == 200 && miss.status == 404, s"exact: hit=${hit.status} miss=${miss.status}")
+      yield ()
+    },
+    scen("matching: path Regex") { control =>
+      for
+        s    <- space(control, MockRule(RequestMatch(path = PathMatch.Regex("^/r/[0-9]+$")), text(200, "ok")))
+        hit  <- SutClient.make(s).send(Method.Get, "/r/123")
+        miss <- SutClient.make(s).send(Method.Get, "/r/abc")
+        _    <- ensure(hit.status == 200 && miss.status == 404, s"regex: hit=${hit.status} miss=${miss.status}")
+      yield ()
+    },
+    scen("matching: path Template (single segment)") { control =>
+      for
+        s    <- space(control, MockRule(RequestMatch(path = PathMatch.Template("/u/{id}")), text(200, "ok")))
+        hit  <- SutClient.make(s).send(Method.Get, "/u/42")
+        miss <- SutClient.make(s).send(Method.Get, "/u/42/9")
+        _    <- ensure(hit.status == 200 && miss.status == 404, s"template: hit=${hit.status} miss=${miss.status}")
+      yield ()
+    },
+    scen("matching: query Equals") { control =>
+      for
+        s <- space(
+               control,
+               MockRule(
+                 RequestMatch(path = PathMatch.Exact("/q"), query = Map("k" -> ValueMatch.Equals("v"))),
+                 text(200, "ok")
+               )
+             )
+        hit  <- SutClient.make(s).send(Method.Get, "/q?k=v")
+        miss <- SutClient.make(s).send(Method.Get, "/q?k=x")
+        _    <- ensure(hit.status == 200 && miss.status == 404, s"query: hit=${hit.status} miss=${miss.status}")
+      yield ()
+    },
+    scen("matching: header Contains") { control =>
+      for
+        s <- space(
+               control,
+               MockRule(
+                 RequestMatch(path = PathMatch.Exact("/h"), headers = Map("X-Tok" -> ValueMatch.Contains("bear"))),
+                 text(200, "ok")
+               )
+             )
+        hit  <- SutClient.make(s).send(Method.Get, "/h", headers = Map("X-Tok" -> "bearer-123"))
+        miss <- SutClient.make(s).send(Method.Get, "/h")
+        _    <- ensure(hit.status == 200 && miss.status == 404, s"header: hit=${hit.status} miss=${miss.status}")
+      yield ()
+    },
+    scen("matching: body Contains") { control =>
+      for
+        s <- space(
+               control,
+               MockRule(
+                 RequestMatch(
+                   method = Some(Method.Post),
+                   path = PathMatch.Exact("/b"),
+                   body = Some(BodyMatch.Contains("hello"))
+                 ),
+                 text(200, "ok")
+               )
+             )
+        hit  <- SutClient.make(s).send(Method.Post, "/b", body = Some("say hello world"))
+        miss <- SutClient.make(s).send(Method.Post, "/b", body = Some("goodbye"))
+        _    <- ensure(hit.status == 200 && miss.status == 404, s"body: hit=${hit.status} miss=${miss.status}")
+      yield ()
+    },
+    scen("matching: body JsonPath (with expected value)") { control =>
+      for
+        s <- space(
+               control,
+               MockRule(
+                 RequestMatch(
+                   method = Some(Method.Post),
+                   path = PathMatch.Exact("/j"),
+                   body = Some(BodyMatch.JsonPath("$.k", Some("v")))
+                 ),
+                 text(200, "ok")
+               )
+             )
+        hit  <- SutClient.make(s).send(Method.Post, "/j", body = Some("""{"k":"v"}"""))
+        miss <- SutClient.make(s).send(Method.Post, "/j", body = Some("""{"k":"x"}"""))
+        _    <- ensure(hit.status == 200 && miss.status == 404, s"jsonpath: hit=${hit.status} miss=${miss.status}")
+      yield ()
+    },
+    scen("matching: body XPath (node exists)") { control =>
+      for
+        s <- space(
+               control,
+               MockRule(
+                 RequestMatch(
+                   method = Some(Method.Post),
+                   path = PathMatch.Exact("/x"),
+                   body = Some(BodyMatch.XPath("/r/k"))
+                 ),
+                 text(200, "ok")
+               )
+             )
+        hit  <- SutClient.make(s).send(Method.Post, "/x", body = Some("<r><k>v</k></r>"))
+        miss <- SutClient.make(s).send(Method.Post, "/x", body = Some("<r></r>"))
+        _    <- ensure(hit.status == 200 && miss.status == 404, s"xpath: hit=${hit.status} miss=${miss.status}")
+      yield ()
+    },
+    scen("matching: composite AND (a partial match does not fire)") { control =>
+      val rm = RequestMatch(
+        method = Some(Method.Post),
+        path = PathMatch.Exact("/c"),
+        headers = Map("X-K" -> ValueMatch.Equals("v")),
+        body = Some(BodyMatch.Contains("z"))
+      )
+      for
+        s         <- space(control, MockRule(rm, text(200, "ok")))
+        hit       <- SutClient.make(s).send(Method.Post, "/c", headers = Map("X-K" -> "v"), body = Some("zzz"))
+        noHeader  <- SutClient.make(s).send(Method.Post, "/c", body = Some("zzz"))
+        wrongBody <- SutClient.make(s).send(Method.Post, "/c", headers = Map("X-K" -> "v"), body = Some("qqq"))
+        _ <- ensure(
+               hit.status == 200 && noHeader.status == 404 && wrongBody.status == 404,
+               s"composite: hit=${hit.status} noHeader=${noHeader.status} wrongBody=${wrongBody.status}"
+             )
+      yield ()
+    },
+    scen("matching: header Matches (regex)") { control =>
+      for
+        s <-
+          space(
+            control,
+            MockRule(
+              RequestMatch(path = PathMatch.Exact("/hm"), headers = Map("X-Tok" -> ValueMatch.Matches("^Bearer .+$"))),
+              text(200, "ok")
+            )
+          )
+        hit  <- SutClient.make(s).send(Method.Get, "/hm", headers = Map("X-Tok" -> "Bearer abc"))
+        miss <- SutClient.make(s).send(Method.Get, "/hm", headers = Map("X-Tok" -> "Basic abc"))
+        _    <- ensure(hit.status == 200 && miss.status == 404, s"header-matches: hit=${hit.status} miss=${miss.status}")
+      yield ()
+    },
+    scen("matching: body Equals (exact)") { control =>
+      for
+        s <- space(
+               control,
+               MockRule(
+                 RequestMatch(
+                   method = Some(Method.Post),
+                   path = PathMatch.Exact("/be"),
+                   body = Some(BodyMatch.Equals("exact-body"))
+                 ),
+                 text(200, "ok")
+               )
+             )
+        hit  <- SutClient.make(s).send(Method.Post, "/be", body = Some("exact-body"))
+        miss <- SutClient.make(s).send(Method.Post, "/be", body = Some("exact-body-plus"))
+        _    <- ensure(hit.status == 200 && miss.status == 404, s"body-equals: hit=${hit.status} miss=${miss.status}")
+      yield ()
+    },
+    scen("matching: body Matches (regex)") { control =>
+      for
+        s <- space(
+               control,
+               MockRule(
+                 RequestMatch(
+                   method = Some(Method.Post),
+                   path = PathMatch.Exact("/bm"),
+                   body = Some(BodyMatch.Matches("^id=[0-9]+$"))
+                 ),
+                 text(200, "ok")
+               )
+             )
+        hit  <- SutClient.make(s).send(Method.Post, "/bm", body = Some("id=42"))
+        miss <- SutClient.make(s).send(Method.Post, "/bm", body = Some("id=abc"))
+        _    <- ensure(hit.status == 200 && miss.status == 404, s"body-matches: hit=${hit.status} miss=${miss.status}")
+      yield ()
+    }
+  )
+
+  // ---- response-fidelity: the response is reproduced verbatim -------------------
+
+  private val responseFidelity = List(
+    scen("response: status + single-value header + Text body verbatim") { control =>
+      for
+        s <- space(
+               control,
+               MockRule(
+                 RequestMatch(path = PathMatch.Exact("/resp")),
+                 ResponseDef(status = 418, headers = Map("X-R" -> "rv"), body = Body.Text("teapot"))
+               )
+             )
+        r <- SutClient.make(s).send(Method.Get, "/resp")
+        _ <- ensure(
+               r.status == 418 && r.body == "teapot" && r.headers.get("x-r").contains("rv"),
+               s"resp: status=${r.status} body=${r.body} headers=${r.headers}"
+             )
+      yield ()
+    },
+    scen("response: Json body") { control =>
+      for
+        s <- space(
+               control,
+               MockRule(
+                 RequestMatch(path = PathMatch.Exact("/json")),
+                 ResponseDef(status = 200, body = Body.Json("""{"a":1}"""))
+               )
+             )
+        r <- SutClient.make(s).send(Method.Get, "/json")
+        _ <- ensure(
+               r.status == 200 && r.body.replaceAll("\\s", "") == """{"a":1}""",
+               s"json: status=${r.status} body=${r.body}"
+             )
+      yield ()
+    },
+    scen("response: Base64 body decodes to raw bytes") { control =>
+      val b64 = java.util.Base64.getEncoder.encodeToString("bin-payload".getBytes("UTF-8"))
+      for
+        s <-
+          space(
+            control,
+            MockRule(RequestMatch(path = PathMatch.Exact("/b64")), ResponseDef(status = 200, body = Body.Base64(b64)))
+          )
+        r <- SutClient.make(s).send(Method.Get, "/b64")
+        _ <- ensure(r.status == 200 && r.body == "bin-payload", s"base64: status=${r.status} body=${r.body}")
+      yield ()
+    },
+    scen("response: delay is applied (delayed minus baseline within tolerance)") { control =>
+      // Measure a no-delay sibling on the same space as the baseline, so the
+      // delta cancels connection/JIT latency — a backend that ignored the delay
+      // directive yields delta ~0 and fails, not a spurious pass on a slow box.
+      def elapsedOf(s: MockSpace, path: String): ZIO[Any, Throwable, (SutResponse, Duration)] =
+        for
+          t0 <- Clock.nanoTime
+          r  <- SutClient.make(s).send(Method.Get, path)
+          t1 <- Clock.nanoTime
+        yield (r, Duration.fromNanos(t1 - t0))
+      for
+        s <- space(
+               control,
+               MockRule(
+                 RequestMatch(path = PathMatch.Exact("/nodelay")),
+                 ResponseDef(status = 200, body = Body.Text("ok"))
+               ),
+               MockRule(
+                 RequestMatch(path = PathMatch.Exact("/delay")),
+                 ResponseDef(status = 200, body = Body.Text("ok"), delay = Some(300.millis))
+               )
+             )
+        baseline <- elapsedOf(s, "/nodelay")
+        delayed  <- elapsedOf(s, "/delay")
+        delta     = Duration.fromNanos(delayed._2.toNanos - baseline._2.toNanos)
+        _ <- ensure(
+               delayed._1.status == 200 && delta >= 200.millis,
+               s"delay: status=${delayed._1.status} delayed=${delayed._2.toMillis}ms baseline=${baseline._2.toMillis}ms delta=${delta.toMillis}ms"
+             )
+      yield ()
+    }
+  )
+
+  // ---- rule-precedence: overlay shadows base; mutations take effect ------------
+
+  private val precedence = List(
+    scen("precedence: an overlay shadows the base rule (deterministic on repeat)") { control =>
+      for
+        s  <- space(control, rule("/p", "base"))
+        _  <- control.addRule(s, rule("/p", "overlay"), Priority.Overlay).mapError(asT)
+        r1 <- SutClient.make(s).send(Method.Get, "/p")
+        r2 <- SutClient.make(s).send(Method.Get, "/p")
+        _  <- ensure(r1.body == "overlay" && r2.body == "overlay", s"overlay: r1=${r1.body} r2=${r2.body}")
+      yield ()
+    },
+    scen("precedence: removeRule reverts to the base rule") { control =>
+      for
+        s      <- space(control, rule("/pr", "base"))
+        id     <- control.addRule(s, rule("/pr", "overlay"), Priority.Overlay).mapError(asT)
+        before <- SutClient.make(s).send(Method.Get, "/pr")
+        _      <- control.removeRule(s, id).mapError(asT)
+        after  <- SutClient.make(s).send(Method.Get, "/pr")
+        _ <-
+          ensure(before.body == "overlay" && after.body == "base", s"revert: before=${before.body} after=${after.body}")
+      yield ()
+    },
+    scen("precedence: replaceRules swaps the whole ruleset") { control =>
+      for
+        s    <- space(control, rule("/old", "old"))
+        _    <- control.replaceRules(s, List(rule("/new", "new"))).mapError(asT)
+        oldR <- SutClient.make(s).send(Method.Get, "/old")
+        newR <- SutClient.make(s).send(Method.Get, "/new")
+        _    <- ensure(oldR.status == 404 && newR.body == "new", s"replace: old=${oldR.status} new=${newR.body}")
+      yield ()
+    }
+  )
+
+  // ---- lifecycle-isolation: locality of provision/destroy ----------------------
+
+  private val lifecycle = List(
+    scen("lifecycle: destroy(A) leaves B serving") { control =>
+      for
+        a     <- control.provision(srcOf(rule("/li", "A"))).mapError(asT).map(_.head)
+        b     <- control.provision(srcOf(rule("/li", "B"))).mapError(asT).map(_.head)
+        _     <- control.destroy(a).mapError(asT)
+        bResp <- SutClient.make(b).send(Method.Get, "/li")
+        _     <- control.destroy(b).ignoreLogged
+        _     <- ensure(bResp.status == 200 && bResp.body == "B", s"isolation: bResp=${bResp.status}/${bResp.body}")
+      yield ()
+    },
+    scen("lifecycle: operations on a destroyed space fail with SpaceNotFound") { control =>
+      for
+        s        <- control.provision(srcOf(rule("/d", "x"))).mapError(asT).map(_.head)
+        _        <- control.destroy(s).mapError(asT)
+        gone      = Left(MockError.SpaceNotFound(s.id))
+        recvE    <- control.received(s).either
+        addE     <- control.addRule(s, rule("/d", "y"), Priority.Base).either
+        removeE  <- control.removeRule(s, RuleId("r1")).either
+        replaceE <- control.replaceRules(s, List(rule("/d", "z"))).either
+        _ <- ensure(
+               recvE == gone && addE == gone && removeE == gone && replaceE == gone,
+               s"destroyed ops: recv=$recvE add=$addE remove=$removeE replace=$replaceE"
+             )
+      yield ()
+    }
+  )
+
+  // ---- verification: received is A-only; count + set semantics ------------------
+
+  private val verification = List(
+    scen("verification: received(A) returns only A's traffic") { control =>
+      for
+        a  <- space(control, rule("/v", "a"))
+        b  <- space(control, rule("/v", "b"))
+        _  <- SutClient.make(a).send(Method.Get, "/v")
+        _  <- SutClient.make(b).send(Method.Get, "/v")
+        _  <- SutClient.make(b).send(Method.Get, "/v")
+        ra <- control.received(a).mapError(asT)
+        rb <- control.received(b).mapError(asT)
+        _  <- ensure(ra.size == 1 && rb.size == 2, s"received: ra=${ra.size} rb=${rb.size}")
+      yield ()
+    },
+    scen("verification: countMatching equals the number of matching requests sent") { control =>
+      for
+        s    <- space(control, rule("/c3", "ok"))
+        _    <- ZIO.foreachDiscard(1 to 3)(_ => SutClient.make(s).send(Method.Get, "/c3"))
+        reqs <- control.received(s).mapError(asT)
+        _ <- ensure(
+               countMatching(reqs, Method.Get, "/c3") == 3 && countMatching(reqs, Method.Post, "/c3") == 0,
+               s"count: get=${countMatching(reqs, Method.Get, "/c3")}"
+             )
+      yield ()
+    },
+    scen("verification: existence (set) semantics — a sent request is present, an unsent path is not") { control =>
+      for
+        s    <- space(control, rule("/e", "ok"))
+        _    <- SutClient.make(s).send(Method.Get, "/e")
+        reqs <- control.received(s).mapError(asT)
+        _ <- ensure(
+               reqs.exists(r => r.method == Method.Get && r.uri == "/e") && !reqs.exists(_.uri == "/never"),
+               s"set: reqs=$reqs"
+             )
+      yield ()
+    }
+  )

--- a/conformance/src/main/scala/zio/bdd/mock/conformance/NegotiationErrorScenarios.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/NegotiationErrorScenarios.scala
@@ -1,0 +1,128 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+
+/**
+ * The capability-negotiation and error-semantics conformance features (#127):
+ * portable scenarios programmed against the neutral [[MockControl]], so they
+ * run identically on every adapter via the matrix. (The native-escape-hatch
+ * feature is per-adapter — each adapter needs its own native snippet — so it
+ * lives in `NativeEscapeHatchSpec`, not here.)
+ */
+object NegotiationErrorScenarios:
+
+  lazy val all: List[ConformanceScenario] = negotiation ++ errorSemantics
+
+  // ---- helpers ------------------------------------------------------------------
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+
+  private def ensure(cond: Boolean, msg: => String): IO[Throwable, Unit] =
+    ZIO.unless(cond)(ZIO.fail(new AssertionError(msg))).unit
+
+  private def srcOf(rules: MockRule*): MockSource = MockSource.Dsl(MockSpec(rules.toList))
+
+  private def rule(path: String, body: String): MockRule =
+    MockRule(RequestMatch(path = PathMatch.Exact(path)), ResponseDef(status = 200, body = Body.Text(body)))
+
+  private def scen(name: String)(check: MockControl => ZIO[Scope, Throwable, Unit]): ConformanceScenario =
+    ConformanceScenario(name, Set.empty, check)
+
+  private def space(control: MockControl, rules: MockRule*): ZIO[Scope, Throwable, MockSpace] =
+    ZIO.acquireRelease(control.provision(srcOf(rules*)).mapError(asT).map(_.head))(s => control.destroy(s).ignoreLogged)
+
+  // ---- capability-negotiation ---------------------------------------------------
+
+  private val negotiation = List(
+    scen("negotiation: capabilities are honest — each accessor matches what's advertised") { control =>
+      val accessors: List[(Capability, IO[Unsupported, Any])] = List(
+        Capability.Faults            -> control.faults,
+        Capability.StatefulScenarios -> control.scenarios,
+        Capability.StateInspection   -> control.stateInspection,
+        Capability.Scripting         -> control.scripting,
+        Capability.ProxyRecord       -> control.proxyRecord,
+        Capability.Templating        -> control.templating
+      )
+      for
+        outcomes <- ZIO.foreach(accessors)((cap, acc) => acc.either.map(cap -> _))
+        _ <- ensure(
+               // the check must cover EVERY capability, so a future one can't escape it,
+               outcomes.map(_._1).toSet == Capability.values.toSet &&
+                 // advertised => the accessor succeeds; un-advertised => fails fast with Unsupported(cap, backend).
+                 outcomes.forall { (cap, e) =>
+                   if control.capabilities.contains(cap) then e.isRight
+                   else e == Left(Unsupported(cap, control.backendName))
+                 },
+               s"capabilities not honest: caps=${control.capabilities} outcomes=$outcomes"
+             )
+      yield ()
+    },
+    scen("negotiation: require fails at wiring naming the gap (and the backend)") { control =>
+      for
+        emptyOk <- control.require().either // requiring nothing always succeeds
+        _ <- Capability.values.find(c => !control.capabilities.contains(c)) match
+               // an un-advertised capability: require must fail naming THAT gap + the backend.
+               case Some(gap) =>
+                 control
+                   .require(gap)
+                   .either
+                   .flatMap(gapE =>
+                     ensure(
+                       emptyOk.isRight && gapE == Left(Unsupported(gap, control.backendName)),
+                       s"require gap: empty=$emptyOk gap=$gap gapE=$gapE"
+                     )
+                   )
+               // a fully-capable adapter has no gap: requiring everything it advertises must succeed.
+               case None =>
+                 control
+                   .require(Capability.values*)
+                   .either
+                   .flatMap(allE => ensure(emptyOk.isRight && allE.isRight, s"require all: empty=$emptyOk all=$allE"))
+      yield ()
+    }
+  )
+
+  // ---- error-semantics ----------------------------------------------------------
+
+  private val errorSemantics = List(
+    scen("error: a malformed source fails fast with a typed MockError (no hang)") { control =>
+      for
+        // .timeout proves it doesn't hang: a completed effect is Some(...), a hang is None.
+        result <- control.provision(MockSource.Json("this is not json")).either.timeout(5.seconds)
+        _ <- ensure(
+               result.exists(_.swap.toOption.exists {
+                 case MockError.InvalidDefinition(_) => true
+                 case _                              => false
+               }),
+               s"malformed source: $result"
+             )
+      yield ()
+    },
+    scen("error: removeRule of an unknown id fails with RuleNotFound") { control =>
+      for
+        s <- space(control, rule("/p", "x"))
+        e <- control.removeRule(s, RuleId("ghost")).either
+        _ <- ensure(e == Left(MockError.RuleNotFound(s.id, RuleId("ghost"))), s"removeRule unknown: $e")
+      yield ()
+    },
+    // (ops on a destroyed space -> defined MockError is covered by CoreConformanceScenarios #125,
+    //  "operations on a destroyed space fail with SpaceNotFound" — all four ops, every adapter.)
+    scen(
+      "error: adding the same rule twice yields distinct ids with precise, non-aliased removal (duplicate-id behaviour)"
+    ) { control =>
+      val dup = rule("/dup", "dup")
+      for
+        s       <- space(control, rule("/keep", "keep"))
+        id1     <- control.addRule(s, dup, Priority.Base).mapError(asT) // identical rules...
+        id2     <- control.addRule(s, dup, Priority.Base).mapError(asT) // ...get distinct managed ids
+        _       <- control.removeRule(s, id1).mapError(asT)
+        rm2     <- control.removeRule(s, id2).either                    // the twin is still removable (not aliased to id1)
+        rmGhost <- control.removeRule(s, id1).either                    // re-removing the gone id -> RuleNotFound
+        _ <- ensure(
+               id1 != id2 && rm2.isRight && rmGhost == Left(MockError.RuleNotFound(s.id, id1)),
+               s"rule ids: id1=$id1 id2=$id2 rm2=$rm2 rmGhost=$rmGhost"
+             )
+      yield ()
+    }
+  )

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceHarnessSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceHarnessSpec.scala
@@ -1,0 +1,103 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+import zio.test.*
+
+/**
+ * Pure + synthetic tests that lock the runner's classification contract — the
+ * FAIL and unjustified-SKIP branches of `conformant` that the live WireMock
+ * matrix never exercises (it only ever produces PASS/justified-SKIP). No
+ * Docker, no real server.
+ */
+object ConformanceHarnessSpec extends ZIOSpecDefault:
+
+  // A no-op backend: the predicate/render tests never run its layer; the harness
+  // tests run a scenario that ignores the control.
+  private val stub: MockControl = new MockControl:
+    def backendName: String           = "stub"
+    def capabilities: Set[Capability] = Set.empty
+    def provision(source: MockSource): IO[MockError, List[MockSpace]] =
+      ZIO.succeed(List(MockSpace("stub://x", identity, SpaceId("x"))))
+    def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+      ZIO.fail(MockError.InvalidDefinition("n/a"))
+    def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] = ZIO.succeed(RuleId("r"))
+    def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit]                        = ZIO.unit
+    def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit]           = ZIO.unit
+    def destroy(space: MockSpace): IO[MockError, Unit]                                       = ZIO.unit
+    def received(space: MockSpace): IO[MockError, List[RecordedRequest]]                     = ZIO.succeed(Nil)
+    def faults: IO[Unsupported, Faults]                                                      = ZIO.fail(Unsupported(Capability.Faults, "stub"))
+    def scenarios: IO[Unsupported, StatefulScenarios]                                        = ZIO.fail(Unsupported(Capability.StatefulScenarios, "stub"))
+    def stateInspection: IO[Unsupported, StateInspection]                                    = ZIO.fail(Unsupported(Capability.StateInspection, "stub"))
+    def scripting: IO[Unsupported, Scripting]                                                = ZIO.fail(Unsupported(Capability.Scripting, "stub"))
+    def proxyRecord: IO[Unsupported, ProxyRecord]                                            = ZIO.fail(Unsupported(Capability.ProxyRecord, "stub"))
+    def templating: IO[Unsupported, Templating]                                              = ZIO.fail(Unsupported(Capability.Templating, "stub"))
+
+  // capabilities = empty -> a Faults-requiring scenario is justifiably skipped.
+  private val backend  = MockBackendUnderTest("b", ZLayer.succeed(stub), Set.empty, Isolation.PerInstance)
+  private val basic    = ConformanceScenario("basic", Set.empty, _ => ZIO.unit) // requires nothing
+  private val needsCap = ConformanceScenario("needs-faults", Set(Capability.Faults), _ => ZIO.unit)
+
+  private def matrixOf(scenarios: List[ConformanceScenario], cells: Cell*): Matrix =
+    Matrix(List(backend), scenarios, cells.toList)
+
+  def spec = suite("ConformanceHarness")(
+    suite("conformant predicate")(
+      test("a FAIL cell makes the column non-conformant") {
+        assertTrue(!matrixOf(List(basic), Cell("basic", "b", Outcome.Fail)).conformant(backend))
+      },
+      test("an UNJUSTIFIED skip (a runnable scenario skipped) makes the column non-conformant") {
+        // 'basic' requires nothing and the backend is available, so a Skip is unjustified.
+        assertTrue(!matrixOf(List(basic), Cell("basic", "b", Outcome.Skip)).conformant(backend))
+      },
+      test("a JUSTIFIED skip (un-advertised capability) keeps the column conformant") {
+        assertTrue(matrixOf(List(needsCap), Cell("needs-faults", "b", Outcome.Skip)).conformant(backend))
+      },
+      test("an all-PASS column is conformant") {
+        assertTrue(matrixOf(List(basic), Cell("basic", "b", Outcome.Pass)).conformant(backend))
+      },
+      test("an unavailable backend's all-SKIP column is (vacuously) conformant") {
+        val down = backend.copy(available = false)
+        assertTrue(Matrix(List(down), List(basic), List(Cell("basic", "b", Outcome.Skip))).conformant(down))
+      }
+    ),
+    test("render shows the P/S/F grid with scenario names and outcomes") {
+      val m = Matrix(
+        List(backend),
+        List(basic, needsCap),
+        List(Cell("basic", "b", Outcome.Pass), Cell("needs-faults", "b", Outcome.Skip))
+      )
+      val r = m.render
+      assertTrue(
+        r.contains("basic"),
+        r.contains("needs-faults"),
+        r.contains("PASS"),
+        r.contains("SKIP"),
+        r.contains("b")
+      )
+    },
+    suite("runner classifies failures")(
+      test("a failing scenario produces a FAIL cell and a non-conformant column") {
+        val boom = ConformanceScenario("boom", Set.empty, _ => ZIO.fail(new RuntimeException("boom")))
+        for matrix <- ConformanceHarness.run(List(backend), List(boom))
+        yield assertTrue(
+          matrix.cell("boom", "b").map(_.outcome).contains(Outcome.Fail),
+          !matrix.conformant(backend)
+        )
+      },
+      test("a backend whose layer cannot build fails every scenario") {
+        val broken = MockBackendUnderTest(
+          "broken",
+          ZLayer.fail(new RuntimeException("no backend")),
+          Set.empty,
+          Isolation.PerInstance
+        )
+        for matrix <- ConformanceHarness.run(List(broken), List(basic, needsCap))
+        yield assertTrue(
+          matrix.cell("basic", "broken").map(_.outcome).contains(Outcome.Fail),
+          matrix.cell("needs-faults", "broken").map(_.outcome).contains(Outcome.Fail),
+          !matrix.conformant(broken)
+        )
+      }
+    )
+  )

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
@@ -1,0 +1,120 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.rift.Rift
+import zio.bdd.mock.wiremock.WireMock
+import zio.http.Client
+import zio.test.*
+
+/**
+ * The conformance matrix (#124): one portable scenario set run against every
+ * registered backend, emitting pass/skip/fail. WireMock runs in-process always;
+ * the Rift container backend is gated behind `RIFT_IT` (like
+ * RiftContainerSpec), so `sbt test` stays Docker-free and CI runs the real
+ * cross-adapter matrix.
+ */
+object ConformanceMatrixSpec extends ZIOSpecDefault:
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+  private def ensure(cond: Boolean, msg: => String): IO[Throwable, Unit] =
+    ZIO.unless(cond)(ZIO.fail(new AssertionError(msg))).unit
+
+  private val pingSource =
+    MockSource.Dsl(
+      MockSpec(
+        List(
+          MockRule(
+            RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+            ResponseDef(status = 200, body = Body.Text("pong"))
+          )
+        )
+      )
+    )
+
+  // ---- the portable scenarios (programmed against MockControl, never a backend) ----
+
+  private val provisionServeRecord = "provision, serve, and record a request"
+  private val isolationReceived    = "isolation: received(A) returns only A's traffic"
+  private val injectFault          = "inject a fault"
+
+  private val scenarios = List(
+    ConformanceScenario(
+      provisionServeRecord,
+      Set.empty,
+      control =>
+        for
+          spaces <- control.provision(pingSource).mapError(asT)
+          space   = spaces.head
+          resp   <- SutClient.make(space).send(Method.Get, "/ping")
+          recv   <- control.received(space).mapError(asT)
+          _      <- control.destroy(space).mapError(asT)
+          _ <- ensure(
+                 resp.status == 200 && resp.body == "pong" && recv.exists(_.uri == "/ping"),
+                 s"basic: status=${resp.status} body=${resp.body} recv=$recv"
+               )
+        yield ()
+    ),
+    ConformanceScenario(
+      isolationReceived,
+      Set.empty,
+      // Portable across modes: PerInstance (two ports) and Correlated (one server,
+      // header-filtered) both yield received(A) = only A's traffic.
+      control =>
+        for
+          a  <- control.provision(pingSource).mapError(asT).map(_.head)
+          b  <- control.provision(pingSource).mapError(asT).map(_.head)
+          _  <- SutClient.make(a).send(Method.Get, "/ping")
+          _  <- SutClient.make(b).send(Method.Get, "/ping")
+          _  <- SutClient.make(b).send(Method.Get, "/ping")
+          ra <- control.received(a).mapError(asT)
+          rb <- control.received(b).mapError(asT)
+          _  <- control.destroy(a).mapError(asT)
+          _  <- control.destroy(b).mapError(asT)
+          _  <- ensure(ra.size == 1 && rb.size == 2, s"isolation: ra=${ra.size} rb=${rb.size}")
+        yield ()
+    ),
+    // Requires Faults — neither adapter advertises it yet (M3), so it must SKIP, never FAIL.
+    ConformanceScenario(
+      injectFault,
+      Set(Capability.Faults),
+      control => control.faults.mapError(u => new RuntimeException(u.toString)).unit
+    )
+  )
+
+  // ---- the backends ----
+
+  private val wiremock =
+    MockBackendUnderTest("wiremock", Provisioning.live >>> WireMock.correlated(), Set.empty, Isolation.Correlated)
+
+  private val riftEnabled = sys.env.contains("RIFT_IT")
+  private val rift =
+    MockBackendUnderTest(
+      "rift",
+      (Client.default ++ Provisioning.live) >>> Rift.managed().mapError(asT),
+      Set.empty,
+      Isolation.PerInstance,
+      available = riftEnabled
+    )
+
+  def spec = suite("ConformanceMatrix")(
+    test("runs the portable scenario set across backends and emits a conformant matrix") {
+      for
+        matrix <- ConformanceHarness.run(List(wiremock, rift), scenarios)
+        _      <- ZIO.logInfo(s"conformance matrix:\n${matrix.render}")
+      yield assertTrue(
+        // WireMock (in-process, always available)
+        matrix.cell(provisionServeRecord, "wiremock").map(_.outcome).contains(Outcome.Pass),
+        matrix.cell(isolationReceived, "wiremock").map(_.outcome).contains(Outcome.Pass),
+        matrix
+          .cell(injectFault, "wiremock")
+          .map(_.outcome)
+          .contains(Outcome.Skip),   // Faults un-advertised → SKIP, not FAIL
+        matrix.conformant(wiremock), // zero FAIL, skip justified by capability
+        // Rift: conformant when available (CI with RIFT_IT), else the column is SKIPPED-unavailable (local, no Docker)
+        if riftEnabled then matrix.conformant(rift)
+        else matrix.cell(provisionServeRecord, "rift").map(_.outcome).contains(Outcome.Skip),
+        matrix.render.contains("wiremock")
+      )
+    } @@ TestAspect.withLiveClock
+  )

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
@@ -123,7 +123,7 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         matrix <- ConformanceHarness.run(List(wiremock, rift), all)
         _      <- ZIO.logInfo(s"core conformance matrix:\n${matrix.render}")
         // Surface any non-Pass cell's detail so a failure is debuggable from the log.
-        wmFails   = nonPass(matrix, "wiremock")
+        wmFails   = nonPass(matrix, "wiremock", all)
         _        <- ZIO.logInfo(s"wiremock non-pass: $wmFails").when(wmFails.nonEmpty)
         riftCells = all.flatMap(s => matrix.cell(s.name, "rift").map(_.outcome))
       yield assertTrue(
@@ -139,11 +139,27 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip),
         matrix.conformant(wiremock)
       )
+    } @@ TestAspect.withLiveClock,
+    test("capability-negotiation + error-semantics features pass on every adapter (#127)") {
+      val all = NegotiationErrorScenarios.all
+      for
+        matrix   <- ConformanceHarness.run(List(wiremock, rift), all)
+        _        <- ZIO.logInfo(s"negotiation/error matrix:\n${matrix.render}")
+        wmFails   = nonPass(matrix, "wiremock", all)
+        _        <- ZIO.logInfo(s"wiremock non-pass: $wmFails").when(wmFails.nonEmpty)
+        riftCells = all.flatMap(s => matrix.cell(s.name, "rift").map(_.outcome))
+      yield assertTrue(
+        all.nonEmpty,
+        all.forall(s => matrix.cell(s.name, "wiremock").exists(_.outcome == Outcome.Pass)),
+        matrix.cells.count(_.backend == "wiremock") == all.size,
+        if riftEnabled then all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Pass))
+        else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
+      )
     } @@ TestAspect.withLiveClock
   )
 
-  private def nonPass(matrix: Matrix, backend: String): List[String] =
-    CoreConformanceScenarios.all.flatMap { s =>
+  private def nonPass(matrix: Matrix, backend: String, scenarios: List[ConformanceScenario]): List[String] =
+    scenarios.flatMap { s =>
       matrix
         .cell(s.name, backend)
         .filter(_.outcome != Outcome.Pass)

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
@@ -116,5 +116,36 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         else matrix.cell(provisionServeRecord, "rift").map(_.outcome).contains(Outcome.Skip),
         matrix.render.contains("wiremock")
       )
+    } @@ TestAspect.withLiveClock,
+    test("core conformance features pass on every adapter (#125)") {
+      val all = CoreConformanceScenarios.all
+      for
+        matrix <- ConformanceHarness.run(List(wiremock, rift), all)
+        _      <- ZIO.logInfo(s"core conformance matrix:\n${matrix.render}")
+        // Surface any non-Pass cell's detail so a failure is debuggable from the log.
+        wmFails   = nonPass(matrix, "wiremock")
+        _        <- ZIO.logInfo(s"wiremock non-pass: $wmFails").when(wmFails.nonEmpty)
+        riftCells = all.flatMap(s => matrix.cell(s.name, "rift").map(_.outcome))
+      yield assertTrue(
+        all.nonEmpty, // the catalog actually ran
+        all.forall(s =>
+          matrix.cell(s.name, "wiremock").exists(_.outcome == Outcome.Pass)
+        ), // every scenario PASSed (presence, not absence-of-Fail)
+        matrix.cells.count(
+          _.backend == "wiremock"
+        ) == all.size, // every scenario produced exactly one cell (no missing/aliased name)
+        // Rift: every scenario PASSes in CI (RIFT_IT); else the whole column is SKIPPED-unavailable.
+        if riftEnabled then all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Pass))
+        else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip),
+        matrix.conformant(wiremock)
+      )
     } @@ TestAspect.withLiveClock
   )
+
+  private def nonPass(matrix: Matrix, backend: String): List[String] =
+    CoreConformanceScenarios.all.flatMap { s =>
+      matrix
+        .cell(s.name, backend)
+        .filter(_.outcome != Outcome.Pass)
+        .map(c => s"${c.scenario} -> ${c.outcome}: ${c.detail.getOrElse("")}")
+    }

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/NativeEscapeHatchSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/NativeEscapeHatchSpec.scala
@@ -1,0 +1,108 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.rift.Rift
+import zio.bdd.mock.wiremock.WireMock
+import zio.http.Client
+import zio.test.*
+
+/**
+ * The native-escape-hatch conformance feature (#127/#119): a
+ * natively-provisioned space honors the core contract (serve + record +
+ * space-local destroy) on every adapter — but each adapter speaks its OWN
+ * native dialect, so this is per-adapter with its own snippet (it can't be a
+ * portable `MockControl`-only scenario).
+ *
+ * WireMock runs in-process always; the Rift backend is gated behind `RIFT_IT`
+ * (the `rift-it` CI job runs the conformance module under it), so the Rift
+ * container isn't built in the default Docker-free lane.
+ */
+object NativeEscapeHatchSpec extends ZIOSpecDefault:
+
+  private def asT(e: MockError): Throwable      = new RuntimeException(s"MockError: $e")
+  private val upWithin: Schedule[Any, Any, Any] = Schedule.recurs(20) && Schedule.spaced(100.millis)
+
+  // Each adapter's own native dialect, both serving GET /native with "native!".
+  private val riftNative =
+    """{"port":9999,"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/native"}}],"responses":[{"is":{"statusCode":200,"body":"native!"}}]}]}"""
+  private val wmNative =
+    """{"request":{"method":"GET","url":"/native"},"response":{"status":201,"body":"native!"}}"""
+
+  private final case class NativeBackend(
+    name: String,
+    layer: ZLayer[Any, Throwable, MockControl],
+    provisionNative: MockControl => IO[MockError, List[MockSpace]],
+    status: Int,
+    body: String
+  )
+
+  private def hatchSuite(b: NativeBackend) =
+    suite(b.name)(
+      test("a natively-provisioned space serves + records its full-fidelity contract; destroy is space-local") {
+        ZIO.scoped {
+          for
+            control <- ZIO.service[MockControl]
+            a <- ZIO.acquireRelease(b.provisionNative(control).mapError(asT).map(_.head))(s =>
+                   control.destroy(s).ignoreLogged
+                 )
+            other <- ZIO.acquireRelease(b.provisionNative(control).mapError(asT).map(_.head))(s =>
+                       control.destroy(s).ignoreLogged
+                     )
+            served <- SutClient.make(a).send(Method.Get, "/native").retry(upWithin)
+            recv   <- control.received(a).mapError(asT)
+            // a native space honors rule mutation (overlays) like a portable one (NativeSpec contract)
+            ovId <- control
+                      .addRule(
+                        a,
+                        MockRule(
+                          RequestMatch(path = PathMatch.Exact("/native")),
+                          ResponseDef(status = 200, body = Body.Text("overlaid"))
+                        ),
+                        Priority.Overlay
+                      )
+                      .mapError(asT)
+            overlaid <- SutClient.make(a).send(Method.Get, "/native")
+            _        <- control.removeRule(a, ovId).mapError(asT)
+            reverted <- SutClient.make(a).send(Method.Get, "/native")
+            _        <- control.destroy(a).mapError(asT)
+            aGone    <- control.received(a).either // ops on a destroyed space
+            bAfter   <- SutClient.make(other).send(Method.Get, "/native").retry(upWithin)
+          yield assertTrue(
+            served.status == b.status, // native serves its own full-fidelity response
+            served.body == b.body,
+            recv.exists(r => r.method == Method.Get && r.uri == "/native"), // records
+            overlaid.status == 200 && overlaid.body == "overlaid",          // overlay shadows the native rule
+            reverted.status == b.status && reverted.body == b.body,         // removeRule reverts to the native rule
+            aGone == Left(MockError.SpaceNotFound(a.id)),                   // destroyed-space op -> defined MockError
+            bAfter.status == b.status                                       // space-local: B unaffected by A's destroy
+          )
+        }
+      }
+    ).provideShared(b.layer) @@ TestAspect.sequential
+
+  private val riftEnabled = sys.env.contains("RIFT_IT")
+
+  private val wiremockBackend =
+    NativeBackend(
+      "wiremock-native",
+      Provisioning.live >>> WireMock.perInstance,
+      _.provisionNative(NativeSpec.WireMock(wmNative)),
+      201,
+      "native!"
+    )
+
+  // Excluded from the list (not just ignored) when RIFT_IT is unset, so its
+  // container is never built in the Docker-free lane.
+  private val riftBackend =
+    NativeBackend(
+      "rift-native",
+      (Client.default ++ Provisioning.live) >>> Rift.managed().mapError(asT),
+      _.provisionNative(NativeSpec.Rift(riftNative)),
+      200,
+      "native!"
+    )
+
+  private val backends = wiremockBackend :: (if riftEnabled then List(riftBackend) else Nil)
+
+  def spec = suite("NativeEscapeHatch")(backends.map(hatchSuite)*) @@ TestAspect.withLiveClock

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ParallelIsolationSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ParallelIsolationSpec.scala
@@ -1,0 +1,179 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.rift.{Rift, RiftMode}
+import zio.bdd.mock.wiremock.WireMock
+import zio.http.Client
+import zio.test.*
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest as JHttpRequest, HttpResponse as JHttpResponse}
+
+/**
+ * The headline isolation contract (#126) under genuine concurrency, run
+ * repeatedly (`nonFlaky`) against EVERY isolation mode each adapter advertises:
+ * WireMock correlated + perInstance (always, in-process) and Rift perInstance +
+ * correlated (gated behind `RIFT_IT`, like
+ * [[zio.bdd.mock.rift.RiftContainerSpec]] — the `rift-it` CI job runs this spec
+ * under `RIFT_IT`, so the Rift backends + the native fixed-port test execute
+ * there, not in the default Docker-free lane).
+ *
+ * Tests within a backend run sequentially so only one N-space wave is live at a
+ * time — Rift PerInstance gives each space its own imposter+port, so a generous
+ * pool (> N) must cover one wave, not all tests at once. Each wave is scoped,
+ * so its spaces are torn down (ports freed) before the next test/repetition.
+ */
+object ParallelIsolationSpec extends ZIOSpecDefault:
+
+  private val N    = 50 // "50+ concurrent spaces"
+  private val Reps = 3  // surface races without exploding the real-container CI time
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+
+  // A GET that does NOT apply space.inject — used to prove inject is load-bearing.
+  private def rawGet(baseUri: String, path: String): Task[(Int, String)] =
+    ZIO.attemptBlocking {
+      val req  = JHttpRequest.newBuilder(URI.create(baseUri + path)).GET().build()
+      val resp = HttpClient.newHttpClient().send(req, JHttpResponse.BodyHandlers.ofString())
+      (resp.statusCode, resp.body)
+    }
+
+  private def srcText(path: String, body: String): MockSource =
+    MockSource.Dsl(
+      MockSpec(
+        List(MockRule(RequestMatch(path = PathMatch.Exact(path)), ResponseDef(status = 200, body = Body.Text(body))))
+      )
+    )
+
+  // A native Rift imposter pinning port 9999 (the "fixed-port" trap) serving `body` at /fp.
+  private def riftFixedPort(body: String): String =
+    s"""{"port":9999,"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/fp"}}],"responses":[{"is":{"statusCode":200,"body":"$body"}}]}]}"""
+
+  // provision -> destroy on scope close (even on failure), so the pool is freed.
+  // ignoreLogged (not bare ignore): teardown must not override the verdict, but a
+  // destroy failure that could starve the pool across waves should be diagnosable.
+  private def serving(control: MockControl, path: String, body: String): RIO[Scope, MockSpace] =
+    ZIO.acquireRelease(control.provision(srcText(path, body)).mapError(asT).map(_.head))(s =>
+      control.destroy(s).ignoreLogged
+    )
+
+  private def servingNative(control: MockControl, imposter: String): RIO[Scope, MockSpace] =
+    ZIO.acquireRelease(control.provisionNative(NativeSpec.Rift(imposter)).mapError(asT).map(_.head))(s =>
+      control.destroy(s).ignoreLogged
+    )
+
+  private final case class Backend(
+    name: String,
+    layer: ZLayer[Any, Throwable, MockControl],
+    isolation: Isolation,
+    native: Boolean
+  )
+
+  private def backendSuite(b: Backend) =
+    val nativeOnly = if b.native then TestAspect.identity else TestAspect.ignore
+    suite(b.name)(
+      test(s"$N concurrent spaces each serve only their own body (no behaviour or recording cross-talk)") {
+        ZIO.scoped {
+          for
+            control <- ZIO.service[MockControl]
+            spaces  <- ZIO.foreachPar(1 to N)(i => serving(control, "/p", s"body-$i").map(i -> _))
+            results <- ZIO.foreachPar(spaces) { (i, s) =>
+                         for
+                           resp <- SutClient.make(s).send(Method.Get, "/p")
+                           recv <- control.received(s).mapError(asT)
+                         yield (i, resp.body, recv.size, recv.forall(_.uri == "/p"))
+                       }
+          yield assertTrue(
+            results.length == N,                                   // all N spaces actually ran (not a short list)
+            results.forall((i, body, _, _) => body == s"body-$i"), // own body — no behaviour cross-talk
+            results.forall((_, _, size, ok) => size == 1 && ok)    // own single recording — no recording cross-talk
+          )
+        }
+      } @@ TestAspect.nonFlaky(Reps),
+      test("overlays applied to a subset under concurrency stay space-local") {
+        ZIO.scoped {
+          for
+            control <- ZIO.service[MockControl]
+            spaces  <- ZIO.foreachPar(1 to N)(i => serving(control, "/p", s"base-$i").map(i -> _))
+            _ <- ZIO.foreachPar(spaces.filter((i, _) => i % 2 == 0)) { (i, s) =>
+                   control
+                     .addRule(
+                       s,
+                       MockRule(
+                         RequestMatch(path = PathMatch.Exact("/p")),
+                         ResponseDef(status = 200, body = Body.Text(s"overlay-$i"))
+                       ),
+                       Priority.Overlay
+                     )
+                     .mapError(asT)
+                 }
+            bodies <- ZIO.foreachPar(spaces)((i, s) => SutClient.make(s).send(Method.Get, "/p").map(i -> _.body))
+          yield assertTrue(
+            bodies.length == N,
+            bodies.count((_, body) => body.startsWith("overlay")) == N / 2, // the subset was overlaid, no more
+            bodies.forall((i, body) => body == (if i % 2 == 0 then s"overlay-$i" else s"base-$i"))
+          )
+        }
+      } @@ TestAspect.nonFlaky(Reps),
+      // RIFT_IT-only: a pinned-port source is a native (Rift) concept; WireMock rejects it.
+      test("a fixed-port source provisioned twice still isolates (the adapter overrides the pinned port)") {
+        ZIO.scoped {
+          for
+            a  <- ZIO.service[MockControl].flatMap(servingNative(_, riftFixedPort("A")))
+            b2 <- ZIO.service[MockControl].flatMap(servingNative(_, riftFixedPort("B")))
+            ra <- SutClient.make(a).send(Method.Get, "/fp")
+            rb <- SutClient.make(b2).send(Method.Get, "/fp")
+          yield assertTrue(a.baseUri != b2.baseUri, ra.body == "A", rb.body == "B")
+        }
+      } @@ nativeOnly @@ TestAspect.nonFlaky(Reps),
+      test("inject is load-bearing (Correlated drops an un-injected request; PerInstance inject is identity)") {
+        ZIO.scoped {
+          for
+            control <- ZIO.service[MockControl]
+            s       <- serving(control, "/p", "body")
+            _       <- SutClient.make(s).send(Method.Get, "/p") // injected -> reaches + records
+            result <- b.isolation match
+                        // A raw GET without the correlation header must not land in the space.
+                        case Isolation.Correlated =>
+                          rawGet(s.baseUri, "/p") *>
+                            control
+                              .received(s)
+                              .mapError(asT)
+                              .map(recv => assertTrue(recv.size == 1, recv.forall(_.uri == "/p")))
+                        // PerInstance has nothing to drop — inject is identity, the load-bearing invariant there.
+                        case Isolation.PerInstance =>
+                          val req = HttpRequest(Method.Get, s.baseUri + "/p")
+                          ZIO.succeed(assertTrue(s.inject(req) == req))
+          yield result
+        }
+      }
+    ).provideShared(b.layer) @@ TestAspect.sequential
+
+  private val riftEnabled = sys.env.contains("RIFT_IT")
+
+  private val wiremockBackends = List(
+    Backend("wiremock-correlated", Provisioning.live >>> WireMock.correlated(), Isolation.Correlated, native = false),
+    Backend("wiremock-perinstance", Provisioning.live >>> WireMock.perInstance, Isolation.PerInstance, native = false)
+  )
+
+  // Rift PerInstance needs a pool wide enough for one N-space wave (+ the 2 native spaces).
+  private val riftBackends = List(
+    Backend(
+      "rift-perinstance",
+      (Client.default ++ Provisioning.live) >>> Rift.managed(poolSize = N + 8).mapError(asT),
+      Isolation.PerInstance,
+      native = true
+    ),
+    Backend(
+      "rift-correlated",
+      (Client.default ++ Provisioning.live) >>> Rift.managed(poolSize = 16, mode = RiftMode.correlated).mapError(asT),
+      Isolation.Correlated,
+      native = true
+    )
+  )
+
+  private val backends = wiremockBackends ++ (if riftEnabled then riftBackends else Nil)
+
+  def spec =
+    suite("ParallelIsolation")(backends.map(backendSuite)*) @@ TestAspect.sequential @@ TestAspect.withLiveClock

--- a/mock/src/main/scala/zio/bdd/mock/Capability.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Capability.scala
@@ -15,8 +15,9 @@ enum Capability:
  *   - Correlated: a shared base URI partitioned by a correlation header (e.g.
  *     WireMock).
  *
- * Marker type only at this stage; the per-adapter behaviour lands with the
- * isolation model in M2 (#123).
+ * The behaviour itself lives in [[MockSpace.inject]] (which hides the mode from
+ * the Gherkin); an adapter reports its mode via [[MockControl.isolation]]
+ * (#123).
  */
 enum Isolation:
   case PerInstance, Correlated

--- a/mock/src/main/scala/zio/bdd/mock/MockControl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockControl.scala
@@ -52,6 +52,16 @@ trait MockControl:
   def capabilities: Set[Capability]
 
   /**
+   * The isolation model this control operates in (#123).
+   * [[Isolation.PerInstance]] is the default — a unique `baseUri` per space
+   * with `inject == identity`; a Correlated adapter (one shared `baseUri`,
+   * `inject` stamps a correlation header) overrides it. Steps never read this:
+   * [[MockSpace.inject]] already hides the mode from the Gherkin. It is exposed
+   * for diagnostics and the suite-override path where an adapter supports both.
+   */
+  def isolation: Isolation = Isolation.PerInstance
+
+  /**
    * Fail-fast capability negotiation: declare what a suite needs up front.
    * Succeeds when every required capability is advertised; otherwise fails with
    * the first missing one (in argument order), naming it and the backend.

--- a/mock/src/main/scala/zio/bdd/mock/SutClient.scala
+++ b/mock/src/main/scala/zio/bdd/mock/SutClient.scala
@@ -17,6 +17,11 @@ final case class SutResponse(status: Int, body: String, headers: Map[String, Str
  *
  * Provide it per scenario via [[SutClient.layer]] — never a process-wide env
  * var — so parallel scenarios each target their own space with no cross-talk.
+ *
+ * This is the canonical *Caller* of the isolation model (#123): it always sends
+ * `space.inject(req)` to `space.baseUri` and never branches on PerInstance vs
+ * Correlated — the whole difference lives in `space.inject`, so steps stay
+ * isolation-agnostic. See [[MockControl.isolation]] for an adapter's mode.
  */
 trait SutClient:
   /**

--- a/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
@@ -118,6 +118,9 @@ object MockControlModelSpec extends ZIOSpecDefault:
     test("Isolation enum has both isolation modes") {
       assertTrue(Isolation.values.toSet == Set(Isolation.PerInstance, Isolation.Correlated))
     },
+    test("MockControl.isolation defaults to PerInstance for an adapter that does not override it") {
+      assertTrue(StubMockControl("stub", Set.empty).isolation == Isolation.PerInstance)
+    },
     test("NativeSpec is backend-tagged and carries its raw payload") {
       // The type ascriptions are the real assertion: they only compile because
       // each case is pinned to its backend tag (Rift / WireMock).

--- a/mock/src/test/scala/zio/bdd/mock/SutClientSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/SutClientSpec.scala
@@ -119,6 +119,22 @@ object SutClientSpec extends ZIOSpecDefault:
         }
       }
     },
+    test("the Caller is isolation-agnostic: one send path reaches a PerInstance AND a Correlated space") {
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          // PerInstance: own baseUri, inject == identity. Correlated: shared baseUri, inject adds the
+          // header. The SutClient call is identical for both — it never branches on the mode.
+          val perInstance = dep.perInstanceSpace("pi")
+          val correlated  = dep.correlatedSpace("co")
+          for
+            _     <- SutClient.make(perInstance).send(Method.Get, "/x")
+            _     <- SutClient.make(correlated).send(Method.Get, "/y")
+            recPi <- dep.received("pi")
+            recCo <- dep.received("co")
+          yield assertTrue(recPi == List(("GET", "/x")), recCo == List(("GET", "/y")))
+        }
+      }
+    },
     test("concurrent SUT calls via per-space clients don't cross-talk (PerInstance)") {
       ZIO.scoped {
         dependency.flatMap { dep =>

--- a/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
@@ -17,10 +17,10 @@ import org.testcontainers.containers.wait.strategy.Wait
  */
 object Rift:
 
-  // Pinned to v0.3.0. Floor is v0.2.0: the first release where DELETE
+  // Pinned to v0.4.0. Floor is v0.2.0: the first release where DELETE
   // /imposters/:port tears down existing keep-alive connections, so a destroyed
   // imposter stops serving even a pooled client (EtaCassiopeia/rift#207).
-  val DefaultImage: String     = "zainalpour/rift-proxy:v0.3.0"
+  val DefaultImage: String     = "zainalpour/rift-proxy:v0.4.0"
   val DefaultAdminPort: Int    = 2525
   val DefaultImposterBase: Int = 4545
   val DefaultPoolSize: Int     = 16

--- a/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
@@ -1,10 +1,45 @@
 package zio.bdd.mock.rift
 
 import zio.*
-import zio.bdd.mock.{MockControl, MockError, Provisioning}
+import zio.bdd.mock.{MockControl, MockError, Provisioning, SpaceId}
 import zio.http.Client
 import com.dimafeng.testcontainers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
+
+/**
+ * How a Correlated space tags its requests on the shared imposter. `header` is
+ * the correlation header (Rift's `flowIdSource = header:<header>` gates stubs +
+ * recorded requests by it natively); `value` is what `MockSpace.inject` stamps
+ * on each request — and the `flowId` the adapter scopes stubs/teardown under.
+ */
+final case class Correlation(header: String, value: SpaceId => String)
+
+object Correlation:
+  /** Default: a dedicated `X-Mock-Space: <spaceId>` header. */
+  val spaceHeader: Correlation = Correlation("X-Mock-Space", id => id.value)
+
+  /**
+   * Correlate by the W3C trace context the SUT already propagates. NOTE: Rift's
+   * flow-id is the whole header value, so `inject` stamps a fixed traceparent
+   * per space — the SUT cannot vary the span-id (unlike the WireMock adapter,
+   * which matches by trace-id).
+   */
+  val traceparent: Correlation =
+    Correlation("traceparent", id => s"00-${traceId(id)}-0000000000000001-01")
+
+  private def traceId(id: SpaceId): String =
+    (0 until 4).map(i => f"${(id.value + ":" + i).hashCode & 0xffffffffL}%08x").mkString
+
+/**
+ * Rift isolation mode (#156). PerInstance (own port per space) is the default.
+ */
+enum RiftMode:
+  case PerInstance
+  case Correlated(correlation: Correlation)
+
+object RiftMode:
+  /** Correlated isolation with the default `X-Mock-Space` correlation. */
+  val correlated: RiftMode = Correlated(Correlation.spaceHeader)
 
 /**
  * Entry points for the Rift adapter — the default, zero-native-artifact
@@ -33,10 +68,11 @@ object Rift:
    */
   def connect(
     adminBase: String,
-    imposterPorts: List[Int]
+    imposterPorts: List[Int],
+    mode: RiftMode = RiftMode.PerInstance
   )(hostFor: Int => String): URLayer[Client & Provisioning, MockControl] =
-    ZLayer {
-      RiftEndpoint.pooled(adminBase, imposterPorts)(hostFor).flatMap(RiftMockControl.make)
+    ZLayer.scoped {
+      RiftEndpoint.pooled(adminBase, imposterPorts)(hostFor).flatMap(RiftMockControl.make(_, mode))
     }
 
   /**
@@ -54,7 +90,8 @@ object Rift:
     image: String = DefaultImage,
     poolSize: Int = DefaultPoolSize,
     adminPort: Int = DefaultAdminPort,
-    imposterBasePort: Int = DefaultImposterBase
+    imposterBasePort: Int = DefaultImposterBase,
+    mode: RiftMode = RiftMode.PerInstance
   ): ZLayer[Client & Provisioning, MockError, MockControl] =
     ZLayer.scoped {
       val imposterPorts = (0 until poolSize).map(imposterBasePort + _).toList
@@ -74,7 +111,7 @@ object Rift:
         host      = container.host
         admin     = s"http://$host:${container.mappedPort(adminPort)}"
         endpoint <- RiftEndpoint.pooled(admin, imposterPorts)(p => s"http://$host:${container.mappedPort(p)}")
-        control  <- RiftMockControl.make(endpoint)
+        control  <- RiftMockControl.make(endpoint, mode)
       yield control
     }
 

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -6,123 +6,101 @@ import zio.json.*
 import zio.json.ast.Json
 import zio.http.{Body, Client, Header, MediaType, Request, URL, Method as HttpMethod}
 
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
+
 /**
  * The Rift adapter: implements the portable [[MockControl]] core port by
  * driving Rift's Mountebank-compatible admin API over zio-http.
  *
- * PerInstance isolation: each [[MockSpace]] is one imposter on its own port and
- * `inject == identity`. `destroy` deletes exactly that imposter (`DELETE
- * /imposters/:port`) — never the global `DELETE /imposters` reset, so tearing
- * down one space never touches another (#113 AC2).
+ * Two isolation modes ([[RiftMode]]):
  *
- * Rule identity: Mountebank addresses stubs by positional index, which shifts
- * as stubs are inserted/removed. The adapter therefore hands out stable opaque
- * [[RuleId]]s and tracks their current order per imposter, translating an id to
- * its live index on removal — so a [[RuleId]] never silently points at the
- * wrong stub after an overlay insert.
+ *   - PerInstance (default): each [[MockSpace]] is one imposter on its own
+ *     port, `inject == identity`. `destroy` deletes exactly that imposter —
+ *     never the global reset, so tearing down one space never touches another
+ *     (#113 AC2).
  *
- * Capabilities are intentionally empty here: the optional capability
- * *interfaces* (faults, scenarios, …) are fleshed out in M3, so this adapter
- * advertises none and every accessor fails fast with [[Unsupported]].
+ *   - Correlated (#156): all spaces share ONE imposter whose `flowIdSource` is
+ *     `header:<correlation>`; each space's stubs are registered under its
+ *     flowId (`POST /imposters/:port/spaces/:flowId/stubs`, rift#223), `inject`
+ *     stamps the correlation header, `received` filters by it (rift#201), and
+ *     `destroy` tears down exactly that space (`DELETE
+ *     /imposters/:port/spaces/:flowId`). Trades a port-per-space for one shared
+ *     imposter — for heavy parallelism.
+ *
+ * A native imposter ([[provisionNative]]) always gets its own port regardless
+ * of mode (full-fidelity), so the two space kinds coexist; per-space operations
+ * dispatch by which space a [[MockSpace]] belongs to, not by the active mode.
+ *
+ * rift#223 exposes only whole-space teardown (no per-stub-in-space delete), so
+ * a Correlated `removeRule`/`replaceRules` (and an `Overlay` `addRule`, which
+ * must be first-match) rebuilds the space: it re-registers the tracked stubs
+ * after a space teardown — which also clears that space's recorded requests +
+ * flow state. Benign because mutations happen at scenario boundaries (overlay
+ * release after `received` is read; `replaceRules` at setup before any
+ * requests).
  */
 private[rift] final case class RiftMockControl(
   endpoint: RiftEndpoint,
   client: Client,
   provisioning: Provisioning,
+  mode: RiftMode,
   spaces: Ref[Map[SpaceId, RiftMockControl.Imposter]],
+  correlated: Ref[Map[SpaceId, RiftMockControl.CorrSpace]],
+  sharedPort: Ref.Synchronized[Option[Int]],
   ids: Ref[Int]
 ) extends MockControl:
 
+  import RiftMockControl.{CorrSpace, Imposter}
+
   def backendName: String           = "rift"
   def capabilities: Set[Capability] = Set.empty
+
+  override def isolation: Isolation = mode match
+    case RiftMode.Correlated(_) => Isolation.Correlated
+    case RiftMode.PerInstance   => Isolation.PerInstance
 
   def provision(source: MockSource): IO[MockError, List[MockSpace]] =
     for
       sources <- provisioning.normalize(source)
       created <- Ref.make(List.empty[MockSpace])
-      // Provision atomically: tear down any spaces already stood up if a later
-      // space in the same source fails, so a partial batch never orphans
-      // imposters/ports the caller can't reach.
+      // Provision atomically: if a later source fails, best-effort tear down the
+      // spaces already stood up. The original failure propagates; a cleanup
+      // failure is logged (not surfaced) rather than masking it.
       spaces <- ZIO
                   .foreach(sources)(src => serveSpace(src).tap(s => created.update(s :: _)))
-                  .onError(_ => created.get.flatMap(ZIO.foreachDiscard(_)(s => destroy(s).ignore)))
+                  .onError(_ =>
+                    created.get.flatMap(
+                      ZIO.foreachDiscard(_)(s =>
+                        destroy(s).catchAllCause(c => ZIO.logWarningCause(s"rollback: destroy ${s.id} failed", c))
+                      )
+                    )
+                  )
     yield spaces
 
   def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
     spec match
-      // A native Rift imposter goes through the same serveSpace machinery as a
-      // portable Raw source (pool port, `_rift`/stub passthrough, tracking), so
-      // the resulting space participates in destroy/received/overlays/isolation
-      // exactly like a portable one.
+      // A native imposter always gets its own port (PerInstance), full-fidelity,
+      // regardless of the active isolation mode.
       case NativeSpec.Rift(imposterJson) =>
-        serveSpace(NormalizedSource("native", SourcePayload.Raw(imposterJson), None)).map(List(_))
+        serveImposter(NormalizedSource("native", SourcePayload.Raw(imposterJson), None)).map(List(_))
       case NativeSpec.WireMock(_) =>
         ZIO.fail(MockError.InvalidDefinition("the Rift adapter cannot provision a WireMock native spec"))
 
   def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
-    withImposter(space) { imp =>
-      for
-        ruleId <- freshId
-        // First match wins in Mountebank, so an overlay rule goes on top
-        // (index 0) and a base rule is appended after the existing stubs.
-        index <- priority match
-                   case Priority.Overlay => ZIO.succeed(0)
-                   case Priority.Base    => imp.stubs.get.map(_.size)
-        u   <- url(s"/imposters/${imp.port}/stubs")
-        res <- send(jsonRequest(HttpMethod.POST, u, RiftProtocol.addStubBody(index, rule)))
-        _   <- expectSuccess(s"add rule to imposter ${imp.port}", res)
-        _   <- imp.stubs.update(v => if priority == Priority.Overlay then ruleId +: v else v :+ ruleId)
-      yield ruleId
-    }
+    dispatch(space)(cs => corrAddRule(cs, rule, priority))(imp => piAddRule(imp, rule, priority))
 
   def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit] =
-    withImposter(space) { imp =>
-      imp.stubs.get.flatMap { ordered =>
-        ordered.indexOf(id) match
-          case -1 => ZIO.fail(MockError.RuleNotFound(space.id, id))
-          case idx =>
-            for
-              u   <- url(s"/imposters/${imp.port}/stubs/$idx")
-              res <- send(Request(method = HttpMethod.DELETE, url = u))
-              _   <- expectSuccess(s"remove rule from imposter ${imp.port}", res)
-              _   <- imp.stubs.update(_.patch(idx, Nil, 1))
-            yield ()
-      }
-    }
+    dispatch(space)(cs => corrRemoveRule(cs, space.id, id))(imp => piRemoveRule(imp, space.id, id))
 
   def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit] =
-    withImposter(space) { imp =>
-      for
-        ruleIds <- freshIds(rules.size)
-        u       <- url(s"/imposters/${imp.port}/stubs")
-        res     <- send(jsonRequest(HttpMethod.PUT, u, RiftProtocol.replaceStubsBody(rules)))
-        _       <- expectSuccess(s"replace rules on imposter ${imp.port}", res)
-        _       <- imp.stubs.set(ruleIds)
-      yield ()
-    }
+    dispatch(space)(cs => corrReplaceRules(cs, rules))(imp => piReplaceRules(imp, rules))
 
   def destroy(space: MockSpace): IO[MockError, Unit] =
-    withImposter(space) { imp =>
-      for
-        u   <- url(s"/imposters/${imp.port}")
-        res <- send(Request(method = HttpMethod.DELETE, url = u))
-        // A 404 means the imposter is already gone — destroy is idempotent.
-        _ <- ZIO.unless(res._1 == 404)(expectSuccess(s"destroy imposter ${imp.port}", res))
-        _ <- endpoint.releasePort(imp.port)
-        _ <- spaces.update(_ - space.id)
-      yield ()
-    }
+    dispatch(space)(cs => corrDestroy(space.id, cs))(imp => piDestroy(space, imp))
 
   def received(space: MockSpace): IO[MockError, List[RecordedRequest]] =
-    withImposter(space) { imp =>
-      for
-        u    <- url(s"/imposters/${imp.port}")
-        res  <- send(Request(method = HttpMethod.GET, url = u))
-        body <- expectSuccess(s"read imposter ${imp.port}", res)
-        // A malformed view is a backend/protocol fault, not a bad user definition.
-        recs <- ZIO.fromEither(RiftProtocol.parseRecorded(body)).mapError(MockError.CommunicationError(_))
-      yield recs
-    }
+    dispatch(space)(corrReceived)(piReceived)
 
   def faults: IO[Unsupported, Faults]                   = unsupported(Capability.Faults)
   def scenarios: IO[Unsupported, StatefulScenarios]     = unsupported(Capability.StatefulScenarios)
@@ -134,6 +112,27 @@ private[rift] final case class RiftMockControl(
   // ---------------------------------------------------------------------------
 
   private def serveSpace(src: NormalizedSource): IO[MockError, MockSpace] =
+    mode match
+      case RiftMode.Correlated(corr) => serveCorrelatedSpace(src, corr)
+      case RiftMode.PerInstance      => serveImposter(src)
+
+  // A space's operations follow the space, not the mode: a Correlated portable
+  // space, or a PerInstance/native imposter space.
+  private def dispatch[A](space: MockSpace)(onCorr: CorrSpace => IO[MockError, A])(
+    onImp: Imposter => IO[MockError, A]
+  ): IO[MockError, A] =
+    correlated.get.flatMap(_.get(space.id) match
+      case Some(cs) => onCorr(cs)
+      case None =>
+        spaces.get.flatMap(_.get(space.id) match
+          case Some(imp) => onImp(imp)
+          case None      => ZIO.fail(MockError.SpaceNotFound(space.id))
+        )
+    )
+
+  // ===== PerInstance — one imposter per space =====================================
+
+  private def serveImposter(src: NormalizedSource): IO[MockError, MockSpace] =
     endpoint.acquirePort.flatMap { port =>
       val stand =
         for
@@ -144,12 +143,62 @@ private[rift] final case class RiftMockControl(
           stubs        <- Ref.make(ruleIds)
           id            = SpaceId(s"${src.name}-$port")
           space         = MockSpace(endpoint.baseUriFor(port), identity, id)
-          _            <- spaces.update(_.updated(id, RiftMockControl.Imposter(port, stubs)))
+          _            <- spaces.update(_.updated(id, Imposter(port, stubs)))
         yield space
-      // Release the port back to the pool on *any* failure after acquiring it
-      // (malformed source, POST rejected, …) so a bad provision can't leak slots.
       stand.onError(_ => endpoint.releasePort(port))
     }
+
+  private def piAddRule(imp: Imposter, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+    for
+      ruleId <- freshId
+      // First match wins in Mountebank: overlay on top (index 0), base appended.
+      index <- priority match
+                 case Priority.Overlay => ZIO.succeed(0)
+                 case Priority.Base    => imp.stubs.get.map(_.size)
+      u   <- url(s"/imposters/${imp.port}/stubs")
+      res <- send(jsonRequest(HttpMethod.POST, u, RiftProtocol.addStubBody(index, rule)))
+      _   <- expectSuccess(s"add rule to imposter ${imp.port}", res)
+      _   <- imp.stubs.update(v => if priority == Priority.Overlay then ruleId +: v else v :+ ruleId)
+    yield ruleId
+
+  private def piRemoveRule(imp: Imposter, spaceId: SpaceId, id: RuleId): IO[MockError, Unit] =
+    imp.stubs.get.flatMap { ordered =>
+      ordered.indexOf(id) match
+        case -1 => ZIO.fail(MockError.RuleNotFound(spaceId, id))
+        case idx =>
+          for
+            u   <- url(s"/imposters/${imp.port}/stubs/$idx")
+            res <- send(Request(method = HttpMethod.DELETE, url = u))
+            _   <- expectSuccess(s"remove rule from imposter ${imp.port}", res)
+            _   <- imp.stubs.update(_.patch(idx, Nil, 1))
+          yield ()
+    }
+
+  private def piReplaceRules(imp: Imposter, rules: List[MockRule]): IO[MockError, Unit] =
+    for
+      ruleIds <- freshIds(rules.size)
+      u       <- url(s"/imposters/${imp.port}/stubs")
+      res     <- send(jsonRequest(HttpMethod.PUT, u, RiftProtocol.replaceStubsBody(rules)))
+      _       <- expectSuccess(s"replace rules on imposter ${imp.port}", res)
+      _       <- imp.stubs.set(ruleIds)
+    yield ()
+
+  private def piDestroy(space: MockSpace, imp: Imposter): IO[MockError, Unit] =
+    for
+      u   <- url(s"/imposters/${imp.port}")
+      res <- send(Request(method = HttpMethod.DELETE, url = u))
+      _   <- ZIO.unless(res._1 == 404)(expectSuccess(s"destroy imposter ${imp.port}", res))
+      _   <- endpoint.releasePort(imp.port)
+      _   <- spaces.update(_ - space.id)
+    yield ()
+
+  private def piReceived(imp: Imposter): IO[MockError, List[RecordedRequest]] =
+    for
+      u    <- url(s"/imposters/${imp.port}")
+      res  <- send(Request(method = HttpMethod.GET, url = u))
+      body <- expectSuccess(s"read imposter ${imp.port}", res)
+      recs <- ZIO.fromEither(RiftProtocol.parseRecorded(body)).mapError(MockError.CommunicationError(_))
+    yield recs
 
   private def imposterBody(port: Int, src: NormalizedSource): IO[MockError, (Json, Int)] =
     src.payload match
@@ -158,6 +207,114 @@ private[rift] final case class RiftMockControl(
       case SourcePayload.Raw(text) =>
         ZIO.fromEither(RiftProtocol.imposterFromRaw(port, src.name, text)).mapError(MockError.InvalidDefinition(_))
 
+  // ===== Correlated — one shared imposter, spaces by flowId =======================
+
+  private def serveCorrelatedSpace(src: NormalizedSource, corr: Correlation): IO[MockError, MockSpace] =
+    for
+      rules  <- rulesOf(src)
+      port   <- ensureSharedImposter(corr)
+      id     <- freshSpaceId(src.name)
+      flowId  = corr.value(id)
+      tagged <- tagRules(rules)
+      // Mirror serveImposter's release-on-error: if a stub POST fails partway, tear
+      // the half-built flow down so it can't orphan stubs on the shared imposter.
+      _        <- registerStubs(port, flowId, tagged).onError(_ => deleteSpace(port, flowId).ignore)
+      rulesRef <- Ref.make(tagged)
+      _        <- correlated.update(_.updated(id, CorrSpace(port, flowId, corr.header, rulesRef)))
+    yield MockSpace(endpoint.baseUriFor(port), req => req.copy(headers = req.headers + (corr.header -> flowId)), id)
+
+  // Create the one shared imposter on first Correlated provision (race-safe).
+  private def ensureSharedImposter(corr: Correlation): IO[MockError, Int] =
+    sharedPort.modifyZIO {
+      case existing @ Some(p) => ZIO.succeed((p, existing))
+      case None =>
+        endpoint.acquirePort.flatMap { p =>
+          postImposter(p, RiftProtocol.correlatedImposter(p, "correlated", corr.header))
+            .as((p, Some(p)))
+            .onError(_ => endpoint.releasePort(p))
+        }
+    }
+
+  private def corrAddRule(cs: CorrSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+    freshId.flatMap { ruleId =>
+      val tagged = (ruleId, rule)
+      // Server-first, then commit tracking — so a failed admin call never leaves
+      // `cs.rules` claiming a stub the server didn't accept (mirrors PerInstance).
+      val act = priority match
+        // Base appends (Rift's space POST appends).
+        case Priority.Base =>
+          postSpaceStub(cs.port, cs.flowId, rule.copy(id = Some(ruleId))) *> cs.rules.update(_ :+ tagged)
+        // Overlay must be first-match — rebuild with the prepended set.
+        case Priority.Overlay =>
+          cs.rules.get.flatMap(cur => rebuildSpaceWith(cs, tagged +: cur) *> cs.rules.set(tagged +: cur))
+      act.as(ruleId)
+    }
+
+  private def corrRemoveRule(cs: CorrSpace, spaceId: SpaceId, id: RuleId): IO[MockError, Unit] =
+    cs.rules.get.flatMap { v =>
+      if !v.exists(_._1 == id) then ZIO.fail(MockError.RuleNotFound(spaceId, id))
+      else
+        val next = v.filterNot(_._1 == id)
+        rebuildSpaceWith(cs, next) *> cs.rules.set(next) // commit tracking only on success
+    }
+
+  private def corrReplaceRules(cs: CorrSpace, rules: List[MockRule]): IO[MockError, Unit] =
+    tagRules(rules).flatMap(next => rebuildSpaceWith(cs, next) *> cs.rules.set(next))
+
+  private def corrDestroy(spaceId: SpaceId, cs: CorrSpace): IO[MockError, Unit] =
+    deleteSpace(cs.port, cs.flowId) *> correlated.update(_ - spaceId)
+
+  private def corrReceived(cs: CorrSpace): IO[MockError, List[RecordedRequest]] =
+    for
+      u    <- url(s"/imposters/${cs.port}/requests?match=${enc(s"header:${cs.header}=${cs.flowId}")}")
+      res  <- send(Request(method = HttpMethod.GET, url = u))
+      body <- expectSuccess(s"read filtered requests for space ${cs.flowId}", res)
+      recs <- ZIO.fromEither(RiftProtocol.parseRequestsArray(body)).mapError(MockError.CommunicationError(_))
+    yield recs
+
+  // rift#223 has no per-stub-in-space delete: re-register `rules` as the space's
+  // stubs after a whole-space teardown. Server-first — the caller commits
+  // tracking only on success. A mid-rebuild failure leaves the space's *server*
+  // stubs partial (surfaced as a CommunicationError); tracking is left unchanged.
+  // (A successful rebuild also clears the space's recorded requests + flow state
+  // — benign at scenario boundaries; see the class doc.)
+  private def rebuildSpaceWith(cs: CorrSpace, rules: Vector[(RuleId, MockRule)]): IO[MockError, Unit] =
+    deleteSpace(cs.port, cs.flowId) *> registerStubs(cs.port, cs.flowId, rules)
+
+  // Assign each rule a fresh id, keyed for tracking + re-registration under a space.
+  private def tagRules(rules: List[MockRule]): UIO[Vector[(RuleId, MockRule)]] =
+    freshIds(rules.size).map(ids => rules.zip(ids).map((r, rid) => (rid, r)).toVector)
+
+  private def registerStubs(port: Int, flowId: String, rules: Vector[(RuleId, MockRule)]): IO[MockError, Unit] =
+    ZIO.foreachDiscard(rules)((rid, rule) => postSpaceStub(port, flowId, rule.copy(id = Some(rid))))
+
+  private def postSpaceStub(port: Int, flowId: String, rule: MockRule): IO[MockError, Unit] =
+    for
+      u   <- url(s"/imposters/$port/spaces/${enc(flowId)}/stubs")
+      res <- send(jsonRequest(HttpMethod.POST, u, RiftProtocol.stub(rule)))
+      _   <- expectSuccess(s"add space stub to $flowId", res)
+    yield ()
+
+  private def deleteSpace(port: Int, flowId: String): IO[MockError, Unit] =
+    for
+      u   <- url(s"/imposters/$port/spaces/${enc(flowId)}")
+      res <- send(Request(method = HttpMethod.DELETE, url = u))
+      // A 404 means the space is already gone — teardown is idempotent.
+      _ <- ZIO.unless(res._1 == 404)(expectSuccess(s"teardown space $flowId", res))
+    yield ()
+
+  private def rulesOf(src: NormalizedSource): IO[MockError, List[MockRule]] =
+    src.payload match
+      case SourcePayload.Rules(rules) => ZIO.succeed(rules)
+      case SourcePayload.Raw(_) =>
+        ZIO.fail(
+          MockError.InvalidDefinition(
+            "Correlated mode needs portable rule sources; provision a raw Rift imposter via provisionNative"
+          )
+        )
+
+  // ===== shared admin plumbing =====================================================
+
   private def postImposter(port: Int, body: Json): IO[MockError, Unit] =
     for
       u   <- url("/imposters")
@@ -165,17 +322,34 @@ private[rift] final case class RiftMockControl(
       _   <- expectSuccess(s"create imposter on port $port", res)
     yield ()
 
+  // Best-effort teardown of the shared Correlated imposter — the one imposter no
+  // single space owns (PerInstance leaves `sharedPort` empty, so this is a no-op).
+  // Registered as a scope finalizer in `make` so it is reclaimed in `connect`
+  // mode too, not only when `managed` stops the container.
+  private[rift] def teardownShared: UIO[Unit] =
+    sharedPort.get.flatMap {
+      case Some(p) =>
+        (deleteImposter(p) *> endpoint.releasePort(p))
+          .catchAllCause(c => ZIO.logWarningCause("shared Correlated imposter teardown failed", c))
+      case None => ZIO.unit
+    }
+
+  private def deleteImposter(port: Int): IO[MockError, Unit] =
+    for
+      u   <- url(s"/imposters/$port")
+      res <- send(Request(method = HttpMethod.DELETE, url = u))
+      _   <- ZIO.unless(res._1 == 404)(expectSuccess(s"delete shared imposter $port", res))
+    yield ()
+
   private def freshId: UIO[RuleId] = ids.updateAndGet(_ + 1).map(n => RuleId(s"r$n"))
 
   private def freshIds(n: Int): UIO[Vector[RuleId]] = ZIO.foreach(0 until n)(_ => freshId).map(_.toVector)
 
-  private def withImposter[A](space: MockSpace)(f: RiftMockControl.Imposter => IO[MockError, A]): IO[MockError, A] =
-    spaces.get.flatMap(_.get(space.id) match
-      case Some(imp) => f(imp)
-      case None      => ZIO.fail(MockError.SpaceNotFound(space.id))
-    )
+  private def freshSpaceId(name: String): UIO[SpaceId] = ids.updateAndGet(_ + 1).map(n => SpaceId(s"$name-s$n"))
 
   private def unsupported[A](c: Capability): IO[Unsupported, A] = ZIO.fail(Unsupported(c, backendName))
+
+  private def enc(s: String): String = URLEncoder.encode(s, UTF_8)
 
   private def url(path: String): IO[MockError, URL] =
     ZIO
@@ -203,15 +377,21 @@ private[rift] final case class RiftMockControl(
 
 private[rift] object RiftMockControl:
   final case class Imposter(port: Int, stubs: Ref[Vector[RuleId]])
+  final case class CorrSpace(port: Int, flowId: String, header: String, rules: Ref[Vector[(RuleId, MockRule)]])
 
   /**
-   * Build an adapter against an endpoint, taking the zio-http [[Client]] and
-   * [[Provisioning]] from the environment.
+   * Build an adapter against an endpoint in the given isolation `mode`, taking
+   * the zio-http [[Client]] and [[Provisioning]] from the environment. Scoped:
+   * the shared Correlated imposter is torn down when the scope closes.
    */
-  def make(endpoint: RiftEndpoint): URIO[Client & Provisioning, MockControl] =
+  def make(endpoint: RiftEndpoint, mode: RiftMode): URIO[Client & Provisioning & Scope, MockControl] =
     for
-      client <- ZIO.service[Client]
-      prov   <- ZIO.service[Provisioning]
-      spaces <- Ref.make(Map.empty[SpaceId, Imposter])
-      ids    <- Ref.make(0)
-    yield RiftMockControl(endpoint, client, prov, spaces, ids)
+      client     <- ZIO.service[Client]
+      prov       <- ZIO.service[Provisioning]
+      spaces     <- Ref.make(Map.empty[SpaceId, Imposter])
+      correlated <- Ref.make(Map.empty[SpaceId, CorrSpace])
+      sharedPort <- Ref.Synchronized.make(Option.empty[Int])
+      ids        <- Ref.make(0)
+      control     = RiftMockControl(endpoint, client, prov, mode, spaces, correlated, sharedPort, ids)
+      _          <- ZIO.addFinalizer(control.teardownShared)
+    yield control

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -16,16 +16,22 @@ private[rift] object RiftProtocol:
   // Canonical model -> Mountebank wire JSON
   // ---------------------------------------------------------------------------
 
+  // Rift/Mountebank serve 200-empty for an unmatched request unless an imposter
+  // `defaultResponse` is set; pin it to 404 so the portable adapter matches the
+  // cross-adapter contract (WireMock's unmatched default) — #165.
+  private val unmatched404: Json = Json.Obj("statusCode" -> Json.Num(404))
+
   /**
    * A full `POST /imposters` body for one space: one imposter, recording on.
    */
   def imposter(port: Int, name: String, rules: List[MockRule]): Json =
     Json.Obj(
-      "port"           -> Json.Num(port),
-      "protocol"       -> Json.Str("http"),
-      "name"           -> Json.Str(name),
-      "recordRequests" -> Json.Bool(true),
-      "stubs"          -> Json.Arr(rules.map(stub)*)
+      "port"            -> Json.Num(port),
+      "protocol"        -> Json.Str("http"),
+      "name"            -> Json.Str(name),
+      "recordRequests"  -> Json.Bool(true),
+      "defaultResponse" -> unmatched404,
+      "stubs"           -> Json.Arr(rules.map(stub)*)
     )
 
   /**
@@ -39,11 +45,12 @@ private[rift] object RiftProtocol:
    */
   def correlatedImposter(port: Int, name: String, correlationHeader: String): Json =
     Json.Obj(
-      "port"           -> Json.Num(port),
-      "protocol"       -> Json.Str("http"),
-      "name"           -> Json.Str(name),
-      "recordRequests" -> Json.Bool(true),
-      "stubs"          -> Json.Arr(),
+      "port"            -> Json.Num(port),
+      "protocol"        -> Json.Str("http"),
+      "name"            -> Json.Str(name),
+      "recordRequests"  -> Json.Bool(true),
+      "defaultResponse" -> unmatched404,
+      "stubs"           -> Json.Arr(),
       "_rift" -> Json.Obj(
         "flowState" -> Json.Obj(
           "backend"                -> Json.Str("inmemory"),

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -28,6 +28,31 @@ private[rift] object RiftProtocol:
       "stubs"          -> Json.Arr(rules.map(stub)*)
     )
 
+  /**
+   * The shared imposter for Correlated isolation (#156): empty stubs (added per
+   * space via `POST /imposters/:port/spaces/:flowId/stubs`) and a flow-id
+   * source of `header:<correlationHeader>`, so Rift resolves each request's
+   * flow + gates stubs/recorded requests by that header natively (rift#223).
+   * The flow-state config is a backend-native extension, so it lives under
+   * `_rift.flowState`
+   * (`imposter.config.rift.flowState.mountebankStateMapping.flowIdSource`).
+   */
+  def correlatedImposter(port: Int, name: String, correlationHeader: String): Json =
+    Json.Obj(
+      "port"           -> Json.Num(port),
+      "protocol"       -> Json.Str("http"),
+      "name"           -> Json.Str(name),
+      "recordRequests" -> Json.Bool(true),
+      "stubs"          -> Json.Arr(),
+      "_rift" -> Json.Obj(
+        "flowState" -> Json.Obj(
+          "backend"                -> Json.Str("inmemory"),
+          "ttlSeconds"             -> Json.Num(300),
+          "mountebankStateMapping" -> Json.Obj("flowIdSource" -> Json.Str(s"header:$correlationHeader"))
+        )
+      )
+    )
+
   /** A single Mountebank stub: predicates (ANDed) + one response. */
   def stub(rule: MockRule): Json =
     val idField = rule.id.map(id => "id" -> Json.Str(id.value)).toList
@@ -103,16 +128,18 @@ private[rift] object RiftProtocol:
 
   /** Parse the `requests[]` of a `GET /imposters/:port` view. */
   def parseRecorded(viewJson: String): Either[String, List[RecordedRequest]] =
-    viewJson.fromJson[WireView].map { v =>
-      v.requests.getOrElse(Nil).map { r =>
-        RecordedRequest(
-          method = methodFromWire(r.method),
-          uri = r.path,
-          headers = r.headers.getOrElse(Map.empty),
-          body = r.body
-        )
-      }
-    }
+    viewJson.fromJson[WireView].map(_.requests.getOrElse(Nil).map(toRecorded))
+
+  /**
+   * Parse the bare JSON array returned by `GET
+   * /imposters/:port/requests?match=…` — the header/flow-id-filtered recorded
+   * requests (rift#201), used by Correlated `received`.
+   */
+  def parseRequestsArray(arrayJson: String): Either[String, List[RecordedRequest]] =
+    arrayJson.fromJson[List[WireReq]].map(_.map(toRecorded))
+
+  private def toRecorded(r: WireReq): RecordedRequest =
+    RecordedRequest(methodFromWire(r.method), r.path, r.headers.getOrElse(Map.empty), r.body)
 
   // ---------------------------------------------------------------------------
   // helpers

--- a/rift/src/test/scala/zio/bdd/mock/rift/FakeRift.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/FakeRift.scala
@@ -9,14 +9,20 @@ import zio.json.ast.Json
  * adapter makes and serves canned imposter views, so the adapter's protocol and
  * isolation behaviour can be unit-tested with no Docker and no real backend.
  *
- * It deliberately does NOT serve imposter traffic — "serving" is the real
- * container's job, proven by the tagged [[RiftContainerSpec]].
+ * It deliberately does NOT serve imposter traffic, nor does it actually filter
+ * recorded requests — "serving" and the real header/flow-id filter are the real
+ * container's job, proven by the tagged [[RiftContainerSpec]]. Here we assert
+ * the adapter *issues* the right space-scoped calls.
  */
 final case class FakeRift(
   posted: Ref[Chunk[String]],
   deletedPorts: Ref[Chunk[Int]],
   globalDeletes: Ref[Int],
   stubCalls: Ref[Chunk[String]],
+  spaceStubs: Ref[Chunk[String]],
+  spaceDeletes: Ref[Chunk[String]],
+  requestMatches: Ref[Chunk[String]],
+  filtered: Ref[String],
   views: Ref[Map[Int, String]],
   failProvision: Ref[Boolean]
 ):
@@ -24,6 +30,11 @@ final case class FakeRift(
    * Preset the `GET /imposters/:port` view (e.g. to inject recorded requests).
    */
   def setView(port: Int, json: String): UIO[Unit] = views.update(_.updated(port, json))
+
+  /**
+   * Preset the body returned by `GET /imposters/:port/requests?match=…` (#201).
+   */
+  def setFiltered(json: String): UIO[Unit] = filtered.set(json)
 
   val routes: Routes[Any, Response] =
     Routes(
@@ -41,6 +52,23 @@ final case class FakeRift(
                 ZIO.succeed(Response(status = Status.Created, body = Body.fromString(s"""{"port":$port}""")))
           }
         }
+      },
+      // Space-scoped stubs (rift#223): POST /imposters/:port/spaces/:flowId/stubs
+      Method.POST / "imposters" / int("port") / "spaces" / string("flowId") / "stubs" -> handler {
+        (port: Int, flowId: String, req: Request) =>
+          req.body.asString.orDie
+            .flatMap(b => spaceStubs.update(_ :+ s"$port/$flowId $b"))
+            .as(Response(status = Status.Created, body = Body.fromString(s"""{"space":"$flowId","stubs":[]}""")))
+      },
+      // Per-space teardown (rift#223): DELETE /imposters/:port/spaces/:flowId
+      Method.DELETE / "imposters" / int("port") / "spaces" / string("flowId") -> handler {
+        (port: Int, flowId: String, _: Request) =>
+          spaceDeletes.update(_ :+ s"$port/$flowId").as(Response.ok)
+      },
+      // Header/flow-id-filtered recorded requests (rift#201): GET /imposters/:port/requests?match=…
+      Method.GET / "imposters" / int("port") / "requests" -> handler { (_: Int, req: Request) =>
+        val m = req.url.queryParams.queryParam("match").getOrElse("")
+        (requestMatches.update(_ :+ m) *> filtered.get).map(f => Response(body = Body.fromString(f)))
       },
       Method.GET / "imposters" / int("port") -> handler { (port: Int, _: Request) =>
         views.get.map(m => Response(body = Body.fromString(m.getOrElse(port, FakeRift.emptyView(port)))))
@@ -68,13 +96,17 @@ object FakeRift:
 
   def make: UIO[FakeRift] =
     for
-      a <- Ref.make(Chunk.empty[String])
-      b <- Ref.make(Chunk.empty[Int])
-      c <- Ref.make(0)
-      d <- Ref.make(Chunk.empty[String])
-      e <- Ref.make(Map.empty[Int, String])
-      f <- Ref.make(false)
-    yield FakeRift(a, b, c, d, e, f)
+      a  <- Ref.make(Chunk.empty[String])
+      b  <- Ref.make(Chunk.empty[Int])
+      c  <- Ref.make(0)
+      d  <- Ref.make(Chunk.empty[String])
+      ss <- Ref.make(Chunk.empty[String])
+      sd <- Ref.make(Chunk.empty[String])
+      rm <- Ref.make(Chunk.empty[String])
+      fl <- Ref.make("[]")
+      e  <- Ref.make(Map.empty[Int, String])
+      f  <- Ref.make(false)
+    yield FakeRift(a, b, c, d, ss, sd, rm, fl, e, f)
 
   def portOf(body: String): Option[Int] =
     import zio.json.*

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
@@ -88,6 +88,41 @@ object RiftContainerSpec extends ZIOSpecDefault:
     }
   ).provideSome[Client](Provisioning.live, riftBackend) @@ TestAspect.sequential @@ TestAspect.withLiveClock
 
+  // Correlated isolation (#156): one shared imposter, spaces told apart by the
+  // X-Mock-Space header. The SAME checks pass with a one-line layer swap (AC1),
+  // and received(A) returns only A's traffic on the shared imposter (AC2).
+  private val correlatedSuite = suite("RiftContainerSpec — Correlated (shared imposter)")(
+    test("provision/serve/record/destroy pass on correlated() too (the one-line swap)") {
+      for
+        control <- ZIO.service[MockControl]
+        space   <- control.provision(pingSource).map(_.head)
+        resp    <- SutClient.make(space).send(Method.Get, "/ping").retry(upWithin) // inject stamps X-Mock-Space
+        recv    <- control.received(space)
+        _       <- control.destroy(space)
+      yield assertTrue(
+        control.isolation == Isolation.Correlated,
+        resp.status == 200 && resp.body == "pong",                   // serves via inject
+        recv.exists(r => r.method == Method.Get && r.uri == "/ping") // records (header-filtered)
+      )
+    },
+    test("received(A) returns only A's traffic on the shared imposter (rift#201 filter)") {
+      for
+        control <- ZIO.service[MockControl]
+        a       <- control.provision(pingSource).map(_.head)
+        b       <- control.provision(pingSource).map(_.head)
+        _       <- SutClient.make(a).send(Method.Get, "/ping").retry(upWithin)
+        _       <- SutClient.make(b).send(Method.Get, "/ping").retry(upWithin)
+        _       <- SutClient.make(b).send(Method.Get, "/ping")
+        ra      <- control.received(a)
+        rb      <- control.received(b)
+      yield assertTrue(
+        a.baseUri == b.baseUri, // one shared imposter
+        ra.size == 1,           // only A's request
+        rb.size == 2            // only B's
+      )
+    }
+  ).provideSome[Client](Provisioning.live, correlatedBackend) @@ TestAspect.sequential @@ TestAspect.withLiveClock
+
   // Two ways to reach a real Rift: testcontainers spins one up (default), or —
   // when RIFT_ADMIN points at an already-running Rift admin URL whose imposter
   // ports are mapped 1:1 to localhost — connect to it directly. The latter
@@ -98,6 +133,13 @@ object RiftContainerSpec extends ZIOSpecDefault:
       case Some(admin) => Rift.connect(admin, (4545 until 4561).toList)(p => s"http://localhost:$p")
       case None        => Rift.managed()
 
+  private def correlatedBackend: ZLayer[Client & Provisioning, MockError, MockControl] =
+    sys.env.get("RIFT_ADMIN") match
+      case Some(admin) =>
+        Rift.connect(admin, (4545 until 4561).toList, RiftMode.correlated)(p => s"http://localhost:$p")
+      case None => Rift.managed(mode = RiftMode.correlated)
+
   def spec =
-    if sys.env.contains("RIFT_IT") then realSuite.provideShared(Client.default)
+    if sys.env.contains("RIFT_IT") then
+      suite("Rift container ITs")(realSuite, correlatedSuite).provideShared(Client.default)
     else suite("RiftContainerSpec (skipped — set RIFT_IT=1 to run against a real Rift container)")()

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
@@ -85,6 +85,15 @@ object RiftContainerSpec extends ZIOSpecDefault:
         recorded.exists(r => r.method == Method.Get && r.uri == "/native"), // records
         gone                                                                // space-local destroy
       )
+    },
+    test("an unmatched request returns 404, not Mountebank's 200-empty default (#165)") {
+      for
+        control <- ZIO.service[MockControl]
+        space   <- control.provision(pingSource).map(_.head)
+        _       <- httpGet(space.baseUri, "/ping").retry(upWithin) // ensure the imposter is up
+        miss    <- httpGet(space.baseUri, "/no-such-path")
+        _       <- control.destroy(space)
+      yield assertTrue(miss._1 == 404)
     }
   ).provideSome[Client](Provisioning.live, riftBackend) @@ TestAspect.sequential @@ TestAspect.withLiveClock
 
@@ -120,6 +129,15 @@ object RiftContainerSpec extends ZIOSpecDefault:
         ra.size == 1,           // only A's request
         rb.size == 2            // only B's
       )
+    },
+    test("an unmatched request returns 404 on the shared imposter (#165)") {
+      for
+        control <- ZIO.service[MockControl]
+        space   <- control.provision(pingSource).map(_.head)
+        _       <- SutClient.make(space).send(Method.Get, "/ping").retry(upWithin)
+        miss    <- SutClient.make(space).send(Method.Get, "/no-such-path") // injected, but no stub matches
+        _       <- control.destroy(space)
+      yield assertTrue(miss.status == 404)
     }
   ).provideSome[Client](Provisioning.live, correlatedBackend) @@ TestAspect.sequential @@ TestAspect.withLiveClock
 

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -75,6 +75,7 @@ object RiftMockControlSpec extends ZIOSpecDefault:
             spaces.size == 1,
             posted.size == 1,
             posted.head.contains("\"recordRequests\":true"),
+            posted.head.contains("\"defaultResponse\":{\"statusCode\":404}"), // unmatched -> 404 (#165)
             FakeRift.portOf(posted.head).contains(portOf(space.baseUri)),
             space.baseUri == s"http://localhost:${portOf(space.baseUri)}",
             space.inject(req) == req
@@ -364,6 +365,7 @@ object RiftMockControlSpec extends ZIOSpecDefault:
             posted.size == 1,                                                 // ONE shared imposter for both spaces
             posted.head.contains("\"flowIdSource\":\"header:X-Mock-Space\""), // Rift gates by the header natively
             posted.head.contains("\"_rift\""),                                // flow-state lives under _rift (native ext), not top-level
+            posted.head.contains("\"defaultResponse\":{\"statusCode\":404}"), // unmatched -> 404 (#165)
             a.baseUri == b.baseUri,                                           // shared imposter -> shared baseUri
             stubs.exists(_.contains(s"/${a.id.value} ")),                     // A's stub scoped under A's flowId
             stubs.exists(_.contains(s"/${b.id.value} ")),

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -27,7 +27,7 @@ object RiftMockControlSpec extends ZIOSpecDefault:
    * Set up a fresh fake admin server + a Rift adapter (with the given imposter
    * port pool) bound to it, in a scope.
    */
-  private def withAdapterPool(ports: List[Int])(
+  private def withAdapterPool(ports: List[Int], mode: RiftMode = RiftMode.PerInstance)(
     use: (MockControl, FakeRift) => UIO[TestResult]
   ): ZIO[Client & Provisioning, Throwable, TestResult] =
     ZIO.scoped {
@@ -35,7 +35,7 @@ object RiftMockControlSpec extends ZIOSpecDefault:
         adminAndFake <- FakeRift.started
         (admin, fake) = adminAndFake
         endpoint     <- RiftEndpoint.pooled(admin, ports)(p => s"http://localhost:$p")
-        control      <- RiftMockControl.make(endpoint)
+        control      <- RiftMockControl.make(endpoint, mode)
         result       <- use(control, fake)
       yield result
     }
@@ -44,6 +44,16 @@ object RiftMockControlSpec extends ZIOSpecDefault:
     use: (MockControl, FakeRift) => UIO[TestResult]
   ): ZIO[Client & Provisioning, Throwable, TestResult] =
     withAdapterPool((4545 until 4600).toList)(use)
+
+  private def withCorrelated(
+    use: (MockControl, FakeRift) => UIO[TestResult]
+  ): ZIO[Client & Provisioning, Throwable, TestResult] =
+    withAdapterPool((4545 until 4600).toList, RiftMode.correlated)(use)
+
+  private def withCorrelatedTraceparent(
+    use: (MockControl, FakeRift) => UIO[TestResult]
+  ): ZIO[Client & Provisioning, Throwable, TestResult] =
+    withAdapterPool((4545 until 4600).toList, RiftMode.Correlated(Correlation.traceparent))(use)
 
   def spec = suite("RiftMockControl (adapter vs fake admin API)")(
     test("the Rift adapter's isolation model is PerInstance (own port, identity inject)") {
@@ -333,6 +343,165 @@ object RiftMockControlSpec extends ZIOSpecDefault:
             case _                                 => false
           }
         )
+      }
+    },
+    test(
+      "Correlated: provision uses ONE shared imposter (flowIdSource header) with space-scoped stubs; inject stamps the header"
+    ) {
+      withCorrelated { (control, fake) =>
+        for
+          aE     <- control.provision(pingSource).either
+          bE     <- control.provision(pingSource).either
+          posted <- fake.posted.get
+          stubs  <- fake.spaceStubs.get
+        yield
+          val a   = aE.toOption.get.head
+          val b   = bE.toOption.get.head
+          val req = HttpRequest(Method.Get, "http://sut/x")
+          assertTrue(
+            aE.isRight && bE.isRight,
+            control.isolation == Isolation.Correlated,
+            posted.size == 1,                                                 // ONE shared imposter for both spaces
+            posted.head.contains("\"flowIdSource\":\"header:X-Mock-Space\""), // Rift gates by the header natively
+            posted.head.contains("\"_rift\""),                                // flow-state lives under _rift (native ext), not top-level
+            a.baseUri == b.baseUri,                                           // shared imposter -> shared baseUri
+            stubs.exists(_.contains(s"/${a.id.value} ")),                     // A's stub scoped under A's flowId
+            stubs.exists(_.contains(s"/${b.id.value} ")),
+            a.inject(req).headers.get("X-Mock-Space").contains(a.id.value), // inject routes the request to A
+            a.inject(req).headers.get("X-Mock-Space") != b.inject(req).headers.get("X-Mock-Space")
+          )
+      }
+    },
+    test(
+      "Correlated: destroy(A) tears down only A's space (DELETE /spaces/:flowId) — never the imposter or a global reset"
+    ) {
+      withCorrelated { (control, fake) =>
+        for
+          aE       <- control.provision(pingSource).either
+          bE       <- control.provision(pingSource).either
+          a         = aE.toOption.get.head
+          b         = bE.toOption.get.head
+          destroyE <- control.destroy(a).either
+          spaceDel <- fake.spaceDeletes.get
+          ports    <- fake.deletedPorts.get
+          globals  <- fake.globalDeletes.get
+          recvB    <- control.received(b).either
+          recvA    <- control.received(a).either
+        yield assertTrue(
+          destroyE.isRight,
+          spaceDel.exists(_.endsWith(s"/${a.id.value}")),  // A's space torn down
+          !spaceDel.exists(_.endsWith(s"/${b.id.value}")), // B's untouched
+          ports.isEmpty,                                   // the shared imposter is NOT deleted
+          globals == 0,                                    // never DELETE /imposters
+          recvB.isRight,
+          recvA == Left(MockError.SpaceNotFound(a.id)) // A is gone from the adapter
+        )
+      }
+    },
+    test("Correlated: received(A) reads the header-filtered requests endpoint (rift#201) and parses the array") {
+      withCorrelated { (control, fake) =>
+        for
+          sE      <- control.provision(pingSource).either
+          s        = sE.toOption.get.head
+          _       <- fake.setFiltered("""[{"method":"GET","path":"/ping","headers":{},"body":null}]""")
+          recvE   <- control.received(s).either
+          matches <- fake.requestMatches.get
+        yield assertTrue(
+          recvE == Right(List(RecordedRequest(Method.Get, "/ping", Map.empty, None))),
+          matches.exists(_.contains(s"header:X-Mock-Space=${s.id.value}")) // filtered by THIS space's flowId
+        )
+      }
+    },
+    test("Correlated: addRule(Base) appends a space-scoped stub") {
+      withCorrelated { (control, fake) =>
+        for
+          sE     <- control.provision(pingSource).either
+          s       = sE.toOption.get.head
+          before <- fake.spaceStubs.get
+          addE   <- control.addRule(s, pingRule, Priority.Base).either
+          after  <- fake.spaceStubs.get
+        yield assertTrue(addE.isRight, after.size == before.size + 1, after.exists(_.contains(s"/${s.id.value} ")))
+      }
+    },
+    test("Correlated: replaceRules rebuilds the space (DELETE /spaces/:flowId then re-POSTs the new set)") {
+      withCorrelated { (control, fake) =>
+        for
+          sE         <- control.provision(pingSource).either // posts 1 stub under the flowId
+          s           = sE.toOption.get.head
+          delsBefore <- fake.spaceDeletes.get
+          replE      <- control.replaceRules(s, List(pingRule, pingRule)).either
+          dels       <- fake.spaceDeletes.get
+          stubs      <- fake.spaceStubs.get
+        yield assertTrue(
+          replE.isRight,
+          delsBefore.isEmpty,
+          dels.exists(_.endsWith(s"/${s.id.value}")),      // rebuilt via space teardown
+          stubs.count(_.contains(s"/${s.id.value} ")) == 3 // 1 (provision) + 2 (re-POST after delete)
+        )
+      }
+    },
+    test("Correlated: addRule(Overlay) rebuilds the space so the overlay is first-match") {
+      withCorrelated { (control, fake) =>
+        for
+          sE    <- control.provision(pingSource).either // 1 base stub
+          s      = sE.toOption.get.head
+          ovE   <- control.addRule(s, pingRule, Priority.Overlay).either
+          dels  <- fake.spaceDeletes.get
+          stubs <- fake.spaceStubs.get
+        yield assertTrue(
+          ovE.isRight,
+          dels.exists(_.endsWith(s"/${s.id.value}")),      // overlay triggers a rebuild
+          stubs.count(_.contains(s"/${s.id.value} ")) == 3 // 1 (provision) + 2 (rebuild: overlay + base)
+        )
+      }
+    },
+    test("Correlated: removeRule rebuilds; an unknown id fails RuleNotFound without touching the server") {
+      withCorrelated { (control, fake) =>
+        for
+          sE      <- control.provision(pingSource).either
+          s        = sE.toOption.get.head
+          addE    <- control.addRule(s, pingRule, Priority.Base).either
+          rmE     <- ZIO.fromEither(addE).flatMap(id => control.removeRule(s, id)).either // rebuild
+          dels    <- fake.spaceDeletes.get
+          ghostE  <- control.removeRule(s, RuleId("ghost")).either
+          delsEnd <- fake.spaceDeletes.get
+        yield assertTrue(
+          addE.isRight,
+          rmE.isRight,
+          dels.exists(_.endsWith(s"/${s.id.value}")), // removeRule rebuilt the space
+          ghostE == Left(MockError.RuleNotFound(s.id, RuleId("ghost"))),
+          delsEnd.size == dels.size // a failed removeRule never hit the server
+        )
+      }
+    },
+    test(
+      "Correlated(traceparent): shared imposter uses flowIdSource header:traceparent; inject stamps a distinct traceparent per space"
+    ) {
+      withCorrelatedTraceparent { (control, fake) =>
+        for
+          aE     <- control.provision(pingSource).either
+          bE     <- control.provision(pingSource).either
+          posted <- fake.posted.get
+        yield
+          val a   = aE.toOption.get.head
+          val b   = bE.toOption.get.head
+          val req = HttpRequest(Method.Get, "http://sut/")
+          val ta  = a.inject(req).headers.get("traceparent")
+          assertTrue(
+            aE.isRight && bE.isRight,
+            posted.head.contains("\"flowIdSource\":\"header:traceparent\""),
+            ta.exists(_.matches("00-[0-9a-f]{32}-[0-9a-f]{16}-01")), // W3C traceparent shape
+            ta != b.inject(req).headers.get("traceparent")           // distinct per space
+          )
+      }
+    },
+    test("Correlated: a raw (non-portable) source is rejected with InvalidDefinition (use provisionNative)") {
+      withCorrelated { (control, _) =>
+        for e <- control.provision(MockSource.Json("""{"port":1,"protocol":"http","stubs":[]}""")).either
+        yield assertTrue(e.swap.toOption.exists {
+          case MockError.InvalidDefinition(_) => true
+          case _                              => false
+        })
       }
     }
   ).provide(Client.default, Provisioning.live) @@ TestAspect.withLiveClock

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -46,6 +46,11 @@ object RiftMockControlSpec extends ZIOSpecDefault:
     withAdapterPool((4545 until 4600).toList)(use)
 
   def spec = suite("RiftMockControl (adapter vs fake admin API)")(
+    test("the Rift adapter's isolation model is PerInstance (own port, identity inject)") {
+      withAdapter { (control, _) =>
+        ZIO.succeed(assertTrue(control.isolation == Isolation.PerInstance))
+      }
+    },
     test("provision creates one recording imposter per space; baseUri reflects its port; inject is identity") {
       withAdapter { (control, fake) =>
         for

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMock.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMock.scala
@@ -1,0 +1,70 @@
+package zio.bdd.mock.wiremock
+
+import zio.*
+import zio.bdd.mock.*
+
+import com.github.tomakehurst.wiremock.client.WireMock as WM
+import com.github.tomakehurst.wiremock.matching.StringValuePattern
+
+/**
+ * How a Correlated space tags its requests and matches them on the shared
+ * server. [[value]] is what [[MockSpace.inject]] stamps; [[matcher]] is what
+ * the space's stubs require, so only requests carrying this space's tag can
+ * match.
+ */
+final case class Correlation(
+  header: String,
+  value: SpaceId => String,
+  matcher: SpaceId => StringValuePattern
+)
+
+object Correlation:
+  /** Default: a dedicated `X-Mock-Space: <spaceId>` header, exact-matched. */
+  val spaceHeader: Correlation =
+    Correlation("X-Mock-Space", id => id.value, id => WM.equalTo(id.value))
+
+  /**
+   * Correlate by the W3C trace context the SUT already propagates: `inject`
+   * stamps a `traceparent` carrying the space's trace-id, and stubs match that
+   * trace-id (the span-id may vary request to request).
+   */
+  val traceparent: Correlation =
+    Correlation(
+      "traceparent",
+      id => s"00-${traceId(id)}-0000000000000001-01",
+      id => WM.matching(s"00-${traceId(id)}-[0-9a-f]{16}-[0-9a-f]{2}")
+    )
+
+  // A stable, W3C-shaped 32-hex trace-id derived from the space id. Four
+  // salted hashes fill the 32 hex so distinct ids don't collapse to the same
+  // repeated chunk (sequential space ids stay distinct).
+  private def traceId(id: SpaceId): String =
+    (0 until 4).map(i => f"${(id.value + ":" + i).hashCode & 0xffffffffL}%08x").mkString
+
+/**
+ * The in-process WireMock provider (#122). Pick an isolation mode and provide a
+ * [[Provisioning]]:
+ * {{{PortAllocator.layer >>> Provisioning.layer >>> WireMock.correlated()}}}
+ * Swapping `WireMock.correlated()` for a Rift layer is the "one-line provider
+ * swap" the portable suite relies on.
+ */
+object WireMock:
+  enum Mode:
+    case Correlated(correlation: Correlation)
+    case PerInstance
+
+  /**
+   * Correlated isolation (default): one shared server, header-tagged spaces.
+   */
+  def correlated(correlation: Correlation = Correlation.spaceHeader): ZLayer[Provisioning, Throwable, MockControl] =
+    layer(Mode.Correlated(correlation))
+
+  /**
+   * PerInstance isolation: a fresh server per space (use when the cost is
+   * acceptable).
+   */
+  val perInstance: ZLayer[Provisioning, Throwable, MockControl] =
+    layer(Mode.PerInstance)
+
+  def layer(mode: Mode): ZLayer[Provisioning, Throwable, MockControl] =
+    ZLayer.scoped(WireMockControl.make(mode))

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
@@ -1,0 +1,272 @@
+package zio.bdd.mock.wiremock
+
+import zio.*
+import zio.bdd.mock.*
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+
+import scala.jdk.CollectionConverters.*
+
+/**
+ * The WireMock adapter: implements the portable [[MockControl]] core port over
+ * an embedded WireMockServer — pure-JVM, zero-Docker.
+ *
+ * Correlated isolation (the default): every space shares one server; each of a
+ * space's stubs carries an `X-Mock-Space: <spaceId>` header matcher and
+ * `inject` stamps that header on the SUT's requests, so a request can only
+ * match (and be `received` by) its own space. `destroy` removes exactly that
+ * space's stubs — never `server.resetAll`. A request without the header matches
+ * nothing and is recorded by no space.
+ *
+ * PerInstance isolation (option): each space owns a fresh server on its own
+ * port, `inject == identity`, and `destroy` stops that server.
+ */
+private[wiremock] final case class WireMockControl(
+  mode: WireMock.Mode,
+  shared: Option[WireMockServer],
+  provisioning: Provisioning,
+  spaces: Ref[Map[SpaceId, WireMockControl.SpaceState]],
+  ids: Ref[Int]
+) extends MockControl:
+
+  import WireMockControl.SpaceState
+
+  def backendName: String           = "wiremock"
+  def capabilities: Set[Capability] = Set.empty
+
+  def provision(source: MockSource): IO[MockError, List[MockSpace]] =
+    for
+      sources <- provisioning.normalize(source)
+      created <- Ref.make(List.empty[MockSpace])
+      // Tear down any spaces already stood up if a later one fails, so a partial
+      // batch never orphans a started server or leaves half a source registered.
+      spaces <-
+        ZIO
+          .foreach(sources)(src => serveSpace(src).tap(s => created.update(s :: _)))
+          .onError(_ =>
+            created.get.flatMap(
+              ZIO.foreachDiscard(_)(s =>
+                destroy(s).catchAllCause(c => ZIO.logWarningCause("WireMock provision rollback: destroy failed", c))
+              )
+            )
+          )
+    yield spaces
+
+  def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+    spec match
+      // A native WireMock stub defines its own matching, so it always gets its
+      // own server (PerInstance) — correlation can't be grafted onto it.
+      case NativeSpec.WireMock(stubMappingJson) =>
+        for
+          id       <- freshSpaceId("native")
+          stub     <- ZIO.attempt(StubMapping.buildFrom(stubMappingJson)).mapError(e => MockError.InvalidDefinition(msg(e)))
+          server   <- WireMockControl.startServer.mapError(e => MockError.ProvisionFailed(msg(e)))
+          rulesRef <- Ref.make(Vector.empty[(RuleId, StubMapping)])
+          ruleId   <- freshRuleId
+          // Stop the server we just started if registration/tracking fails or is
+          // interrupted before it lands in `spaces` — otherwise it leaks.
+          space <- (ZIO
+                     .attempt(server.addStubMapping(stub))
+                     .zipRight(rulesRef.set(Vector(ruleId -> stub)))
+                     .mapError(e => MockError.CommunicationError(msg(e)))
+                     .zipRight(spaces.update(_.updated(id, SpaceState(server, ownsServer = true, None, rulesRef))))
+                     .as(MockSpace(server.baseUrl(), identity, id)))
+                     .onError(_ => stop(server))
+        yield List(space)
+      case NativeSpec.Rift(_) =>
+        ZIO.fail(MockError.InvalidDefinition("the WireMock adapter cannot provision a Rift native spec"))
+
+  def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+    withSpace(space)(st => registerRule(st, space.id, rule, priority))
+
+  def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit] =
+    withSpace(space) { st =>
+      st.rules.get.flatMap(_.find(_._1 == id) match
+        case None => ZIO.fail(MockError.RuleNotFound(space.id, id))
+        case Some((_, stub)) =>
+          ZIO
+            .attempt(st.server.removeStubMapping(stub))
+            .mapError(e => MockError.CommunicationError(msg(e)))
+            .zipRight(st.rules.update(_.filterNot(_._1 == id)))
+      )
+    }
+
+  def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit] =
+    withSpace(space) { st =>
+      for
+        current <- st.rules.getAndSet(Vector.empty)
+        _       <- removeStubs(st.server, current.map(_._2))
+        _       <- ZIO.foreachDiscard(rules)(r => registerRule(st, space.id, r, Priority.Base))
+      yield ()
+    }
+
+  def destroy(space: MockSpace): IO[MockError, Unit] =
+    withSpace(space) { st =>
+      for
+        current <- st.rules.get
+        _       <- removeStubs(st.server, current.map(_._2))
+        _       <- ZIO.when(st.ownsServer)(stop(st.server))
+        _       <- spaces.update(_ - space.id)
+      yield ()
+    }
+
+  def received(space: MockSpace): IO[MockError, List[RecordedRequest]] =
+    withSpace(space) { st =>
+      // Only the backend call is wrapped — a defect in the pure translation below
+      // must stay a defect, not get relabelled as a communication error.
+      ZIO
+        .attempt(st.server.getAllServeEvents.asScala.toList)
+        .mapError(e => MockError.CommunicationError(msg(e)))
+        .map(_.reverse.flatMap { ev =>
+          val req = ev.getRequest
+          val keep = st.correlation match
+            case Some(c) => Option(req.getHeader(c.header)).exists(h => c.matcher(space.id).`match`(h).isExactMatch)
+            case None    => true
+          Option.when(keep)(
+            WireMockTranslation.recorded(
+              req.getMethod.getName,
+              req.getUrl,
+              req.getHeaders.all.asScala.map(h => h.key.toLowerCase -> h.firstValue).toMap,
+              Option(req.getBodyAsString).filter(_.nonEmpty)
+            )
+          )
+        })
+    }
+
+  def faults: IO[Unsupported, Faults]                   = unsupported(Capability.Faults)
+  def scenarios: IO[Unsupported, StatefulScenarios]     = unsupported(Capability.StatefulScenarios)
+  def stateInspection: IO[Unsupported, StateInspection] = unsupported(Capability.StateInspection)
+  def scripting: IO[Unsupported, Scripting]             = unsupported(Capability.Scripting)
+  def proxyRecord: IO[Unsupported, ProxyRecord]         = unsupported(Capability.ProxyRecord)
+  def templating: IO[Unsupported, Templating]           = unsupported(Capability.Templating)
+
+  // Stop every server this adapter still owns — the layer's scope finalizer.
+  private[wiremock] def stopAll: UIO[Unit] =
+    for
+      snap <- spaces.get
+      _    <- ZIO.foreachDiscard(snap.values.filter(_.ownsServer))(st => stop(st.server))
+      _    <- ZIO.foreachDiscard(shared.toList)(stop)
+    yield ()
+
+  // ---------------------------------------------------------------------------
+
+  private def serveSpace(src: NormalizedSource): IO[MockError, MockSpace] =
+    for
+      rules    <- rulesOf(src)
+      id       <- freshSpaceId(src.name)
+      rulesRef <- Ref.make(Vector.empty[(RuleId, StubMapping)])
+      corr      = correlationOf
+      server   <- serverFor(id)
+      st        = SpaceState(server, ownsServer = corr.isEmpty, corr, rulesRef)
+      // If a rule fails mid-batch the space is never tracked, so destroy can
+      // never reach it: undo its stubs (and stop its own server) here, or they
+      // orphan on the shared server.
+      _ <- ZIO
+             .foreachDiscard(rules)(r => registerRule(st, id, r, Priority.Base))
+             .onError(_ => cleanupSpace(st))
+      _ <- spaces.update(_.updated(id, st))
+    yield MockSpace(server.baseUrl(), injectFor(id, corr), id)
+
+  // Best-effort teardown of a half-built (untracked) space.
+  private def cleanupSpace(st: SpaceState): UIO[Unit] =
+    for
+      rs <- st.rules.get
+      _  <- removeStubs(st.server, rs.map(_._2)).ignore
+      _  <- ZIO.when(st.ownsServer)(stop(st.server))
+    yield ()
+
+  private def registerRule(st: SpaceState, id: SpaceId, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+    for
+      ruleId <- freshRuleId
+      stub    = WireMockTranslation.stub(id, rule.copy(id = Some(ruleId)), priority, st.correlation)
+      _ <- ZIO
+             .attempt(st.server.addStubMapping(stub))
+             .mapError(e => MockError.CommunicationError(msg(e)))
+      _ <- st.rules.update(v => if priority == Priority.Overlay then (ruleId, stub) +: v else v :+ (ruleId, stub))
+    yield ruleId
+
+  private def removeStubs(server: WireMockServer, stubs: Vector[StubMapping]): IO[MockError, Unit] =
+    ZIO
+      .attempt(stubs.foreach(server.removeStubMapping))
+      .mapError(e => MockError.CommunicationError(msg(e)))
+
+  private def rulesOf(src: NormalizedSource): IO[MockError, List[MockRule]] =
+    src.payload match
+      case SourcePayload.Rules(rules) => ZIO.succeed(rules)
+      case SourcePayload.Raw(_) =>
+        ZIO.fail(
+          MockError.InvalidDefinition(
+            "a raw/native WireMock source must go through provisionNative(NativeSpec.WireMock)"
+          )
+        )
+
+  private def correlationOf: Option[Correlation] = mode match
+    case WireMock.Mode.Correlated(c) => Some(c)
+    case WireMock.Mode.PerInstance   => None
+
+  private def serverFor(id: SpaceId): IO[MockError, WireMockServer] = mode match
+    case WireMock.Mode.Correlated(_) => ZIO.succeed(shared.get)
+    case WireMock.Mode.PerInstance   => WireMockControl.startServer.mapError(e => MockError.ProvisionFailed(msg(e)))
+
+  private def injectFor(id: SpaceId, corr: Option[Correlation]): HttpRequest => HttpRequest =
+    corr match
+      case Some(c) => req => req.copy(headers = req.headers + (c.header -> c.value(id)))
+      case None    => identity
+
+  private def stop(server: WireMockServer): UIO[Unit] =
+    ZIO
+      .attempt(server.stop())
+      .catchAllCause(c => ZIO.logWarningCause("WireMock server stop failed", c))
+
+  private def freshRuleId: UIO[RuleId]                 = ids.updateAndGet(_ + 1).map(n => RuleId(s"r$n"))
+  private def freshSpaceId(name: String): UIO[SpaceId] = ids.updateAndGet(_ + 1).map(n => SpaceId(s"$name-$n"))
+
+  private def withSpace[A](space: MockSpace)(f: SpaceState => IO[MockError, A]): IO[MockError, A] =
+    spaces.get.flatMap(_.get(space.id) match
+      case Some(st) => f(st)
+      case None     => ZIO.fail(MockError.SpaceNotFound(space.id))
+    )
+
+  private def unsupported[A](c: Capability): IO[Unsupported, A] = ZIO.fail(Unsupported(c, backendName))
+
+  private def msg(t: Throwable): String =
+    def render(x: Throwable): String =
+      Option(x.getMessage).filter(_.nonEmpty).fold(x.getClass.getSimpleName)(m => s"${x.getClass.getSimpleName}: $m")
+    // Keep the root cause — WireMock/JVM faults wrap the actionable detail
+    // (e.g. a BindException behind a generic startup error).
+    val cause = Option(t.getCause).filter(_ ne t).fold("")(c => s" (cause: ${render(c)})")
+    s"${render(t)}$cause"
+
+private[wiremock] object WireMockControl:
+  final case class SpaceState(
+    server: WireMockServer,
+    ownsServer: Boolean,
+    correlation: Option[Correlation],
+    rules: Ref[Vector[(RuleId, StubMapping)]]
+  )
+
+  /**
+   * Build the adapter for `mode`, starting the shared server in Correlated mode
+   * and registering a scope finalizer that stops every server it owns.
+   */
+  def make(mode: WireMock.Mode): ZIO[Provisioning & Scope, Throwable, MockControl] =
+    for
+      prov   <- ZIO.service[Provisioning]
+      spaces <- Ref.make(Map.empty[SpaceId, SpaceState])
+      ids    <- Ref.make(0)
+      shared <- mode match
+                  case WireMock.Mode.Correlated(_) => startServer.map(Some(_))
+                  case WireMock.Mode.PerInstance   => ZIO.none
+      control = WireMockControl(mode, shared, prov, spaces, ids)
+      _      <- ZIO.addFinalizer(control.stopAll)
+    yield control
+
+  // Create and start an embedded server on an OS-assigned port.
+  private def startServer: Task[WireMockServer] =
+    ZIO.attempt {
+      val server = new WireMockServer(options().dynamicPort())
+      server.start()
+      server
+    }

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
@@ -36,6 +36,10 @@ private[wiremock] final case class WireMockControl(
   def backendName: String           = "wiremock"
   def capabilities: Set[Capability] = Set.empty
 
+  override def isolation: Isolation = mode match
+    case WireMock.Mode.Correlated(_) => Isolation.Correlated
+    case WireMock.Mode.PerInstance   => Isolation.PerInstance
+
   def provision(source: MockSource): IO[MockError, List[MockSpace]] =
     for
       sources <- provisioning.normalize(source)

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockTranslation.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockTranslation.scala
@@ -1,0 +1,84 @@
+package zio.bdd.mock.wiremock
+
+import zio.bdd.mock.*
+
+import com.github.tomakehurst.wiremock.client.{MappingBuilder, ResponseDefinitionBuilder, WireMock as WM}
+import com.github.tomakehurst.wiremock.matching.StringValuePattern
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+
+import java.util.UUID
+
+/**
+ * Translates the backend-neutral [[MockRule]] model to WireMock stub mappings.
+ */
+private[wiremock] object WireMockTranslation:
+
+  /**
+   * Build the stub for `rule` on space `id`. In Correlated mode `correlation`
+   * stamps the matcher (header == this space) onto the request pattern so only
+   * requests carrying the space's tag can match it; in PerInstance mode it is
+   * `None` (the space owns its server outright).
+   */
+  def stub(id: SpaceId, rule: MockRule, priority: Priority, correlation: Option[Correlation]): StubMapping =
+    val base = methodAndUrl(rule.`match`)
+    rule.`match`.headers.foreach((k, v) => base.withHeader(k, valuePattern(v)))
+    rule.`match`.query.foreach((k, v) => base.withQueryParam(k, valuePattern(v)))
+    rule.`match`.body.foreach(b => base.withRequestBody(bodyPattern(b)))
+    correlation.foreach(c => base.withHeader(c.header, c.matcher(id)))
+    base.atPriority(priority match
+      case Priority.Overlay => 1
+      case Priority.Base    => 10
+    )
+    base.withId(UUID.randomUUID())
+    base.willReturn(response(rule.respond)).build()
+
+  private def methodAndUrl(m: RequestMatch): MappingBuilder =
+    val url = m.path match
+      case PathMatch.Any         => WM.anyUrl()
+      case PathMatch.Exact(p)    => WM.urlPathEqualTo(p)
+      case PathMatch.Regex(p)    => WM.urlPathMatching(p)
+      case PathMatch.Template(t) => WM.urlPathTemplate(t)
+    m.method match
+      case Some(method) => WM.request(method.toString.toUpperCase, url)
+      case None         => WM.any(url)
+
+  private def valuePattern(v: ValueMatch): StringValuePattern = v match
+    case ValueMatch.Equals(value)   => WM.equalTo(value)
+    case ValueMatch.Contains(value) => WM.containing(value)
+    case ValueMatch.Matches(regex)  => WM.matching(regex)
+
+  private def bodyPattern(b: BodyMatch): StringValuePattern = b match
+    case BodyMatch.Equals(value)   => WM.equalTo(value)
+    case BodyMatch.Contains(value) => WM.containing(value)
+    case BodyMatch.Matches(regex)  => WM.matching(regex)
+    case BodyMatch.JsonPath(path, expected) =>
+      expected.fold(WM.matchingJsonPath(path))(e => WM.matchingJsonPath(path, WM.equalTo(e)))
+    case BodyMatch.XPath(path, expected) =>
+      expected.fold(WM.matchingXPath(path))(e => WM.matchingXPath(path, WM.equalTo(e)))
+
+  private def response(r: ResponseDef): ResponseDefinitionBuilder =
+    val rb = WM.aResponse().withStatus(r.status)
+    r.headers.foreach((k, v) => rb.withHeader(k, v))
+    r.body match
+      case Body.Empty     => ()
+      case Body.Text(v)   => rb.withBody(v)
+      case Body.Json(v)   => rb.withBody(v)
+      case Body.Base64(v) => rb.withBase64Body(v)
+    r.delay.foreach(d => rb.withFixedDelay(d.toMillis.toInt))
+    rb
+
+  /** A [[RecordedRequest]] from a WireMock logged request. */
+  def recorded(method: String, url: String, headers: Map[String, String], body: Option[String]): RecordedRequest =
+    RecordedRequest(parseMethod(method), url, headers, body)
+
+  private def parseMethod(name: String): Method = name.toUpperCase match
+    case "GET"     => Method.Get
+    case "POST"    => Method.Post
+    case "PUT"     => Method.Put
+    case "DELETE"  => Method.Delete
+    case "PATCH"   => Method.Patch
+    case "HEAD"    => Method.Head
+    case "OPTIONS" => Method.Options
+    case "TRACE"   => Method.Trace
+    case "CONNECT" => Method.Connect
+    case other     => Method.Get

--- a/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
+++ b/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
@@ -152,8 +152,26 @@ object WireMockControlSpec extends ZIOSpecDefault:
           resp    <- rawGet(a.baseUri + "/native").orDie // its own server, no space header needed
           rift    <- control.provisionNative(NativeSpec.Rift("{}")).either
         yield assertTrue(resp == 201, rift.isLeft)
+      },
+      test("the Correlated adapter reports Correlated isolation") {
+        ZIO.serviceWith[MockControl](c => assertTrue(c.isolation == Isolation.Correlated))
+      },
+      test("received(A) returns only A's traffic when A and B share one server") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          b       <- die(control.provision(pingSource)).map(_.head)
+          _       <- SutClient.make(a).send(Method.Get, "/ping").orDie
+          _       <- SutClient.make(b).send(Method.Get, "/ping").orDie
+          _       <- SutClient.make(b).send(Method.Get, "/ping").orDie
+          ra      <- die(control.received(a))
+          rb      <- die(control.received(b))
+        yield assertTrue(ra.size == 1, rb.size == 2) // received filters by space header on the shared server
       }
     ).provide(correlated),
+    test("the PerInstance-mode adapter reports PerInstance isolation") {
+      ZIO.serviceWith[MockControl](c => assertTrue(c.isolation == Isolation.PerInstance))
+    }.provide(perInstance),
     test("PerInstance gives each space its own server (distinct ports, inject identity), destroy stops only that one") {
       for
         control <- ZIO.service[MockControl]

--- a/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
+++ b/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
@@ -1,0 +1,199 @@
+package zio.bdd.mock.wiremock
+
+import zio.*
+import zio.bdd.mock.*
+import zio.test.*
+
+import java.net.{URI, http as jhttp}
+
+object WireMockControlSpec extends ZIOSpecDefault:
+
+  private val pingRule =
+    MockRule(
+      RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+      ResponseDef(status = 200, body = Body.Text("pong"))
+    )
+  private val healthRule =
+    MockRule(
+      RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/health")),
+      ResponseDef(status = 200, body = Body.Text("ok"))
+    )
+  private val pingSource = MockSource.Dsl(MockSpec(List(pingRule)))
+
+  private val baseHealth = MockRule(
+    RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/h")),
+    ResponseDef(status = 200, body = Body.Text("base"))
+  )
+  private val overlayHealth = MockRule(
+    RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/h")),
+    ResponseDef(status = 200, body = Body.Text("overlay"))
+  )
+  private val slowSource =
+    MockSource.Dsl(
+      MockSpec(
+        List(
+          MockRule(
+            RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/slow")),
+            ResponseDef(status = 200, body = Body.Text("slow"), delay = Some(300.millis))
+          )
+        )
+      )
+    )
+  private val nativeStubJson =
+    """{"request":{"method":"GET","url":"/native"},"response":{"status":201,"body":"native!"}}"""
+
+  private val correlated  = PortAllocator.layer >>> Provisioning.layer >>> WireMock.correlated()
+  private val perInstance = PortAllocator.layer >>> Provisioning.layer >>> WireMock.perInstance
+  private val traceparent = PortAllocator.layer >>> Provisioning.layer >>> WireMock.correlated(Correlation.traceparent)
+
+  private def die[A](z: IO[MockError, A]): UIO[A] = z.orDieWith(e => new RuntimeException(e.toString))
+
+  // Send straight to a base URI with no inject (and an optional raw header), to
+  // model a SUT that did NOT carry the space tag.
+  private def rawGet(url: String, header: Option[(String, String)] = None): IO[Throwable, Int] =
+    ZIO.attemptBlocking {
+      val b   = jhttp.HttpRequest.newBuilder(URI.create(url)).GET()
+      val req = header.fold(b)((k, v) => b.header(k, v)).build()
+      jhttp.HttpClient.newHttpClient().send(req, jhttp.HttpResponse.BodyHandlers.ofString()).statusCode
+    }
+
+  def spec = suite("WireMockControl")(
+    suite("Correlated (default)")(
+      test("provision serves a portable rule, records the injected request, and destroy removes the space's stubs") {
+        for
+          control <- ZIO.service[MockControl]
+          spaces  <- die(control.provision(pingSource))
+          space    = spaces.head
+          resp    <- SutClient.make(space).send(Method.Get, "/ping").orDie
+          recv    <- die(control.received(space))
+          _       <- die(control.destroy(space))
+          after   <- SutClient.make(space).send(Method.Get, "/ping").orDie
+        yield assertTrue(
+          spaces.size == 1,
+          resp.status == 200,
+          resp.body == "pong",
+          recv.map(r => (r.method, r.uri)) == List((Method.Get, "/ping")),
+          after.status == 404 // the space's stub is gone after destroy
+        )
+      },
+      test("destroy(A) removes only A's stubs — B still serves and records") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          b       <- die(control.provision(pingSource)).map(_.head)
+          _       <- SutClient.make(b).send(Method.Get, "/ping").orDie
+          _       <- die(control.destroy(a))
+          rb      <- die(control.received(b))
+          respB   <- SutClient.make(b).send(Method.Get, "/ping").orDie
+          respA   <- SutClient.make(a).send(Method.Get, "/ping").orDie
+        yield assertTrue(rb.nonEmpty, respB.status == 200, respA.status == 404)
+      },
+      test("a request WITHOUT the space header gets 404 and leaks into NO Correlated space") {
+        for
+          control  <- ZIO.service[MockControl]
+          a        <- die(control.provision(pingSource)).map(_.head)
+          withResp <- SutClient.make(a).send(Method.Get, "/ping").orDie // inject stamps X-Mock-Space
+          rawResp  <- rawGet(a.baseUri + "/ping").orDie                 // no header
+          recv     <- die(control.received(a))
+        yield assertTrue(
+          withResp.status == 200,
+          rawResp == 404,                   // unmatched without the space tag
+          recv.count(_.uri == "/ping") == 1 // only the injected request, never the raw one
+        )
+      },
+      test("addRule serves a new rule; removeRule stops it") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          rid     <- die(control.addRule(a, healthRule, Priority.Overlay))
+          r1      <- SutClient.make(a).send(Method.Get, "/health").orDie
+          _       <- die(control.removeRule(a, rid))
+          r2      <- SutClient.make(a).send(Method.Get, "/health").orDie
+        yield assertTrue(r1.status == 200, r1.body == "ok", r2.status == 404)
+      },
+      test("replaceRules swaps the space's whole rule set") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          _       <- die(control.replaceRules(a, List(healthRule)))
+          ping    <- SutClient.make(a).send(Method.Get, "/ping").orDie
+          health  <- SutClient.make(a).send(Method.Get, "/health").orDie
+        yield assertTrue(ping.status == 404, health.status == 200, health.body == "ok")
+      },
+      test("removeRule of an unknown id fails RuleNotFound") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          res     <- control.removeRule(a, RuleId("ghost")).either
+        yield assertTrue(res == Left(MockError.RuleNotFound(a.id, RuleId("ghost"))))
+      },
+      test("an Overlay rule shadows a Base rule on the same path") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(MockSource.Dsl(MockSpec(List(baseHealth))))).map(_.head)
+          _       <- die(control.addRule(a, overlayHealth, Priority.Overlay))
+          resp    <- SutClient.make(a).send(Method.Get, "/h").orDie
+        yield assertTrue(resp.status == 200, resp.body == "overlay") // higher priority (atPriority 1) wins
+      },
+      test("the response delay is applied to served responses") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(slowSource)).map(_.head)
+          start   <- Clock.nanoTime
+          resp    <- SutClient.make(a).send(Method.Get, "/slow").orDie
+          elapsed <- Clock.nanoTime.map(_ - start)
+        yield assertTrue(resp.status == 200, elapsed >= 250.millis.toNanos) // ~300ms fixed delay
+      } @@ TestAspect.withLiveClock,
+      test("provisionNative(WireMock) serves a raw stub on its own server; a Rift spec is rejected") {
+        for
+          control <- ZIO.service[MockControl]
+          spaces  <- die(control.provisionNative(NativeSpec.WireMock(nativeStubJson)))
+          a        = spaces.head
+          resp    <- rawGet(a.baseUri + "/native").orDie // its own server, no space header needed
+          rift    <- control.provisionNative(NativeSpec.Rift("{}")).either
+        yield assertTrue(resp == 201, rift.isLeft)
+      }
+    ).provide(correlated),
+    test("PerInstance gives each space its own server (distinct ports, inject identity), destroy stops only that one") {
+      for
+        control <- ZIO.service[MockControl]
+        a       <- die(control.provision(pingSource)).map(_.head)
+        b       <- die(control.provision(pingSource)).map(_.head)
+        ra      <- SutClient.make(a).send(Method.Get, "/ping").orDie
+        _       <- die(control.destroy(a))
+        rb      <- SutClient.make(b).send(Method.Get, "/ping").orDie
+        aGone   <- rawGet(a.baseUri + "/ping").either
+      yield assertTrue(
+        a.baseUri != b.baseUri, // a fresh server (port) per space
+        ra.status == 200,
+        rb.status == 200, // B's server is untouched by destroy(A)
+        aGone.isLeft      // A's server was stopped — connection refused
+      )
+    }.provide(perInstance),
+    suite("traceparent correlation")(
+      test("inject stamps a traceparent; a foreign trace-id does not reach the space") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          resp    <- SutClient.make(a).send(Method.Get, "/ping").orDie
+          recv    <- die(control.received(a))
+          foreign <- rawGet(
+                       a.baseUri + "/ping",
+                       Some("traceparent" -> "00-ffffffffffffffffffffffffffffffff-0000000000000001-01")
+                     ).orDie
+        yield assertTrue(resp.status == 200, recv.nonEmpty, foreign == 404)
+      },
+      test("a request reusing the space's trace-id but a DIFFERENT span-id still matches") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          _       <- SutClient.make(a).send(Method.Get, "/ping").orDie // records the space's traceparent
+          recv    <- die(control.received(a))
+          tp       = recv.head.headers("traceparent")                  // 00-<traceId>-<span>-01
+          traceId  = tp.split("-")(1)
+          // same trace-id, a span-id the space never injected
+          varied <- rawGet(a.baseUri + "/ping", Some("traceparent" -> s"00-$traceId-ffffffffffffffff-01")).orDie
+        yield assertTrue(varied == 200) // matched by trace-id; the span-id is free to vary
+      }
+    ).provide(traceparent)
+  )


### PR DESCRIPTION
Milestone **M2 (Epic C)** acceptance gate — promotes the `epic/m2-wiremock-conformance` branch to `master`.

## What M2 delivers
A second mock backend (in-process WireMock) behind the portable `MockControl` SPI, a backend-neutral isolation model, and a **CI-gated cross-adapter conformance suite** that proves both adapters (WireMock + a real Rift v0.4.0 container) honor the same contract.

| Issue | Delivered |
|---|---|
| #122 | In-process WireMock adapter (Correlated isolation) |
| #123 | Portable isolation model + per-adapter defaults (`MockControl.isolation`) |
| #124 | Conformance harness + pass/skip/fail matrix runner |
| #125 | Core conformance features (matching / response fidelity / precedence / isolation / verification) |
| #126 | Parallel-isolation contract under concurrency, every advertised mode |
| #127 | Capability-negotiation + native-escape-hatch + error-semantics |
| #156 | Rift Correlated isolation (shared imposter, port-pressure scale option) |
| #165 | Rift unmatched-request → 404 (cross-adapter contract); wired the matrix Rift column into CI (#163) |

Plus: the rift-proxy image bumped to v0.4.0 (#159).

## CI
The `rift-it` job runs the full `conformance/test` under `RIFT_IT` against a real Rift container — the matrix, parallel-isolation, and native-escape-hatch suites all exercise the Rift column end-to-end; WireMock runs in-process in the hermetic `build` job.

## Merge strategy
Please **merge with a merge commit** (not squash) to preserve the per-issue history of the epic.

## Open follow-up (not blocking the gate)
- #162 — multi-value header support (needs a model change).

Closes #122
Closes #123
Closes #124
Closes #125
Closes #126
Closes #127
Closes #156
Closes #163
Closes #165