### PR TITLE
feat: WireMock StatefulScenarios adapter

### DIFF
--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
@@ -85,7 +85,12 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
   // ---- the backends ----
 
   private val wiremock =
-    MockBackendUnderTest("wiremock", Provisioning.live >>> WireMock.correlated(), Set.empty, Isolation.Correlated)
+    MockBackendUnderTest(
+      "wiremock",
+      Provisioning.live >>> WireMock.correlated(),
+      Set(Capability.StatefulScenarios, Capability.StateInspection),
+      Isolation.Correlated
+    )
 
   private val riftEnabled = sys.env.contains("RIFT_IT")
   private val rift =
@@ -156,17 +161,21 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
       )
     } @@ TestAspect.withLiveClock,
-    test("cap-stateful feature is defined + capability-gated; SKIPs until an adapter advertises it (#129)") {
+    test("cap-stateful feature PASSes on WireMock; SKIPs on Rift until #131 (#130)") {
       val all = CapStatefulScenarios.all
       for
-        matrix <- ConformanceHarness.run(List(wiremock, rift), all)
-        _      <- ZIO.logInfo(s"cap-stateful matrix:\n${matrix.render}")
+        matrix   <- ConformanceHarness.run(List(wiremock, rift), all)
+        _        <- ZIO.logInfo(s"cap-stateful matrix:\n${matrix.render}")
+        wmFails   = nonPass(matrix, "wiremock", all)
+        _        <- ZIO.logInfo(s"wiremock non-pass: $wmFails").when(wmFails.nonEmpty)
+        riftCells = all.flatMap(s => matrix.cell(s.name, "rift").map(_.outcome))
       yield assertTrue(
         all.nonEmpty,
-        // Neither adapter advertises StatefulScenarios/StateInspection yet -> every cell is a justified SKIP.
-        all.forall(s => matrix.cell(s.name, "wiremock").exists(_.outcome == Outcome.Skip)),
-        all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Skip)),
-        matrix.conformant(wiremock) // justified (capability-gated) skips keep the column conformant
+        // WireMock now advertises StatefulScenarios + StateInspection -> the whole feature runs and passes.
+        all.forall(s => matrix.cell(s.name, "wiremock").exists(_.outcome == Outcome.Pass)),
+        matrix.cells.count(_.backend == "wiremock") == all.size,
+        // Rift doesn't advertise these until #131 -> every Rift cell is a justified SKIP.
+        riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
       )
     } @@ TestAspect.withLiveClock
   )

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
@@ -31,10 +31,10 @@ private[wiremock] final case class WireMockControl(
   ids: Ref[Int]
 ) extends MockControl:
 
-  import WireMockControl.SpaceState
+  import WireMockControl.{ScenarioRecord, SpaceState}
 
   def backendName: String           = "wiremock"
-  def capabilities: Set[Capability] = Set.empty
+  def capabilities: Set[Capability] = Set(Capability.StatefulScenarios, Capability.StateInspection)
 
   override def isolation: Isolation = mode match
     case WireMock.Mode.Correlated(_) => Isolation.Correlated
@@ -68,16 +68,18 @@ private[wiremock] final case class WireMockControl(
           stub     <- ZIO.attempt(StubMapping.buildFrom(stubMappingJson)).mapError(e => MockError.InvalidDefinition(msg(e)))
           server   <- WireMockControl.startServer.mapError(e => MockError.ProvisionFailed(msg(e)))
           rulesRef <- Ref.make(Vector.empty[(RuleId, StubMapping)])
+          scenRef  <- Ref.make(Map.empty[String, ScenarioRecord])
           ruleId   <- freshRuleId
           // Stop the server we just started if registration/tracking fails or is
           // interrupted before it lands in `spaces` — otherwise it leaks.
-          space <- (ZIO
-                     .attempt(server.addStubMapping(stub))
-                     .zipRight(rulesRef.set(Vector(ruleId -> stub)))
-                     .mapError(e => MockError.CommunicationError(msg(e)))
-                     .zipRight(spaces.update(_.updated(id, SpaceState(server, ownsServer = true, None, rulesRef))))
-                     .as(MockSpace(server.baseUrl(), identity, id)))
-                     .onError(_ => stop(server))
+          space <-
+            (ZIO
+              .attempt(server.addStubMapping(stub))
+              .zipRight(rulesRef.set(Vector(ruleId -> stub)))
+              .mapError(e => MockError.CommunicationError(msg(e)))
+              .zipRight(spaces.update(_.updated(id, SpaceState(server, ownsServer = true, None, rulesRef, scenRef))))
+              .as(MockSpace(server.baseUrl(), identity, id)))
+              .onError(_ => stop(server))
         yield List(space)
       case NativeSpec.Rift(_) =>
         ZIO.fail(MockError.InvalidDefinition("the WireMock adapter cannot provision a Rift native spec"))
@@ -110,7 +112,8 @@ private[wiremock] final case class WireMockControl(
     withSpace(space) { st =>
       for
         current <- st.rules.get
-        _       <- removeStubs(st.server, current.map(_._2))
+        scen    <- st.scenarios.get
+        _       <- removeStubs(st.server, current.map(_._2) ++ scen.values.flatMap(_.stubs))
         _       <- ZIO.when(st.ownsServer)(stop(st.server))
         _       <- spaces.update(_ - space.id)
       yield ()
@@ -140,11 +143,83 @@ private[wiremock] final case class WireMockControl(
     }
 
   def faults: IO[Unsupported, Faults]                   = unsupported(Capability.Faults)
-  def scenarios: IO[Unsupported, StatefulScenarios]     = unsupported(Capability.StatefulScenarios)
-  def stateInspection: IO[Unsupported, StateInspection] = unsupported(Capability.StateInspection)
+  def scenarios: IO[Unsupported, StatefulScenarios]     = ZIO.succeed(statefulScenarios)
+  def stateInspection: IO[Unsupported, StateInspection] = ZIO.succeed(stateInspector)
   def scripting: IO[Unsupported, Scripting]             = unsupported(Capability.Scripting)
   def proxyRecord: IO[Unsupported, ProxyRecord]         = unsupported(Capability.ProxyRecord)
   def templating: IO[Unsupported, Templating]           = unsupported(Capability.Templating)
+
+  // Native scenarios on the shared server are namespaced by space so two spaces
+  // declaring the same scenario name keep independent FSM state (the correlation
+  // header alone would still share one WireMock scenario, hence one state token).
+  private def scenarioName(id: SpaceId, name: String): String = s"${id.value}::$name"
+
+  private val statefulScenarios: StatefulScenarios = new StatefulScenarios:
+    def define(space: MockSpace, scenarioDef: ScenarioDef): IO[MockError, Unit] =
+      withSpace(space) { st =>
+        val nsName = scenarioName(space.id, scenarioDef.name)
+        val stubs = scenarioDef.rules.zipWithIndex.map { (r, i) =>
+          WireMockTranslation.statefulStub(
+            space.id,
+            nsName,
+            r.whenState,
+            r.thenState,
+            MockRule(r.request, r.respond),
+            i + 1,
+            st.correlation
+          )
+        }
+        for
+          existing <- st.scenarios.get
+          // Register the new edges and set the initial state, rolling back exactly the stubs we
+          // added if any step fails or is interrupted — a partial define must never orphan stubs
+          // on the shared server. The previous scenario (on re-define) is left intact until this
+          // succeeds, so a failed redefine never destroys known-good state.
+          _ <- (ZIO.attempt(stubs.foreach(st.server.addStubMapping)) *>
+                 // A scenario only exists once a stub references it, so only pin the initial
+                 // state when there are rules (an empty ScenarioDef installs nothing).
+                 ZIO.when(stubs.nonEmpty)(ZIO.attempt(st.server.setScenarioState(nsName, scenarioDef.initial.value))))
+                 .mapError(e => MockError.CommunicationError(msg(e)))
+                 .onError(_ => removeStubs(st.server, stubs.toVector).ignore)
+          _ <- existing.get(scenarioDef.name).fold(ZIO.unit)(rec => removeStubs(st.server, rec.stubs))
+          _ <- st.scenarios.update(_ + (scenarioDef.name -> ScenarioRecord(scenarioDef.initial, stubs.toVector)))
+        yield ()
+      }
+
+    def reset(space: MockSpace, name: String): IO[MockError, Unit] =
+      withSpace(space) { st =>
+        st.scenarios.get.flatMap(_.get(name) match
+          case Some(rec) =>
+            ZIO
+              .attempt(st.server.setScenarioState(scenarioName(space.id, name), rec.initial.value))
+              .mapError(e => MockError.CommunicationError(msg(e)))
+          case None => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${space.id.value}"))
+        )
+      }
+
+  private val stateInspector: StateInspection = new StateInspection:
+    def currentState(space: MockSpace, name: String): IO[MockError, ScenarioState] =
+      withSpace(space) { st =>
+        val nsName = scenarioName(space.id, name)
+        ZIO
+          .attempt(st.server.getAllScenarios.getScenarios.asScala.find(_.getName == nsName).map(_.getState))
+          .mapError(e => MockError.CommunicationError(msg(e)))
+          .flatMap {
+            case Some(s) => ZIO.succeed(ScenarioState(s))
+            case None    => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${space.id.value}"))
+          }
+      }
+
+    def setState(space: MockSpace, name: String, to: ScenarioState): IO[MockError, Unit] =
+      withSpace(space) { st =>
+        st.scenarios.get.flatMap(_.get(name) match
+          case Some(_) =>
+            ZIO
+              .attempt(st.server.setScenarioState(scenarioName(space.id, name), to.value))
+              .mapError(e => MockError.CommunicationError(msg(e)))
+          case None => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${space.id.value}"))
+        )
+      }
 
   // Stop every server this adapter still owns — the layer's scope finalizer.
   private[wiremock] def stopAll: UIO[Unit] =
@@ -161,9 +236,10 @@ private[wiremock] final case class WireMockControl(
       rules    <- rulesOf(src)
       id       <- freshSpaceId(src.name)
       rulesRef <- Ref.make(Vector.empty[(RuleId, StubMapping)])
+      scenRef  <- Ref.make(Map.empty[String, ScenarioRecord])
       corr      = correlationOf
       server   <- serverFor(id)
-      st        = SpaceState(server, ownsServer = corr.isEmpty, corr, rulesRef)
+      st        = SpaceState(server, ownsServer = corr.isEmpty, corr, rulesRef, scenRef)
       // If a rule fails mid-batch the space is never tracked, so destroy can
       // never reach it: undo its stubs (and stop its own server) here, or they
       // orphan on the shared server.
@@ -248,8 +324,13 @@ private[wiremock] object WireMockControl:
     server: WireMockServer,
     ownsServer: Boolean,
     correlation: Option[Correlation],
-    rules: Ref[Vector[(RuleId, StubMapping)]]
+    rules: Ref[Vector[(RuleId, StubMapping)]],
+    scenarios: Ref[Map[String, ScenarioRecord]]
   )
+
+  // A defined scenario's initial state (for `reset`) plus the stubs it installed
+  // (so `destroy` removes them from the shared server — they are not in `rules`).
+  final case class ScenarioRecord(initial: ScenarioState, stubs: Vector[StubMapping])
 
   /**
    * Build the adapter for `mode`, starting the shared server in Correlated mode

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockTranslation.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockTranslation.scala
@@ -20,17 +20,47 @@ private[wiremock] object WireMockTranslation:
    * `None` (the space owns its server outright).
    */
   def stub(id: SpaceId, rule: MockRule, priority: Priority, correlation: Option[Correlation]): StubMapping =
-    val base = methodAndUrl(rule.`match`)
-    rule.`match`.headers.foreach((k, v) => base.withHeader(k, valuePattern(v)))
-    rule.`match`.query.foreach((k, v) => base.withQueryParam(k, valuePattern(v)))
-    rule.`match`.body.foreach(b => base.withRequestBody(bodyPattern(b)))
-    correlation.foreach(c => base.withHeader(c.header, c.matcher(id)))
+    val base = requestBuilder(id, rule.`match`, correlation)
     base.atPriority(priority match
       case Priority.Overlay => 1
       case Priority.Base    => 10
     )
     base.withId(UUID.randomUUID())
     base.willReturn(response(rule.respond)).build()
+
+  /**
+   * Build one edge of a scenario FSM (#130): the request matcher (plus the
+   * space's correlation header) gated by
+   * `inScenario(name).whenScenarioStateIs`, optionally transitioning via
+   * `willSetStateTo` (`None` = stay). `priority` comes from the rule's
+   * declaration index so that among rules eligible in the same state, the
+   * first-declared wins — WireMock otherwise breaks an equal-priority tie in
+   * favour of the most-recently-added stub.
+   */
+  def statefulStub(
+    id: SpaceId,
+    scenarioName: String,
+    whenState: ScenarioState,
+    thenState: Option[ScenarioState],
+    rule: MockRule,
+    priority: Int,
+    correlation: Option[Correlation]
+  ): StubMapping =
+    val sc = requestBuilder(id, rule.`match`, correlation)
+      .inScenario(scenarioName)
+      .whenScenarioStateIs(whenState.value)
+    thenState.foreach(s => sc.willSetStateTo(s.value))
+    sc.atPriority(priority)
+    sc.withId(UUID.randomUUID())
+    sc.willReturn(response(rule.respond)).build()
+
+  private def requestBuilder(id: SpaceId, m: RequestMatch, correlation: Option[Correlation]): MappingBuilder =
+    val base = methodAndUrl(m)
+    m.headers.foreach((k, v) => base.withHeader(k, valuePattern(v)))
+    m.query.foreach((k, v) => base.withQueryParam(k, valuePattern(v)))
+    m.body.foreach(b => base.withRequestBody(bodyPattern(b)))
+    correlation.foreach(c => base.withHeader(c.header, c.matcher(id)))
+    base
 
   private def methodAndUrl(m: RequestMatch): MappingBuilder =
     val url = m.path match

--- a/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
+++ b/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
@@ -2,6 +2,7 @@ package zio.bdd.mock.wiremock
 
 import zio.*
 import zio.bdd.mock.*
+import zio.bdd.mock.dsl.*
 import zio.test.*
 
 import java.net.{URI, http as jhttp}
@@ -46,7 +47,10 @@ object WireMockControlSpec extends ZIOSpecDefault:
   private val perInstance = PortAllocator.layer >>> Provisioning.layer >>> WireMock.perInstance
   private val traceparent = PortAllocator.layer >>> Provisioning.layer >>> WireMock.correlated(Correlation.traceparent)
 
-  private def die[A](z: IO[MockError, A]): UIO[A] = z.orDieWith(e => new RuntimeException(e.toString))
+  private def die[A](z: IO[MockError, A]): UIO[A]    = z.orDieWith(e => new RuntimeException(e.toString))
+  private def dieU[A](z: IO[Unsupported, A]): UIO[A] = z.orDieWith(u => new RuntimeException(u.toString))
+
+  private val emptySource = MockSource.Dsl(MockSpec(Nil))
 
   // Send straight to a base URI with no inject (and an optional raw header), to
   // model a SUT that did NOT carry the space tag.
@@ -167,7 +171,75 @@ object WireMockControlSpec extends ZIOSpecDefault:
           ra      <- die(control.received(a))
           rb      <- die(control.received(b))
         yield assertTrue(ra.size == 1, rb.size == 2) // received filters by space header on the shared server
-      }
+      },
+      // --- stateful scenarios (#130): edges the portable cap-stateful catalog can't express ---
+      suite("stateful scenarios")(
+        test("define replaces an existing scenario of the same name (replacing any existing)") {
+          for
+            control <- ZIO.service[MockControl]
+            ss      <- dieU(control.scenarios)
+            a       <- die(control.provision(emptySource)).map(_.head)
+            _       <- die(ss.define(a, scenario("sc").when("Started", get("/x")).respond(ok.text("v1")).stay.build))
+            r1      <- SutClient.make(a).send(Method.Get, "/x").orDie
+            _       <- die(ss.define(a, scenario("sc").when("Started", get("/x")).respond(ok.text("v2")).stay.build))
+            r2      <- SutClient.make(a).send(Method.Get, "/x").orDie
+          yield assertTrue(r1.body == "v1", r2.body == "v2") // the old edge is gone, not shadowed
+        },
+        test("a non-Started initial state is honoured by define and restored by reset") {
+          val oc =
+            scenario("oc")
+              .startingAt("Open")
+              .when("Open", get("/o"))
+              .respond(ok.text("open"))
+              .goTo("Closed")
+              .when("Closed", get("/o"))
+              .respond(ok.text("closed"))
+              .stay
+              .build
+          for
+            control <- ZIO.service[MockControl]
+            ss      <- dieU(control.scenarios)
+            si      <- dieU(control.stateInspection)
+            a       <- die(control.provision(emptySource)).map(_.head)
+            _       <- die(ss.define(a, oc))
+            s0      <- die(si.currentState(a, "oc"))
+            r1      <- SutClient.make(a).send(Method.Get, "/o").orDie // Open -> "open", -> Closed
+            r2      <- SutClient.make(a).send(Method.Get, "/o").orDie // Closed -> "closed"
+            _       <- die(ss.reset(a, "oc"))
+            s1      <- die(si.currentState(a, "oc"))
+            r3      <- SutClient.make(a).send(Method.Get, "/o").orDie // back in Open -> "open"
+          yield assertTrue(
+            s0 == ScenarioState("Open"),
+            r1.body == "open",
+            r2.body == "closed",
+            s1 == ScenarioState("Open"),
+            r3.body == "open"
+          )
+        },
+        test("reset / currentState / setState of an unknown scenario fail with InvalidDefinition") {
+          for
+            control <- ZIO.service[MockControl]
+            ss      <- dieU(control.scenarios)
+            si      <- dieU(control.stateInspection)
+            a       <- die(control.provision(emptySource)).map(_.head)
+            e1      <- ss.reset(a, "ghost").either
+            e2      <- si.currentState(a, "ghost").either
+            e3      <- si.setState(a, "ghost", ScenarioState("X")).either
+            expected = MockError.InvalidDefinition(s"no scenario 'ghost' on space ${a.id.value}")
+          yield assertTrue(e1 == Left(expected), e2 == Left(expected), e3 == Left(expected))
+        },
+        test("destroy removes the scenario's stubs from the shared server") {
+          for
+            control <- ZIO.service[MockControl]
+            ss      <- dieU(control.scenarios)
+            a       <- die(control.provision(emptySource)).map(_.head)
+            _       <- die(ss.define(a, scenario("sc").when("Started", get("/x")).respond(ok.text("v1")).stay.build))
+            before  <- SutClient.make(a).send(Method.Get, "/x").orDie
+            _       <- die(control.destroy(a))
+            after   <- SutClient.make(a).send(Method.Get, "/x").orDie
+          yield assertTrue(before.status == 200, before.body == "v1", after.status == 404)
+        }
+      )
     ).provide(correlated),
     test("the PerInstance-mode adapter reports PerInstance isolation") {
       ZIO.serviceWith[MockControl](c => assertTrue(c.isolation == Isolation.PerInstance))


### PR DESCRIPTION
The WireMock `StatefulScenarios` + `StateInspection` adapter — the constrained backend, implemented first to validate the portable subset (#129). It flips the `cap-stateful` conformance feature from SKIP to **PASS on WireMock**.

## Mapping
- Each `StatefulRule` → a WireMock stub with `inScenario(name).whenScenarioStateIs(whenState).willSetStateTo(thenState?)` (`None` = stay), carrying the space's correlation header.
- **Locality**: the WireMock scenario name is namespaced by space id (`${space.id}::name`) — a shared scenario name would otherwise mean one shared FSM state token across spaces (correlation only filters request *matching*, not which token the FSM reads/writes).
- **First-match**: ascending `atPriority(index+1)` so the first-declared rule wins among same-state candidates (WireMock breaks an equal-priority tie in favour of the most-recently-added stub).
- **StateInspection**: `currentState` via `getAllScenarios`, `setState` via `setScenarioState`; both keyed by the namespaced name.

## Robustness
- `define` registers the new edges with `.onError` rollback and drops the previous scenario's stubs only on success — a failed (re)define neither orphans stubs on the shared server nor destroys known-good state.
- `destroy` removes the scenario stubs too (they live in the per-space scenario record, not `rules`).
- `reset`/`currentState`/`setState` of an unknown scenario fail with `InvalidDefinition` (consistent error model).

## Verification
- The cap-stateful matrix test asserts all 7 scenarios **PASS on WireMock** (eligibility+transition, unmatched-no-change, reset, locality, first-match, 8-space concurrency, StateInspection); Rift cells **SKIP** until #131.
- A focused `WireMockControlSpec` suite covers the edges the portable catalog can't express: re-define replacement, a non-`Started` initial state, the `InvalidDefinition` paths, and destroy-removes-scenario-stubs.
- 817 tests pass; scalafmt clean.

Closes #130
Milestone: M3