### PR TITLE
feat: multi-value header support in the mock model (response + recorded requests)

### DIFF
--- a/conformance/src/main/scala/zio/bdd/mock/conformance/CoreConformanceScenarios.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/CoreConformanceScenarios.scala
@@ -11,18 +11,17 @@ import zio.bdd.mock.*
  * adapter.
  *
  * Scope is deliberately the cross-adapter intersection both Rift and WireMock
- * translate faithfully. Two model limits keep multi-value-header scenarios out:
- * `ResponseDef.headers`/`RecordedRequest.headers` are `Map[String, String]`
- * (single value per key), and WireMock records only the first value +
- * lowercases recorded header keys — so scenarios use single-value headers and
- * never assert a recorded request-header by exact case. (Multi-value headers
- * need a model change — a follow-up, not #125.)
+ * translate faithfully. Multi-value headers are in scope as of #162 (the
+ * `Headers` model): the `multiValueHeaders` group asserts both values survive a
+ * response and a recorded request on both adapters. Recorded header keys are
+ * canonicalised to lower-case (see [[Headers]]), so assertions key by the
+ * lower-case name rather than the exact sent case.
  */
 object CoreConformanceScenarios:
 
   // lazy: the group vals below initialise after this declaration in source order.
   lazy val all: List[ConformanceScenario] =
-    matching ++ responseFidelity ++ precedence ++ lifecycle ++ verification
+    matching ++ responseFidelity ++ precedence ++ lifecycle ++ verification ++ multiValueHeaders
 
   // ---- helpers ------------------------------------------------------------------
 
@@ -120,7 +119,7 @@ object CoreConformanceScenarios:
                  text(200, "ok")
                )
              )
-        hit  <- SutClient.make(s).send(Method.Get, "/h", headers = Map("X-Tok" -> "bearer-123"))
+        hit  <- SutClient.make(s).send(Method.Get, "/h", headers = Headers("X-Tok" -> "bearer-123"))
         miss <- SutClient.make(s).send(Method.Get, "/h")
         _    <- ensure(hit.status == 200 && miss.status == 404, s"header: hit=${hit.status} miss=${miss.status}")
       yield ()
@@ -188,9 +187,9 @@ object CoreConformanceScenarios:
       )
       for
         s         <- space(control, MockRule(rm, text(200, "ok")))
-        hit       <- SutClient.make(s).send(Method.Post, "/c", headers = Map("X-K" -> "v"), body = Some("zzz"))
+        hit       <- SutClient.make(s).send(Method.Post, "/c", headers = Headers("X-K" -> "v"), body = Some("zzz"))
         noHeader  <- SutClient.make(s).send(Method.Post, "/c", body = Some("zzz"))
-        wrongBody <- SutClient.make(s).send(Method.Post, "/c", headers = Map("X-K" -> "v"), body = Some("qqq"))
+        wrongBody <- SutClient.make(s).send(Method.Post, "/c", headers = Headers("X-K" -> "v"), body = Some("qqq"))
         _ <- ensure(
                hit.status == 200 && noHeader.status == 404 && wrongBody.status == 404,
                s"composite: hit=${hit.status} noHeader=${noHeader.status} wrongBody=${wrongBody.status}"
@@ -207,8 +206,8 @@ object CoreConformanceScenarios:
               text(200, "ok")
             )
           )
-        hit  <- SutClient.make(s).send(Method.Get, "/hm", headers = Map("X-Tok" -> "Bearer abc"))
-        miss <- SutClient.make(s).send(Method.Get, "/hm", headers = Map("X-Tok" -> "Basic abc"))
+        hit  <- SutClient.make(s).send(Method.Get, "/hm", headers = Headers("X-Tok" -> "Bearer abc"))
+        miss <- SutClient.make(s).send(Method.Get, "/hm", headers = Headers("X-Tok" -> "Basic abc"))
         _    <- ensure(hit.status == 200 && miss.status == 404, s"header-matches: hit=${hit.status} miss=${miss.status}")
       yield ()
     },
@@ -259,12 +258,12 @@ object CoreConformanceScenarios:
                control,
                MockRule(
                  RequestMatch(path = PathMatch.Exact("/resp")),
-                 ResponseDef(status = 418, headers = Map("X-R" -> "rv"), body = Body.Text("teapot"))
+                 ResponseDef(status = 418, headers = Headers("X-R" -> "rv"), body = Body.Text("teapot"))
                )
              )
         r <- SutClient.make(s).send(Method.Get, "/resp")
         _ <- ensure(
-               r.status == 418 && r.body == "teapot" && r.headers.get("x-r").contains("rv"),
+               r.status == 418 && r.body == "teapot" && r.headers.first("x-r").contains("rv"),
                s"resp: status=${r.status} body=${r.body} headers=${r.headers}"
              )
       yield ()
@@ -435,6 +434,34 @@ object CoreConformanceScenarios:
                reqs.exists(r => r.method == Method.Get && r.uri == "/e") && !reqs.exists(_.uri == "/never"),
                s"set: reqs=$reqs"
              )
+      yield ()
+    }
+  )
+
+  // ---- multi-value headers: both values survive in each direction (#162) --------
+
+  private val multiValueHeaders = List(
+    scen("response-fidelity: a multi-value response header reaches the SUT intact (#162)") { control =>
+      for
+        s <- space(
+               control,
+               MockRule(
+                 RequestMatch(path = PathMatch.Exact("/mvh")),
+                 ResponseDef(status = 200, headers = Headers.multi("X-Multi" -> List("a", "b")), body = Body.Text("ok"))
+               )
+             )
+        r <- SutClient.make(s).send(Method.Get, "/mvh")
+        vs = r.headers.values("x-multi")
+        _ <- ensure(r.status == 200 && vs.size == 2 && vs.toSet == Set("a", "b"), s"multi response: ${r.headers}")
+      yield ()
+    },
+    scen("record-fidelity: a multi-value request header is surfaced by received (#162)") { control =>
+      for
+        s    <- space(control, rule("/mvr", "ok"))
+        _    <- SutClient.make(s).send(Method.Get, "/mvr", headers = Headers.multi("X-Multi" -> List("a", "b")))
+        reqs <- control.received(s).mapError(asT)
+        vs    = reqs.find(_.uri == "/mvr").map(_.headers.values("x-multi")).getOrElse(Nil)
+        _    <- ensure(vs.size == 2 && vs.toSet == Set("a", "b"), s"multi recorded: ${reqs.map(_.headers)}")
       yield ()
     }
   )

--- a/core/src/main/scala/zio/bdd/mock/steps/MockSteps.scala
+++ b/core/src/main/scala/zio/bdd/mock/steps/MockSteps.scala
@@ -13,7 +13,7 @@ import scala.jdk.CollectionConverters.*
  * The last response from sending a request through a mock space — staged per
  * scenario so the response-assertion steps can read it.
  */
-final case class MockResponse(status: Int, body: String, headers: Map[String, String])
+final case class MockResponse(status: Int, body: String, headers: Headers)
 
 /**
  * Mixin providing ready-made Gherkin steps for the portable mocking SPI,
@@ -81,7 +81,7 @@ trait MockSteps[R, S] { self: ZIOSteps[R & MockControl, S] =>
 
   Then("the space response header " / string / " is " / string) { (name: String, expected: String) =>
     stagedResponse.flatMap { r =>
-      r.headers.get(name.toLowerCase) match
+      r.headers.first(name) match
         case Some(actual) => Assertions.assertEquals(actual, expected, s"response header '$name' mismatch")
         case None =>
           ZIO.fail(
@@ -162,20 +162,17 @@ trait MockSteps[R, S] { self: ZIOSteps[R & MockControl, S] =>
     methodOf(method).flatMap { m =>
       val injected = space.inject(HttpRequest(m, space.baseUri + path))
       ZIO.attemptBlocking {
-        val builder = injected.headers.foldLeft(JHttpRequest.newBuilder(URI.create(injected.uri))) { case (b, (k, v)) =>
-          b.header(k, v)
+        val builder = injected.headers.entries.foldLeft(JHttpRequest.newBuilder(URI.create(injected.uri))) {
+          case (b, (k, vs)) => vs.foldLeft(b)((bb, v) => bb.header(k, v))
         }
         val publisher = injected.body match
           case Some(body) => JHttpRequest.BodyPublishers.ofString(body)
           case None       => JHttpRequest.BodyPublishers.noBody()
         val request  = builder.method(injected.method.toString.toUpperCase, publisher).build()
         val response = HttpClient.newHttpClient().send(request, JHttpResponse.BodyHandlers.ofString())
-        val headers = response
-          .headers()
-          .map()
-          .asScala
-          .collect { case (k, vs) if !vs.isEmpty => k.toLowerCase -> vs.asScala.mkString(", ") }
-          .toMap
+        val headers = response.headers().map().asScala.foldLeft(Headers.empty) { case (h, (k, vs)) =>
+          vs.asScala.foldLeft(h)((acc, v) => acc.add(k, v))
+        }
         MockResponse(response.statusCode, response.body, headers)
       }
     }

--- a/core/src/test/scala/zio/bdd/mock/steps/MockStepsSpec.scala
+++ b/core/src/test/scala/zio/bdd/mock/steps/MockStepsSpec.scala
@@ -105,7 +105,7 @@ object MockStepsSpec extends ZIOSpecDefault:
                     RecordedRequest(
                       methodOf(exchange.getRequestMethod),
                       path,
-                      Map.empty,
+                      Headers.empty,
                       Option(body).filter(_.nonEmpty)
                     )
                   )

--- a/mock/src/main/scala/zio/bdd/mock/Dsl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Dsl.scala
@@ -97,8 +97,9 @@ object dsl:
     def base64(value: String): ResponseDef = r.copy(body = Body.Base64(value))
     def withBody(b: Body): ResponseDef     = r.copy(body = b)
     def withStatus(code: Int): ResponseDef = r.copy(status = code)
+    // Appends, so calling it twice for one key emits a multi-value response header (#162).
     def withHeader(name: String, value: String): ResponseDef =
-      r.copy(headers = r.headers.updated(name, value))
+      r.copy(headers = r.headers.add(name, value))
     def withLatency(d: Duration): ResponseDef = r.copy(delay = Some(d))
 
   // --- rule + spec assembly -------------------------------------------------

--- a/mock/src/main/scala/zio/bdd/mock/SutClient.scala
+++ b/mock/src/main/scala/zio/bdd/mock/SutClient.scala
@@ -7,7 +7,7 @@ import java.net.http.{HttpClient, HttpRequest as JHttpRequest, HttpResponse as J
 import scala.jdk.CollectionConverters.*
 
 /** A response the SUT received from its (mocked) dependency. */
-final case class SutResponse(status: Int, body: String, headers: Map[String, String])
+final case class SutResponse(status: Int, body: String, headers: Headers)
 
 /**
  * The SUT's dependency client, bound to one [[MockSpace]]. It derives the
@@ -37,7 +37,7 @@ trait SutClient:
   def send(
     method: Method,
     path: String,
-    headers: Map[String, String] = Map.empty,
+    headers: Headers = Headers.empty,
     body: Option[String] = None
   ): IO[Throwable, SutResponse]
 
@@ -53,24 +53,23 @@ object SutClient:
     def send(
       method: Method,
       path: String,
-      headers: Map[String, String],
+      headers: Headers,
       body: Option[String]
     ): IO[Throwable, SutResponse] =
       val injected = space.inject(HttpRequest(method, space.baseUri + path, headers, body))
       ZIO.attemptBlocking {
-        val builder = injected.headers.foldLeft(JHttpRequest.newBuilder(URI.create(injected.uri))) { case (b, (k, v)) =>
-          b.header(k, v)
+        // One builder.header(k, v) per value so multi-value request headers go on the wire intact.
+        val builder = injected.headers.entries.foldLeft(JHttpRequest.newBuilder(URI.create(injected.uri))) {
+          case (b, (k, vs)) => vs.foldLeft(b)((bb, v) => bb.header(k, v))
         }
         val publisher = injected.body match
           case Some(content) => JHttpRequest.BodyPublishers.ofString(content)
           case None          => JHttpRequest.BodyPublishers.noBody()
         val request  = builder.method(injected.method.toString.toUpperCase, publisher).build()
         val response = HttpClient.newHttpClient().send(request, JHttpResponse.BodyHandlers.ofString())
-        val respHeaders = response
-          .headers()
-          .map()
-          .asScala
-          .collect { case (k, vs) if !vs.isEmpty => k.toLowerCase -> vs.asScala.mkString(", ") }
-          .toMap
+        // Preserve every value per response header key (Headers canonicalises keys to lower-case).
+        val respHeaders = response.headers().map().asScala.foldLeft(Headers.empty) { case (h, (k, vs)) =>
+          vs.asScala.foldLeft(h)((acc, v) => acc.add(k, v))
+        }
         SutResponse(response.statusCode, response.body, respHeaders)
       }

--- a/mock/src/main/scala/zio/bdd/mock/model.scala
+++ b/mock/src/main/scala/zio/bdd/mock/model.scala
@@ -61,6 +61,48 @@ object SpaceId:
   extension (id: SpaceId) def value: String = id
 
 /**
+ * HTTP headers with multi-value support (#162). Keys are canonicalised to
+ * lower-case so cross-adapter assertions are well-defined — WireMock
+ * lower-cases recorded keys, Rift preserves them, and this normalises both.
+ * Values keep their insertion order per key.
+ */
+opaque type Headers = Map[String, List[String]]
+object Headers:
+  val empty: Headers = Map.empty
+
+  /** One value per key — the common case (`Headers("Accept" -> "json")`). */
+  def apply(pairs: (String, String)*): Headers =
+    pairs.foldLeft(empty)((h, kv) => h.add(kv._1, kv._2))
+
+  /**
+   * Several values per key (`Headers.multi("Set-Cookie" -> List("a", "b"))`).
+   */
+  def multi(entries: (String, List[String])*): Headers =
+    entries.foldLeft(empty)((h, kv) => kv._2.foldLeft(h)((acc, v) => acc.add(kv._1, v)))
+
+  /** Lift a single-valued map (keys canonicalised). */
+  def fromSingle(m: Map[String, String]): Headers =
+    m.foldLeft(empty)((h, kv) => h.add(kv._1, kv._2))
+
+  extension (h: Headers)
+    /**
+     * Append `value` under `key` (key lower-cased), preserving existing values.
+     */
+    def add(key: String, value: String): Headers =
+      val k = key.toLowerCase
+      h.updated(k, h.getOrElse(k, Nil) :+ value)
+    def values(key: String): List[String]  = h.getOrElse(key.toLowerCase, Nil)
+    def first(key: String): Option[String] = values(key).headOption
+    def contains(key: String): Boolean     = h.contains(key.toLowerCase)
+    def keys: Set[String]                  = h.keySet
+    def isEmpty: Boolean                   = h.isEmpty
+    def nonEmpty: Boolean                  = h.nonEmpty
+
+    /** The underlying multimap (lower-cased keys, ordered values). */
+    def toMultiMap: Map[String, List[String]] = h
+    def entries: List[(String, List[String])] = h.toList
+
+/**
  * Portable HTTP request the SUT issues. [[MockSpace.inject]] decorates it (e.g.
  * rewriting the base URI or adding a correlation header) so a mock space can be
  * reached under share-nothing isolation. SUT-side wiring lands in #117.
@@ -68,7 +110,7 @@ object SpaceId:
 final case class HttpRequest(
   method: Method,
   uri: String,
-  headers: Map[String, String] = Map.empty,
+  headers: Headers = Headers.empty,
   body: Option[String] = None
 )
 
@@ -78,7 +120,7 @@ final case class HttpRequest(
 final case class RecordedRequest(
   method: Method,
   uri: String,
-  headers: Map[String, String] = Map.empty,
+  headers: Headers = Headers.empty,
   body: Option[String] = None
 )
 
@@ -97,7 +139,7 @@ final case class RequestMatch(
 /** The response a matched rule serves. */
 final case class ResponseDef(
   status: Int = 200,
-  headers: Map[String, String] = Map.empty,
+  headers: Headers = Headers.empty,
   body: Body = Body.Empty,
   delay: Option[Duration] = None
 )

--- a/mock/src/test/scala/zio/bdd/mock/DslSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/DslSpec.scala
@@ -114,7 +114,7 @@ object DslSpec extends ZIOSpecDefault:
       test("withHeader / withStatus / withLatency refine the response") {
         assertTrue(
           ok.withHeader("Content-Type", "application/json") ==
-            ResponseDef(status = 200, headers = Map("Content-Type" -> "application/json")),
+            ResponseDef(status = 200, headers = Headers("Content-Type" -> "application/json")),
           ok.withStatus(204) == ResponseDef(status = 204),
           ok.json("{}").withLatency(50.millis) ==
             ResponseDef(status = 200, body = Body.Json("{}"), delay = Some(50.millis))
@@ -152,7 +152,7 @@ object DslSpec extends ZIOSpecDefault:
           ),
           respond = ResponseDef(
             status = 201,
-            headers = Map("Location" -> "/users/1"),
+            headers = Headers("Location" -> "/users/1"),
             body = Body.Json("""{"ok":true}"""),
             delay = Some(10.millis)
           ),

--- a/mock/src/test/scala/zio/bdd/mock/HeadersSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/HeadersSpec.scala
@@ -1,0 +1,47 @@
+package zio.bdd.mock
+
+import zio.test.*
+
+/**
+ * The [[Headers]] value type (#162): multi-value per key, canonical lower-case
+ * keys (so cross-adapter recorded-header assertions are well-defined), and
+ * insertion-ordered values.
+ */
+object HeadersSpec extends ZIOSpecDefault:
+
+  def spec = suite("Headers")(
+    test("keys are canonicalised to lower-case for construction, lookup, and equality") {
+      val h = Headers("Content-Type" -> "json")
+      assertTrue(
+        h.first("content-type").contains("json"),
+        h.first("CONTENT-TYPE").contains("json"), // lookup is case-insensitive
+        h.contains("Content-Type"),
+        h.keys == Set("content-type"),
+        h == Headers("content-type" -> "json") // mixed/lower construction compare equal
+      )
+    },
+    test("multiple values per key are preserved in insertion order") {
+      val h = Headers.multi("X-Multi" -> List("a", "b"))
+      assertTrue(
+        h.values("x-multi") == List("a", "b"),
+        h.first("x-multi").contains("a")
+      )
+    },
+    test("add appends under a key, building a multi-value header") {
+      val h = Headers.empty.add("Set-Cookie", "a=1").add("set-cookie", "b=2")
+      assertTrue(h.values("set-cookie") == List("a=1", "b=2"), h.keys == Set("set-cookie"))
+    },
+    test("a missing key yields no values; empty is empty; an empty value list adds no key") {
+      assertTrue(
+        Headers.empty.isEmpty,
+        Headers.empty.values("nope") == Nil,
+        Headers.empty.first("nope").isEmpty,
+        Headers("a" -> "1").nonEmpty,
+        Headers.multi("X" -> Nil) == Headers.empty, // a key with no values is absent
+        !Headers.multi("X" -> Nil).contains("X")
+      )
+    },
+    test("fromSingle lifts a single-valued map with canonical keys") {
+      assertTrue(Headers.fromSingle(Map("A" -> "1", "B" -> "2")) == Headers("a" -> "1", "b" -> "2"))
+    }
+  )

--- a/mock/src/test/scala/zio/bdd/mock/SutClientSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/SutClientSpec.scala
@@ -26,7 +26,7 @@ object SutClientSpec extends ZIOSpecDefault:
     def correlatedSpace(id: String): MockSpace =
       MockSpace(
         s"http://localhost:$port",
-        req => req.copy(headers = req.headers + ("x-correlation-id" -> id)),
+        req => req.copy(headers = req.headers.add("x-correlation-id", id)),
         SpaceId(id)
       )
 
@@ -179,9 +179,9 @@ object SutClientSpec extends ZIOSpecDefault:
             down <- client.send(Method.Get, "/down")
           yield assertTrue(
             ok.status == 200,
-            ok.body == "hello",                            // request body sent + response body decoded
-            ok.headers.get("x-served-by").contains("dep"), // header normalised to lower-case
-            down.status == 503                             // non-2xx surfaced as a SutResponse, not a failure
+            ok.body == "hello",                              // request body sent + response body decoded
+            ok.headers.first("x-served-by").contains("dep"), // header normalised to lower-case
+            down.status == 503                               // non-2xx surfaced as a SutResponse, not a failure
           )
         }
       }

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -221,7 +221,7 @@ private[rift] final case class RiftMockControl(
       _        <- registerStubs(port, flowId, tagged).onError(_ => deleteSpace(port, flowId).ignore)
       rulesRef <- Ref.make(tagged)
       _        <- correlated.update(_.updated(id, CorrSpace(port, flowId, corr.header, rulesRef)))
-    yield MockSpace(endpoint.baseUriFor(port), req => req.copy(headers = req.headers + (corr.header -> flowId)), id)
+    yield MockSpace(endpoint.baseUriFor(port), req => req.copy(headers = req.headers.add(corr.header, flowId)), id)
 
   // Create the one shared imposter on first Correlated provision (race-safe).
   private def ensureSharedImposter(corr: Correlation): IO[MockError, Int] =

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -93,7 +93,14 @@ private[rift] object RiftProtocol:
   def response(r: ResponseDef): Json =
     val headers =
       if r.headers.isEmpty then Nil
-      else List("headers" -> Json.Obj(r.headers.toList.map((k, v) => k -> Json.Str(v))*))
+      else
+        // Rift's wire accepts a string for a single value and an array for many (rift#241).
+        List("headers" -> Json.Obj(r.headers.entries.map { (k, vs) =>
+          k -> (vs match
+            case v :: Nil => Json.Str(v)
+            case many     => Json.Arr(many.map(Json.Str(_))*)
+          )
+        }*))
     val body = r.body match
       case Body.Empty     => Nil
       case Body.Text(v)   => List("body" -> Json.Str(v))
@@ -125,10 +132,12 @@ private[rift] object RiftProtocol:
   // Mountebank wire JSON -> canonical model (recorded requests)
   // ---------------------------------------------------------------------------
 
+  // headers decode as the raw AST per key so we accept both Rift's single-value
+  // string form (`"k": "v"`) and the multi-value array form (`"k": ["a", "b"]`, rift#241).
   private case class WireReq(
     method: String,
     path: String,
-    headers: Option[Map[String, String]] = None,
+    headers: Option[Map[String, Json]] = None,
     body: Option[String] = None
   ) derives JsonDecoder
   private case class WireView(requests: Option[List[WireReq]] = None) derives JsonDecoder
@@ -146,7 +155,14 @@ private[rift] object RiftProtocol:
     arrayJson.fromJson[List[WireReq]].map(_.map(toRecorded))
 
   private def toRecorded(r: WireReq): RecordedRequest =
-    RecordedRequest(methodFromWire(r.method), r.path, r.headers.getOrElse(Map.empty), r.body)
+    val headers = r.headers.getOrElse(Map.empty).foldLeft(Headers.empty) { case (h, (k, json)) =>
+      json match
+        case Json.Str(v) => h.add(k, v)
+        case Json.Arr(elems) =>
+          elems.foldLeft(h)((acc, j) => j match { case Json.Str(v) => acc.add(k, v); case _ => acc })
+        case _ => h
+    }
+    RecordedRequest(methodFromWire(r.method), r.path, headers, r.body)
 
   // ---------------------------------------------------------------------------
   // helpers

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -117,7 +117,7 @@ object RiftMockControlSpec extends ZIOSpecDefault:
                  s"""{"port":$port,"requests":[{"method":"GET","path":"/ping","headers":{},"body":null}]}"""
                )
           recvE <- control.received(s).either
-        yield assertTrue(recvE == Right(List(RecordedRequest(Method.Get, "/ping", Map.empty, None))))
+        yield assertTrue(recvE == Right(List(RecordedRequest(Method.Get, "/ping", Headers.empty, None))))
       }
     },
     test("addRule/replaceRules/removeRule hit the stubs sub-resource endpoints") {
@@ -237,7 +237,7 @@ object RiftMockControlSpec extends ZIOSpecDefault:
           deleted  <- fake.deletedPorts.get
           globals  <- fake.globalDeletes.get
         yield assertTrue(
-          recvE == Right(List(RecordedRequest(Method.Get, "/native", Map.empty, None))),
+          recvE == Right(List(RecordedRequest(Method.Get, "/native", Headers.empty, None))),
           destroyE.isRight,
           deleted == Chunk(port), // space-local: only this imposter
           globals == 0            // never the global reset
@@ -369,8 +369,8 @@ object RiftMockControlSpec extends ZIOSpecDefault:
             a.baseUri == b.baseUri,                                           // shared imposter -> shared baseUri
             stubs.exists(_.contains(s"/${a.id.value} ")),                     // A's stub scoped under A's flowId
             stubs.exists(_.contains(s"/${b.id.value} ")),
-            a.inject(req).headers.get("X-Mock-Space").contains(a.id.value), // inject routes the request to A
-            a.inject(req).headers.get("X-Mock-Space") != b.inject(req).headers.get("X-Mock-Space")
+            a.inject(req).headers.first("X-Mock-Space").contains(a.id.value), // inject routes the request to A
+            a.inject(req).headers.first("X-Mock-Space") != b.inject(req).headers.first("X-Mock-Space")
           )
       }
     },
@@ -409,7 +409,7 @@ object RiftMockControlSpec extends ZIOSpecDefault:
           recvE   <- control.received(s).either
           matches <- fake.requestMatches.get
         yield assertTrue(
-          recvE == Right(List(RecordedRequest(Method.Get, "/ping", Map.empty, None))),
+          recvE == Right(List(RecordedRequest(Method.Get, "/ping", Headers.empty, None))),
           matches.exists(_.contains(s"header:X-Mock-Space=${s.id.value}")) // filtered by THIS space's flowId
         )
       }
@@ -488,12 +488,12 @@ object RiftMockControlSpec extends ZIOSpecDefault:
           val a   = aE.toOption.get.head
           val b   = bE.toOption.get.head
           val req = HttpRequest(Method.Get, "http://sut/")
-          val ta  = a.inject(req).headers.get("traceparent")
+          val ta  = a.inject(req).headers.first("traceparent")
           assertTrue(
             aE.isRight && bE.isRight,
             posted.head.contains("\"flowIdSource\":\"header:traceparent\""),
             ta.exists(_.matches("00-[0-9a-f]{32}-[0-9a-f]{16}-01")), // W3C traceparent shape
-            ta != b.inject(req).headers.get("traceparent")           // distinct per space
+            ta != b.inject(req).headers.first("traceparent")         // distinct per space
           )
       }
     },

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
@@ -17,7 +17,7 @@ object RiftProtocolSpec extends ZIOSpecDefault:
 
   private val pingRule = MockRule(
     `match` = RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
-    respond = ResponseDef(status = 200, headers = Map("Content-Type" -> "text/plain"), body = Body.Text("pong"))
+    respond = ResponseDef(status = 200, headers = Headers("Content-Type" -> "text/plain"), body = Body.Text("pong"))
   )
 
   def spec = suite("RiftProtocol (canonical <-> Mountebank)")(
@@ -41,7 +41,23 @@ object RiftProtocolSpec extends ZIOSpecDefault:
         pathPred.exists(_ / "equals" / "path" == Json.Str("/ping")),
         isResp / "statusCode" == Json.Num(200),
         isResp / "body" == Json.Str("pong"),
-        isResp / "headers" / "Content-Type" == Json.Str("text/plain")
+        isResp / "headers" / "content-type" == Json.Str("text/plain")
+      )
+    },
+    test("a multi-value response header emits a JSON array; a single value stays a bare string (rift#241)") {
+      val multi  = RiftProtocol.response(ResponseDef(status = 200, headers = Headers.multi("X-Multi" -> List("a", "b"))))
+      val single = RiftProtocol.response(ResponseDef(status = 200, headers = Headers("X-One" -> "v")))
+      assertTrue(
+        arr(multi / "is" / "headers" / "x-multi") == List(Json.Str("a"), Json.Str("b")),
+        single / "is" / "headers" / "x-one" == Json.Str("v") // single value is not wrapped in an array
+      )
+    },
+    test("parseRecorded decodes a multi-value header array into multiple values; keys lower-case (rift#241)") {
+      val view   = """{"requests":[{"method":"GET","path":"/p","headers":{"X-Multi":["a","b"],"Host":"x"}}]}"""
+      val parsed = RiftProtocol.parseRecorded(view)
+      assertTrue(
+        parsed.map(_.head.headers.values("x-multi")) == Right(List("a", "b")),
+        parsed.map(_.head.headers.first("host")) == Right(Some("x")) // mixed-case wire key surfaces lower-cased
       )
     },
     test("a regex path becomes a matches predicate; a template path is anchored regex") {
@@ -76,8 +92,8 @@ object RiftProtocolSpec extends ZIOSpecDefault:
       assertTrue(
         parsed == Right(
           List(
-            RecordedRequest(Method.Get, "/ping", Map("Host" -> "x"), None),
-            RecordedRequest(Method.Post, "/echo", Map.empty, Some("hi"))
+            RecordedRequest(Method.Get, "/ping", Headers("Host" -> "x"), None),
+            RecordedRequest(Method.Post, "/echo", Headers.empty, Some("hi"))
           )
         )
       )

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
@@ -132,7 +132,10 @@ private[wiremock] final case class WireMockControl(
             WireMockTranslation.recorded(
               req.getMethod.getName,
               req.getUrl,
-              req.getHeaders.all.asScala.map(h => h.key.toLowerCase -> h.firstValue).toMap,
+              // keep every value per key (Headers lower-cases the key) — don't drop to firstValue (#162)
+              req.getHeaders.all.asScala.foldLeft(Headers.empty)((acc, h) =>
+                h.values.asScala.foldLeft(acc)((a, v) => a.add(h.key, v))
+              ),
               Option(req.getBodyAsString).filter(_.nonEmpty)
             )
           )
@@ -216,7 +219,7 @@ private[wiremock] final case class WireMockControl(
 
   private def injectFor(id: SpaceId, corr: Option[Correlation]): HttpRequest => HttpRequest =
     corr match
-      case Some(c) => req => req.copy(headers = req.headers + (c.header -> c.value(id)))
+      case Some(c) => req => req.copy(headers = req.headers.add(c.header, c.value(id)))
       case None    => identity
 
   private def stop(server: WireMockServer): UIO[Unit] =

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockTranslation.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockTranslation.scala
@@ -58,7 +58,7 @@ private[wiremock] object WireMockTranslation:
 
   private def response(r: ResponseDef): ResponseDefinitionBuilder =
     val rb = WM.aResponse().withStatus(r.status)
-    r.headers.foreach((k, v) => rb.withHeader(k, v))
+    r.headers.entries.foreach((k, vs) => rb.withHeader(k, vs*)) // one header line per value (#162)
     r.body match
       case Body.Empty     => ()
       case Body.Text(v)   => rb.withBody(v)
@@ -68,7 +68,7 @@ private[wiremock] object WireMockTranslation:
     rb
 
   /** A [[RecordedRequest]] from a WireMock logged request. */
-  def recorded(method: String, url: String, headers: Map[String, String], body: Option[String]): RecordedRequest =
+  def recorded(method: String, url: String, headers: Headers, body: Option[String]): RecordedRequest =
     RecordedRequest(parseMethod(method), url, headers, body)
 
   private def parseMethod(name: String): Method = name.toUpperCase match

--- a/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
+++ b/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
@@ -207,7 +207,7 @@ object WireMockControlSpec extends ZIOSpecDefault:
           a       <- die(control.provision(pingSource)).map(_.head)
           _       <- SutClient.make(a).send(Method.Get, "/ping").orDie // records the space's traceparent
           recv    <- die(control.received(a))
-          tp       = recv.head.headers("traceparent")                  // 00-<traceId>-<span>-01
+          tp       = recv.head.headers.first("traceparent").get        // 00-<traceId>-<span>-01
           traceId  = tp.split("-")(1)
           // same trace-id, a span-id the space never injected
           varied <- rawGet(a.baseUri + "/ping", Some("traceparent" -> s"00-$traceId-ffffffffffffffff-01")).orDie


### PR DESCRIPTION
Headers in the canonical mock model were single-value (`Map[String, String]`); multiple values for one key (two `Set-Cookie`, repeated `Accept`, …) weren't representable. This adds a `Headers` value type and threads it end-to-end.

## Model
- New `Headers` opaque type — multi-value per key, keys canonicalised to **lower-case** (the documented key-case contract: WireMock lower-cases recorded keys, Rift preserves them; this normalises both so cross-adapter assertions are well-defined), values insertion-ordered. Single-value sugar (`Headers("a" -> "b")`) keeps the common case terse.
- `HttpRequest`/`RecordedRequest`/`ResponseDef`/`SutResponse`/`MockResponse` headers → `Headers`. `RequestMatch` (match side) is unchanged.

## Adapters
- **SutClient** sends one header line per value and preserves every value per key on decode (was a `mkString(", ")` collapse).
- **WireMock** emits `withHeader(k, vs*)` and `received` collects all values per key (was `.firstValue`).
- **Rift** uses v0.6.0's multi-value wire format (rift#241): a string for a single value, a JSON array for many, decoded back as either.

## Verification
- Conformance gains two scenarios — a multi-value response header observed by the SUT, and a multi-value recorded request header surfaced via `received` — run on **both** adapters (WireMock in-process; Rift under `RIFT_IT`).
- `HeadersSpec` pins the key-case contract + multi-value semantics; `RiftProtocolSpec` unit-guards the array emit/decode so a wire regression is caught without the container.
- 816 tests pass; scalafmt clean.

Closes #162
Milestone: M2 (Epic C / conformance follow-up)