### PR TITLE
build: bump rift-proxy image to v0.5.0

### DIFF
--- a/conformance/src/main/scala/zio/bdd/mock/conformance/CoreConformanceScenarios.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/CoreConformanceScenarios.scala
@@ -301,6 +301,10 @@ object CoreConformanceScenarios:
       // Measure a no-delay sibling on the same space as the baseline, so the
       // delta cancels connection/JIT latency — a backend that ignored the delay
       // directive yields delta ~0 and fails, not a spurious pass on a slow box.
+      // SutClient opens a fresh connection per send, so setup cost is noisy: use
+      // a 1s delay with a 500ms floor (signal >> noise) and the MIN of two
+      // baselines (discount the occasional slow cold connection), so connection
+      // jitter can't flip a genuinely-applied delay to a false failure.
       def elapsedOf(s: MockSpace, path: String): ZIO[Any, Throwable, (SutResponse, Duration)] =
         for
           t0 <- Clock.nanoTime
@@ -316,15 +320,17 @@ object CoreConformanceScenarios:
                ),
                MockRule(
                  RequestMatch(path = PathMatch.Exact("/delay")),
-                 ResponseDef(status = 200, body = Body.Text("ok"), delay = Some(300.millis))
+                 ResponseDef(status = 200, body = Body.Text("ok"), delay = Some(1.second))
                )
              )
-        baseline <- elapsedOf(s, "/nodelay")
-        delayed  <- elapsedOf(s, "/delay")
-        delta     = Duration.fromNanos(delayed._2.toNanos - baseline._2.toNanos)
+        base1   <- elapsedOf(s, "/nodelay")
+        base2   <- elapsedOf(s, "/nodelay")
+        delayed <- elapsedOf(s, "/delay")
+        baseline = math.min(base1._2.toNanos, base2._2.toNanos)
+        delta    = Duration.fromNanos(delayed._2.toNanos - baseline)
         _ <- ensure(
-               delayed._1.status == 200 && delta >= 200.millis,
-               s"delay: status=${delayed._1.status} delayed=${delayed._2.toMillis}ms baseline=${baseline._2.toMillis}ms delta=${delta.toMillis}ms"
+               delayed._1.status == 200 && delta >= 500.millis,
+               s"delay: status=${delayed._1.status} delayed=${delayed._2.toMillis}ms baseline=${baseline / 1000000}ms delta=${delta.toMillis}ms"
              )
       yield ()
     }

--- a/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
@@ -52,10 +52,12 @@ object RiftMode:
  */
 object Rift:
 
-  // Pinned to v0.4.0. Floor is v0.2.0: the first release where DELETE
-  // /imposters/:port tears down existing keep-alive connections, so a destroyed
-  // imposter stops serving even a pooled client (EtaCassiopeia/rift#207).
-  val DefaultImage: String     = "zainalpour/rift-proxy:v0.4.0"
+  // Pinned to v0.5.0. Floor is v0.4.0: Correlated isolation (#156) needs the
+  // space-scoped stub + per-space teardown endpoints (EtaCassiopeia/rift#223),
+  // first shipped in v0.4.0 — which also supersedes the older v0.2.0 floor (the
+  // rift#207 release where DELETE /imposters/:port tears down keep-alive
+  // connections so a destroyed imposter stops serving a pooled client).
+  val DefaultImage: String     = "zainalpour/rift-proxy:v0.5.0"
   val DefaultAdminPort: Int    = 2525
   val DefaultImposterBase: Int = 4545
   val DefaultPoolSize: Int     = 16


### PR DESCRIPTION
Bumps the pinned Rift adapter image from `v0.4.0` to `v0.5.0` (single source of truth: `Rift.DefaultImage`; CI's `rift-it` job + the conformance matrix's Rift column resolve this constant via `Rift.managed()`).

- The v0.5.0 image pulls cleanly; the module compiles; the 39 non-container rift tests + the conformance suite pass with `RiftContainerSpec` gated behind `RIFT_IT`.
- Corrects the floor note: the binding floor is now **v0.4.0** (Correlated isolation, #156, needs rift#223's space-scoped stub + per-space teardown endpoints), superseding the older v0.2.0/rift#207 floor.

## Verification
The real-container behaviour against v0.5.0 is verified by the **`rift-it` CI job** (real Docker) — `RiftContainerSpec` plus the full conformance module (matrix, parallel-isolation, native-escape-hatch) under `RIFT_IT`. Local `RIFT_IT=1` can't run it (testcontainers can't resolve the Docker Desktop socket from the sandbox — environmental; the image itself pulls fine).

Base: `master` (M2 is merged; no active epic).