### PR TITLE
feat: StatefulScenarios + StateInspection traits + DSL builder

### DIFF
--- a/conformance/src/main/scala/zio/bdd/mock/conformance/CapStatefulScenarios.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/CapStatefulScenarios.scala
@@ -1,0 +1,172 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.dsl.*
+
+/**
+ * The `cap-stateful` conformance feature (#129): the normative single-token-FSM
+ * semantics, programmed against the neutral [[StatefulScenarios]] /
+ * [[StateInspection]] capabilities. Each scenario is capability-gated, so it
+ * runs (and validates the semantics) only on a backend that advertises the
+ * capability — until #130 (WireMock) / #131 (Rift) land, every backend
+ * justifiably SKIPs.
+ */
+object CapStatefulScenarios:
+
+  lazy val all: List[ConformanceScenario] = core ++ inspection
+
+  // ---- helpers ------------------------------------------------------------------
+
+  private def asT(e: MockError): Throwable    = new RuntimeException(s"MockError: $e")
+  private def asTU(u: Unsupported): Throwable = new RuntimeException(s"Unsupported: $u")
+
+  private def ensure(cond: Boolean, msg: => String): IO[Throwable, Unit] =
+    ZIO.unless(cond)(ZIO.fail(new AssertionError(msg))).unit
+
+  // An empty space; the scenario's own rules are installed by `define`.
+  private val emptySpace: MockSource = MockSource.Dsl(MockSpec(Nil))
+
+  private def space(control: MockControl): ZIO[Scope, Throwable, MockSpace] =
+    ZIO.acquireRelease(control.provision(emptySpace).mapError(asT).map(_.head))(s => control.destroy(s).ignoreLogged)
+
+  // Started --GET /inv--> "created" --> Paid --GET /inv--> "paid" (stays).
+  private val invoice: ScenarioDef =
+    scenario("invoice")
+      .when("Started", get("/inv"))
+      .respond(ok.text("created"))
+      .goTo("Paid")
+      .when("Paid", get("/inv"))
+      .respond(ok.text("paid"))
+      .stay
+      .build
+
+  // Two rules eligible in "Started" for the same request: the first declared wins.
+  private val firstMatch: ScenarioDef =
+    scenario("fm")
+      .when("Started", get("/fm"))
+      .respond(ok.text("first"))
+      .stay
+      .when("Started", get("/fm"))
+      .respond(ok.text("second"))
+      .stay
+      .build
+
+  private def scen(name: String, requires: Set[Capability])(
+    check: MockControl => ZIO[Scope, Throwable, Unit]
+  ): ConformanceScenario =
+    ConformanceScenario(name, requires, check)
+
+  private val needsStateful = Set(Capability.StatefulScenarios)
+  private val needsBoth     = Set(Capability.StatefulScenarios, Capability.StateInspection)
+
+  // ---- core (StatefulScenarios) -------------------------------------------------
+
+  private val core = List(
+    scen("stateful: eligibility + transition advance the FSM", needsStateful) { control =>
+      ZIO.scoped {
+        for
+          ss <- control.scenarios.mapError(asTU)
+          s  <- space(control)
+          _  <- ss.define(s, invoice).mapError(asT)
+          r1 <- SutClient.make(s).send(Method.Get, "/inv") // Started -> "created", -> Paid
+          r2 <- SutClient.make(s).send(Method.Get, "/inv") // Paid    -> "paid"
+          _  <- ensure(r1.body == "created" && r2.body == "paid", s"transition: r1=${r1.body} r2=${r2.body}")
+        yield ()
+      }
+    },
+    scen("stateful: a request matching no eligible rule leaves the state unchanged", needsStateful) { control =>
+      ZIO.scoped {
+        for
+          ss   <- control.scenarios.mapError(asTU)
+          s    <- space(control)
+          _    <- ss.define(s, invoice).mapError(asT)
+          miss <- SutClient.make(s).send(Method.Get, "/other") // no eligible rule -> no transition
+          hit  <- SutClient.make(s).send(Method.Get, "/inv")   // still in Started -> "created"
+          _    <- ensure(miss.status == 404 && hit.body == "created", s"no-change: miss=${miss.status} hit=${hit.body}")
+        yield ()
+      }
+    },
+    scen("stateful: reset returns the FSM to its initial state", needsStateful) { control =>
+      ZIO.scoped {
+        for
+          ss <- control.scenarios.mapError(asTU)
+          s  <- space(control)
+          _  <- ss.define(s, invoice).mapError(asT)
+          _  <- SutClient.make(s).send(Method.Get, "/inv") // advance to Paid
+          _  <- ss.reset(s, "invoice").mapError(asT)
+          r  <- SutClient.make(s).send(Method.Get, "/inv") // back in Started -> "created"
+          _  <- ensure(r.body == "created", s"reset: r=${r.body}")
+        yield ()
+      }
+    },
+    scen("stateful: two spaces sharing a scenario name keep independent state (locality)", needsStateful) { control =>
+      ZIO.scoped {
+        for
+          ss <- control.scenarios.mapError(asTU)
+          a  <- space(control)
+          b  <- space(control)
+          _  <- ss.define(a, invoice).mapError(asT)
+          _  <- ss.define(b, invoice).mapError(asT)
+          _  <- SutClient.make(a).send(Method.Get, "/inv") // advance A to Paid
+          aR <- SutClient.make(a).send(Method.Get, "/inv") // A -> "paid"
+          bR <- SutClient.make(b).send(Method.Get, "/inv") // B untouched -> "created"
+          _  <- ensure(aR.body == "paid" && bR.body == "created", s"locality: a=${aR.body} b=${bR.body}")
+        yield ()
+      }
+    },
+    scen("stateful: among rules eligible in the same state, the first declared wins (first-match)", needsStateful) {
+      control =>
+        ZIO.scoped {
+          for
+            ss <- control.scenarios.mapError(asTU)
+            s  <- space(control)
+            _  <- ss.define(s, firstMatch).mapError(asT)
+            r  <- SutClient.make(s).send(Method.Get, "/fm") // both rules eligible -> first wins
+            _  <- ensure(r.body == "first", s"first-match: r=${r.body}")
+          yield ()
+        }
+    },
+    scen("stateful: concurrent advances on independent spaces stay isolated (concurrency)", needsStateful) { control =>
+      ZIO.scoped {
+        for
+          ss     <- control.scenarios.mapError(asTU)
+          spaces <- ZIO.foreachPar(1 to 8)(_ => space(control))
+          _      <- ZIO.foreachPar(spaces)(s => ss.define(s, invoice).mapError(asT))
+          // concurrently advance the even-indexed spaces to Paid; the odd ones stay in Started
+          _ <- ZIO.foreachPar(spaces.zipWithIndex.filter((_, i) => i % 2 == 0)) { (s, _) =>
+                 SutClient.make(s).send(Method.Get, "/inv")
+               }
+          bodies <-
+            ZIO.foreachPar(spaces.zipWithIndex)((s, i) => SutClient.make(s).send(Method.Get, "/inv").map(i -> _.body))
+          _ <- ensure(
+                 bodies.forall((i, b) => b == (if i % 2 == 0 then "paid" else "created")),
+                 s"concurrency: $bodies"
+               )
+        yield ()
+      }
+    }
+  )
+
+  // ---- StateInspection (gated separately) ---------------------------------------
+
+  private val inspection = List(
+    scen("inspection: currentState reflects the FSM; setState forces a transition", needsBoth) { control =>
+      ZIO.scoped {
+        for
+          ss   <- control.scenarios.mapError(asTU)
+          si   <- control.stateInspection.mapError(asTU)
+          s    <- space(control)
+          _    <- ss.define(s, invoice).mapError(asT)
+          init <- si.currentState(s, "invoice").mapError(asT)
+          _    <- si.setState(s, "invoice", ScenarioState("Paid")).mapError(asT)
+          now  <- si.currentState(s, "invoice").mapError(asT)
+          r    <- SutClient.make(s).send(Method.Get, "/inv") // forced to Paid -> "paid"
+          _ <- ensure(
+                 init == ScenarioState.Started && now == ScenarioState("Paid") && r.body == "paid",
+                 s"inspection: init=$init now=$now r=${r.body}"
+               )
+        yield ()
+      }
+    }
+  )

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
@@ -155,6 +155,19 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         if riftEnabled then all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Pass))
         else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
       )
+    } @@ TestAspect.withLiveClock,
+    test("cap-stateful feature is defined + capability-gated; SKIPs until an adapter advertises it (#129)") {
+      val all = CapStatefulScenarios.all
+      for
+        matrix <- ConformanceHarness.run(List(wiremock, rift), all)
+        _      <- ZIO.logInfo(s"cap-stateful matrix:\n${matrix.render}")
+      yield assertTrue(
+        all.nonEmpty,
+        // Neither adapter advertises StatefulScenarios/StateInspection yet -> every cell is a justified SKIP.
+        all.forall(s => matrix.cell(s.name, "wiremock").exists(_.outcome == Outcome.Skip)),
+        all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Skip)),
+        matrix.conformant(wiremock) // justified (capability-gated) skips keep the column conformant
+      )
     } @@ TestAspect.withLiveClock
   )
 

--- a/mock/src/main/scala/zio/bdd/mock/Capability.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Capability.scala
@@ -1,5 +1,7 @@
 package zio.bdd.mock
 
+import zio.IO
+
 /**
  * Optional capabilities an adapter MAY implement beyond the total core port. An
  * adapter advertises a capability via [[MockControl.capabilities]]; for each
@@ -23,7 +25,7 @@ enum Isolation:
   case PerInstance, Correlated
 
 // Capability interfaces returned by the typed accessors on [[MockControl]].
-// Empty markers here — their operations are fleshed out in M3 (#128/#129/#132).
+// Faults/Scripting/ProxyRecord/Templating remain markers until their M3 issues.
 
 /**
  * Fault injection (latency, errors, connection resets). Capability:
@@ -32,16 +34,31 @@ enum Isolation:
 trait Faults
 
 /**
- * Single-state-token FSM per scenario. Capability:
- * [[Capability.StatefulScenarios]].
+ * Single-token FSM per scenario (#129): a request eligible in the scenario's
+ * current state serves its response and (optionally) transitions the state.
+ * Capability: [[Capability.StatefulScenarios]].
  */
-trait StatefulScenarios
+trait StatefulScenarios:
+  /**
+   * Install (replacing any existing) the named scenario on `space`, in its
+   * initial state.
+   */
+  def define(space: MockSpace, scenario: ScenarioDef): IO[MockError, Unit]
+
+  /** Return the named scenario on `space` to its initial state. */
+  def reset(space: MockSpace, name: String): IO[MockError, Unit]
 
 /**
- * Arrange/assert scenario state without driving requests. Capability:
- * [[Capability.StateInspection]].
+ * Arrange/assert scenario state without driving requests — split from
+ * [[StatefulScenarios]] because not every backend exposes direct state poking.
+ * Capability: [[Capability.StateInspection]].
  */
-trait StateInspection
+trait StateInspection:
+  /** The scenario's current state on `space`. */
+  def currentState(space: MockSpace, name: String): IO[MockError, ScenarioState]
+
+  /** Force the scenario on `space` to state `to`. */
+  def setState(space: MockSpace, name: String, to: ScenarioState): IO[MockError, Unit]
 
 /** Backend scripting hooks. Capability: [[Capability.Scripting]]. */
 trait Scripting

--- a/mock/src/main/scala/zio/bdd/mock/Dsl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Dsl.scala
@@ -119,3 +119,50 @@ object dsl:
 
   /** Build a DSL [[MockSource]] straight from rules. */
   def dslSource(rules: MockRule*): MockSource = mock(rules*).source
+
+  // --- stateful scenario builder (#129) -------------------------------------
+  // Fluent FSM builder: scenario("invoice").startingAt("Created")
+  //   .when("Created", get("/x")).respond(ok.text("a")).goTo("Paid")
+  //   .when("Paid", get("/x")).respond(ok.text("b")).stay
+  //   .build  ->  a ScenarioDef structurally identical to the hand-written one.
+
+  /**
+   * Begin a [[ScenarioDef]] named `name`, starting in
+   * [[ScenarioState.Started]].
+   */
+  def scenario(name: String): ScenarioBuilder = ScenarioBuilder(name, ScenarioState.Started, Vector.empty)
+
+  final case class ScenarioBuilder private[dsl] (
+    name: String,
+    initial: ScenarioState,
+    rules: Vector[StatefulRule]
+  ):
+    /** Override the initial state (default [[ScenarioState.Started]]). */
+    def startingAt(state: String): ScenarioBuilder = copy(initial = ScenarioState(state))
+
+    /**
+     * Begin an edge that fires while the FSM is in `state` and a request
+     * matches `request` (continue with `.respond`).
+     */
+    def when(state: String, request: RequestMatch): WhenStep = WhenStep(this, ScenarioState(state), request)
+
+    def build: ScenarioDef = ScenarioDef(name, rules.toList, initial)
+
+  final case class WhenStep private[dsl] (sb: ScenarioBuilder, whenState: ScenarioState, request: RequestMatch):
+    /** ...serves `response` (continue with `.goTo`/`.stay`). */
+    def respond(response: ResponseDef): RespondedStep = RespondedStep(sb, whenState, request, response)
+
+  final case class RespondedStep private[dsl] (
+    sb: ScenarioBuilder,
+    whenState: ScenarioState,
+    request: RequestMatch,
+    response: ResponseDef
+  ):
+    /** ...then transition to `state`. */
+    def goTo(state: String): ScenarioBuilder = add(Some(ScenarioState(state)))
+
+    /** ...and stay in the current state. */
+    def stay: ScenarioBuilder = add(None)
+
+    private def add(thenState: Option[ScenarioState]): ScenarioBuilder =
+      sb.copy(rules = sb.rules :+ StatefulRule(whenState, request, response, thenState))

--- a/mock/src/main/scala/zio/bdd/mock/model.scala
+++ b/mock/src/main/scala/zio/bdd/mock/model.scala
@@ -110,6 +110,36 @@ final case class MockRule(
 )
 
 /**
+ * A scenario FSM state token. The default initial state is
+ * [[ScenarioState.Started]].
+ */
+opaque type ScenarioState = String
+object ScenarioState:
+  val Started: ScenarioState                     = "Started"
+  def apply(value: String): ScenarioState        = value
+  extension (s: ScenarioState) def value: String = s
+
+/**
+ * One edge of a single-token scenario FSM (#129): while the scenario is in
+ * `whenState` and a request matches `request`, serve `respond` and transition
+ * to `thenState` — `None` stays in `whenState`. The portable subset both
+ * adapters (#130 WireMock, #131 Rift) honour.
+ */
+final case class StatefulRule(
+  whenState: ScenarioState,
+  request: RequestMatch,
+  respond: ResponseDef,
+  thenState: Option[ScenarioState] = None
+)
+
+/** A named single-token FSM: starts in `initial`, advances via its `rules`. */
+final case class ScenarioDef(
+  name: String,
+  rules: List[StatefulRule],
+  initial: ScenarioState = ScenarioState.Started
+)
+
+/**
  * The unit of isolation. Hides *how* isolation is achieved:
  *   - PerInstance: a unique `baseUri` per space; `inject = identity`.
  *   - Correlated: a shared `baseUri`; `inject` stamps a correlation header.

--- a/mock/src/test/scala/zio/bdd/mock/CapabilityNegotiationSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/CapabilityNegotiationSpec.scala
@@ -24,8 +24,8 @@ object CapabilityNegotiationSpec extends ZIOSpecDefault:
       if caps(c) then ZIO.succeed(a) else ZIO.fail(Unsupported(c, backendName))
 
     def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(new Faults {})
-    def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(new StatefulScenarios {})
-    def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(new StateInspection {})
+    def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(StubCaps.scenarios)
+    def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(StubCaps.stateInspection)
     def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(new Scripting {})
     def proxyRecord: IO[Unsupported, ProxyRecord]         = cap(Capability.ProxyRecord)(new ProxyRecord {})
     def templating: IO[Unsupported, Templating]           = cap(Capability.Templating)(new Templating {})

--- a/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
@@ -30,8 +30,8 @@ object MockControlModelSpec extends ZIOSpecDefault:
       if caps(c) then ZIO.succeed(a) else ZIO.fail(Unsupported(c, backend))
 
     def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(new Faults {})
-    def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(new StatefulScenarios {})
-    def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(new StateInspection {})
+    def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(StubCaps.scenarios)
+    def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(StubCaps.stateInspection)
     def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(new Scripting {})
     def proxyRecord: IO[Unsupported, ProxyRecord]         = cap(Capability.ProxyRecord)(new ProxyRecord {})
     def templating: IO[Unsupported, Templating]           = cap(Capability.Templating)(new Templating {})

--- a/mock/src/test/scala/zio/bdd/mock/StatefulDslSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/StatefulDslSpec.scala
@@ -1,0 +1,65 @@
+package zio.bdd.mock
+
+import zio.bdd.mock.dsl.*
+import zio.test.*
+
+/**
+ * The stateful-scenario model + fluent DSL (#129): the builder is pure
+ * convenience, so its output must be structurally identical to the same
+ * [[ScenarioDef]] written by hand (the same contract the rest of the DSL
+ * keeps).
+ */
+object StatefulDslSpec extends ZIOSpecDefault:
+
+  def spec = suite("StatefulScenarios model + DSL")(
+    test("ScenarioState.Started is the default initial state") {
+      assertTrue(
+        ScenarioState.Started.value == "Started",
+        ScenarioDef("s", rules = Nil).initial == ScenarioState.Started
+      )
+    },
+    test("the fluent builder yields a ScenarioDef structurally identical to the hand-written one") {
+      val built =
+        scenario("invoice")
+          .startingAt("Created")
+          .when("Created", get("/invoice"))
+          .respond(ok.text("created"))
+          .goTo("Paid")
+          .when("Paid", get("/invoice"))
+          .respond(ok.text("paid"))
+          .stay
+          .build
+
+      val handWritten =
+        ScenarioDef(
+          "invoice",
+          List(
+            StatefulRule(
+              ScenarioState("Created"),
+              RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/invoice")),
+              ResponseDef(status = 200, body = Body.Text("created")),
+              Some(ScenarioState("Paid"))
+            ),
+            StatefulRule(
+              ScenarioState("Paid"),
+              RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/invoice")),
+              ResponseDef(status = 200, body = Body.Text("paid")),
+              None // .stay
+            )
+          ),
+          ScenarioState("Created") // initial (.startingAt)
+        )
+
+      assertTrue(built == handWritten)
+    },
+    test("goTo sets thenState; stay leaves it None; the default starting state is Started") {
+      val d = scenario("s").when("Started", get("/x")).respond(ok).stay.build
+      val g = scenario("s").when("Started", get("/x")).respond(ok).goTo("Done").build
+      assertTrue(
+        d.initial == ScenarioState.Started,
+        d.rules.head.whenState == ScenarioState.Started,
+        d.rules.head.thenState.isEmpty,
+        g.rules.head.thenState.contains(ScenarioState("Done"))
+      )
+    }
+  )

--- a/mock/src/test/scala/zio/bdd/mock/StubCaps.scala
+++ b/mock/src/test/scala/zio/bdd/mock/StubCaps.scala
@@ -1,0 +1,18 @@
+package zio.bdd.mock
+
+import zio.*
+
+/**
+ * Minimal capability-instance stubs for tests that only need an advertised
+ * accessor to return *some* valid instance (the negotiation tests don't drive
+ * the capability's behaviour — they assert advertised ⇒ Right / un-advertised ⇒
+ * Unsupported).
+ */
+object StubCaps:
+  val scenarios: StatefulScenarios = new StatefulScenarios:
+    def define(space: MockSpace, scenario: ScenarioDef): IO[MockError, Unit] = ZIO.unit
+    def reset(space: MockSpace, name: String): IO[MockError, Unit]           = ZIO.unit
+
+  val stateInspection: StateInspection = new StateInspection:
+    def currentState(space: MockSpace, name: String): IO[MockError, ScenarioState]       = ZIO.succeed(ScenarioState.Started)
+    def setState(space: MockSpace, name: String, to: ScenarioState): IO[MockError, Unit] = ZIO.unit


### PR DESCRIPTION
The portable **single-token-FSM** foundation for M3 (Epic D) — no adapter (WireMock=#130, Rift=#131).

## SPI + model + DSL
- **model**: `ScenarioState` (opaque, `Started`), `StatefulRule(whenState, request, respond, thenState: Option)` (`None` = stay), `ScenarioDef(name, rules, initial = Started)`.
- **traits** (filled the previously-empty markers): `StatefulScenarios { define(space, ScenarioDef); reset(space, name) }` and `StateInspection { currentState(space, name); setState(space, name, to) }` — split because not every backend exposes direct state poking.
- **DSL**: `scenario("invoice").startingAt("Created").when("Created", get("/inv")).respond(ok.text("created")).goTo("Paid")…build`. The type-state chain (`when → respond → goTo/stay`) makes a half-built rule unrepresentable, and the output is **structurally identical** to a hand-written `ScenarioDef` (unit-tested).

## cap-stateful conformance feature
`CapStatefulScenarios` pins the normative semantics — eligibility, transition, **first-match**, unmatched-no-change, reset, locality, **concurrency**, and StateInspection — programmed against the neutral capabilities. Each scenario is `@capability`-gated, so it **SKIPs (justified)** on both adapters until one advertises `StatefulScenarios`/`StateInspection`. The matrix test asserts the correct gating.

## What's validated where
- The model + DSL semantics are **unit-validated here** (`StatefulDslSpec`, mutant-discriminated).
- The cap-stateful scenario *bodies* (HTTP-serving FSM behaviour) are first executed in **#130** — the WireMock adapter, "implemented first to validate the portable subset" — then **#131** (Rift; rift#190 shipped in v0.5.0). This SKIP-until-#130 boundary is the issue's design.

## Verification
813 tests pass; cap-stateful SKIPs justified on both adapters. `StubCaps` keeps the existing negotiation specs compiling against the now-non-empty traits.

Closes #129
Milestone: M3