### PR TITLE
build: bump rift-proxy image to v0.6.0

### DIFF
--- a/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
@@ -52,12 +52,12 @@ object RiftMode:
  */
 object Rift:
 
-  // Pinned to v0.5.0. Floor is v0.4.0: Correlated isolation (#156) needs the
+  // Pinned to v0.6.0. Floor is v0.4.0: Correlated isolation (#156) needs the
   // space-scoped stub + per-space teardown endpoints (EtaCassiopeia/rift#223),
   // first shipped in v0.4.0 — which also supersedes the older v0.2.0 floor (the
   // rift#207 release where DELETE /imposters/:port tears down keep-alive
   // connections so a destroyed imposter stops serving a pooled client).
-  val DefaultImage: String     = "zainalpour/rift-proxy:v0.5.0"
+  val DefaultImage: String     = "zainalpour/rift-proxy:v0.6.0"
   val DefaultAdminPort: Int    = 2525
   val DefaultImposterBase: Int = 4545
   val DefaultPoolSize: Int     = 16


### PR DESCRIPTION
Pin the Rift container image to **v0.6.0** (from v0.5.0).

v0.6.0 ships real connection-level TCP faults (rift#242, resolving the issue filed for #128) and multi-value header support for responses + recorded requests (rift#241, resolving the issue filed for #162). The multi-value change is wire-compatible — a single header string still deserialises — and the adapter doesn't yet exercise faults, so this bump is behaviour-neutral. The `rift-it` job verifies it against the real container. Floor stays v0.4.0.

Standalone build bump → master.