### PR TITLE
feat: Faults capability + Rift/WireMock adapters

### DIFF
--- a/conformance/src/main/scala/zio/bdd/mock/conformance/FaultScenarios.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/FaultScenarios.scala
@@ -1,0 +1,93 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+
+/**
+ * The portable fault-injection conformance scenarios (#128) — the `cap-faults`
+ * feature. Each is programmed against the neutral [[MockControl]] (never a
+ * concrete backend) and gated on [[Capability.Faults]], so a backend that does
+ * not advertise Faults SKIPs them. Asserting via a real [[SutClient]]
+ * round-trip makes each fault kind produce its specified *client-observable*
+ * failure identically on every advertising adapter (WireMock natively; Rift via
+ * `_rift.fault`, rift#239).
+ *
+ *   - The four connection kinds abort the transport, so the SUT's client throws
+ *     (the `send` effect FAILs) — observed as `Exit.isFailure`, not a status.
+ *   - [[FaultKind.LatencySpike]] delays an otherwise-normal 200 response —
+ *     observed as a status-200 round-trip whose latency exceeds a baseline.
+ */
+object FaultScenarios:
+
+  lazy val all: List[ConformanceScenario] =
+    List(
+      connectionFault("faults: ConnectionReset aborts the client connection", FaultKind.ConnectionReset),
+      connectionFault("faults: EmptyResponse aborts the client connection", FaultKind.EmptyResponse),
+      connectionFault("faults: MalformedChunk aborts the client connection", FaultKind.MalformedChunk),
+      connectionFault("faults: RandomThenClose aborts the client connection", FaultKind.RandomThenClose),
+      latencySpike
+    )
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+
+  private def ensure(cond: Boolean, msg: => String): IO[Throwable, Unit] =
+    ZIO.unless(cond)(ZIO.fail(new AssertionError(msg))).unit
+
+  // A baseline space serving GET /ping -> pong, torn down with the scenario scope.
+  private val pingSource =
+    MockSource.Dsl(
+      MockSpec(List(MockRule(RequestMatch(path = PathMatch.Exact("/ping")), ResponseDef(body = Body.Text("pong")))))
+    )
+
+  private def space(control: MockControl): ZIO[Scope, Throwable, MockSpace] =
+    ZIO.acquireRelease(control.provision(pingSource).mapError(asT).map(_.head))(s => control.destroy(s).ignoreLogged)
+
+  private def faultsOf(control: MockControl): IO[Throwable, Faults] =
+    control.faults.mapError(u => new RuntimeException(u.toString))
+
+  private def connectionFault(name: String, kind: FaultKind): ConformanceScenario =
+    ConformanceScenario(
+      name,
+      Set(Capability.Faults),
+      control =>
+        for
+          s      <- space(control)
+          faults <- faultsOf(control)
+          _      <- faults.inject(s, RequestMatch(path = PathMatch.Exact("/boom")), kind).mapError(asT)
+          result <- SutClient.make(s).send(Method.Get, "/boom").exit
+          _      <- ensure(result.isFailure, s"$name: expected a client-side transport failure, got $result")
+        yield ()
+    )
+
+  private val latencySpike =
+    ConformanceScenario(
+      "faults: LatencySpike delays an otherwise-normal response",
+      Set(Capability.Faults),
+      control =>
+        // Measure /slow against a no-fault /ping baseline on the same space, so the
+        // delta cancels connection/JIT noise (mirrors the core delay scenario): a 1s
+        // spike with a 500ms floor and the MIN of two baselines keeps jitter from
+        // flipping a genuinely-applied delay to a false failure.
+        def elapsed(s: MockSpace, path: String): ZIO[Any, Throwable, (SutResponse, Duration)] =
+          for
+            t0 <- Clock.nanoTime
+            r  <- SutClient.make(s).send(Method.Get, path)
+            t1 <- Clock.nanoTime
+          yield (r, Duration.fromNanos(t1 - t0))
+        for
+          s      <- space(control)
+          faults <- faultsOf(control)
+          _ <- faults
+                 .inject(s, RequestMatch(path = PathMatch.Exact("/slow")), FaultKind.LatencySpike(1.second))
+                 .mapError(asT)
+          base1   <- elapsed(s, "/ping")
+          base2   <- elapsed(s, "/ping")
+          slow    <- elapsed(s, "/slow")
+          baseline = math.min(base1._2.toNanos, base2._2.toNanos)
+          delta    = Duration.fromNanos(slow._2.toNanos - baseline)
+          _ <- ensure(
+                 slow._1.status == 200 && delta >= 500.millis,
+                 s"latency: status=${slow._1.status} slow=${slow._2.toMillis}ms baseline=${baseline / 1000000}ms delta=${delta.toMillis}ms"
+               )
+        yield ()
+    )

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
@@ -88,7 +88,7 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
     MockBackendUnderTest(
       "wiremock",
       Provisioning.live >>> WireMock.correlated(),
-      Set(Capability.StatefulScenarios, Capability.StateInspection),
+      Set(Capability.Faults, Capability.StatefulScenarios, Capability.StateInspection),
       Isolation.Correlated
     )
 
@@ -97,7 +97,7 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
     MockBackendUnderTest(
       "rift",
       (Client.default ++ Provisioning.live) >>> Rift.managed().mapError(asT),
-      Set.empty,
+      Set(Capability.Faults),
       Isolation.PerInstance,
       available = riftEnabled
     )
@@ -114,7 +114,7 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         matrix
           .cell(injectFault, "wiremock")
           .map(_.outcome)
-          .contains(Outcome.Skip),   // Faults un-advertised → SKIP, not FAIL
+          .contains(Outcome.Pass),   // Faults advertised (#128) → the accessor succeeds → PASS
         matrix.conformant(wiremock), // zero FAIL, skip justified by capability
         // Rift: conformant when available (CI with RIFT_IT), else the column is SKIPPED-unavailable (local, no Docker)
         if riftEnabled then matrix.conformant(rift)
@@ -176,6 +176,25 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         matrix.cells.count(_.backend == "wiremock") == all.size,
         // Rift doesn't advertise these until #131 -> every Rift cell is a justified SKIP.
         riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
+      )
+    } @@ TestAspect.withLiveClock,
+    test("fault-injection features pass on every adapter (#128)") {
+      val all = FaultScenarios.all
+      for
+        matrix   <- ConformanceHarness.run(List(wiremock, rift), all)
+        _        <- ZIO.logInfo(s"faults matrix:\n${matrix.render}")
+        wmFails   = nonPass(matrix, "wiremock", all)
+        _        <- ZIO.logInfo(s"wiremock non-pass: $wmFails").when(wmFails.nonEmpty)
+        rfFails   = nonPass(matrix, "rift", all)
+        _        <- ZIO.logInfo(s"rift non-pass: $rfFails").when(rfFails.nonEmpty)
+        riftCells = all.flatMap(s => matrix.cell(s.name, "rift").map(_.outcome))
+      yield assertTrue(
+        all.nonEmpty,
+        all.forall(s => matrix.cell(s.name, "wiremock").exists(_.outcome == Outcome.Pass)),
+        matrix.cells.count(_.backend == "wiremock") == all.size,
+        // Rift: every fault kind PASSes in CI (RIFT_IT, real container); else the column is SKIPPED-unavailable.
+        if riftEnabled then all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Pass))
+        else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
       )
     } @@ TestAspect.withLiveClock
   )

--- a/mock/src/main/scala/zio/bdd/mock/Capability.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Capability.scala
@@ -31,7 +31,15 @@ enum Isolation:
  * Fault injection (latency, errors, connection resets). Capability:
  * [[Capability.Faults]].
  */
-trait Faults
+trait Faults:
+  /**
+   * Inject `fault` for requests matching `m` in `space`, returning the id of
+   * the fault rule (removable via [[MockControl.removeRule]]). The four
+   * connection kinds make the SUT's client observe a transport-level failure;
+   * [[FaultKind.LatencySpike]] delays an otherwise normal 200 response. The
+   * fault takes precedence over a normal rule on the same match.
+   */
+  def inject(space: MockSpace, m: RequestMatch, fault: FaultKind): IO[MockError, RuleId]
 
 /**
  * Single-token FSM per scenario (#129): a request eligible in the scenario's

--- a/mock/src/main/scala/zio/bdd/mock/model.scala
+++ b/mock/src/main/scala/zio/bdd/mock/model.scala
@@ -182,6 +182,20 @@ final case class ScenarioDef(
 )
 
 /**
+ * A client-observable fault the [[Faults]] capability injects for matching
+ * requests (#128). The four connection kinds produce a transport-level failure
+ * (the SUT's HTTP client throws); [[LatencySpike]] instead delays an otherwise
+ * normal response. The names mirror WireMock's `Fault` enum so both adapters
+ * (WireMock natively, Rift via `_rift.fault.tcp`) realise the same behaviour.
+ */
+enum FaultKind:
+  case ConnectionReset
+  case EmptyResponse
+  case MalformedChunk
+  case RandomThenClose
+  case LatencySpike(delay: Duration)
+
+/**
  * The unit of isolation. Hides *how* isolation is achieved:
  *   - PerInstance: a unique `baseUri` per space; `inject = identity`.
  *   - Correlated: a shared `baseUri`; `inject` stamps a correlation header.

--- a/mock/src/test/scala/zio/bdd/mock/CapabilityNegotiationSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/CapabilityNegotiationSpec.scala
@@ -23,7 +23,9 @@ object CapabilityNegotiationSpec extends ZIOSpecDefault:
     private def cap[A](c: Capability)(a: => A): IO[Unsupported, A] =
       if caps(c) then ZIO.succeed(a) else ZIO.fail(Unsupported(c, backendName))
 
-    def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(new Faults {})
+    private val anyFault: Faults = (_, _, _) => ZIO.succeed(RuleId("fault"))
+
+    def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(anyFault)
     def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(StubCaps.scenarios)
     def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(StubCaps.stateInspection)
     def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(new Scripting {})

--- a/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
@@ -29,7 +29,9 @@ object MockControlModelSpec extends ZIOSpecDefault:
     private def cap[A](c: Capability)(a: => A): IO[Unsupported, A] =
       if caps(c) then ZIO.succeed(a) else ZIO.fail(Unsupported(c, backend))
 
-    def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(new Faults {})
+    private val anyFault: Faults = (_, _, _) => ZIO.succeed(RuleId("fault"))
+
+    def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(anyFault)
     def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(StubCaps.scenarios)
     def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(StubCaps.stateInspection)
     def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(new Scripting {})

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -54,7 +54,7 @@ private[rift] final case class RiftMockControl(
   import RiftMockControl.{CorrSpace, Imposter}
 
   def backendName: String           = "rift"
-  def capabilities: Set[Capability] = Set.empty
+  def capabilities: Set[Capability] = Set(Capability.Faults)
 
   override def isolation: Isolation = mode match
     case RiftMode.Correlated(_) => Isolation.Correlated
@@ -102,12 +102,45 @@ private[rift] final case class RiftMockControl(
   def received(space: MockSpace): IO[MockError, List[RecordedRequest]] =
     dispatch(space)(corrReceived)(piReceived)
 
-  def faults: IO[Unsupported, Faults]                   = unsupported(Capability.Faults)
+  def faults: IO[Unsupported, Faults]                   = ZIO.succeed(riftFaults)
   def scenarios: IO[Unsupported, StatefulScenarios]     = unsupported(Capability.StatefulScenarios)
   def stateInspection: IO[Unsupported, StateInspection] = unsupported(Capability.StateInspection)
   def scripting: IO[Unsupported, Scripting]             = unsupported(Capability.Scripting)
   def proxyRecord: IO[Unsupported, ProxyRecord]         = unsupported(Capability.ProxyRecord)
   def templating: IO[Unsupported, Templating]           = unsupported(Capability.Templating)
+
+  // ===== Faults (#128) — `_rift.fault` (rift#239) =================================
+
+  private val riftFaults: Faults = new Faults:
+    def inject(space: MockSpace, m: RequestMatch, fault: FaultKind): IO[MockError, RuleId] =
+      dispatch(space)(cs => corrInjectFault(cs, m, fault))(imp => piInjectFault(imp, m, fault))
+
+  // PerInstance: first-match (index 0) so the fault wins over any normal rule on
+  // the same match; tracked in `imp.stubs` so it stays index-aligned with the
+  // server and is removable via `removeRule`.
+  private def piInjectFault(imp: Imposter, m: RequestMatch, fault: FaultKind): IO[MockError, RuleId] =
+    for
+      ruleId <- freshId
+      u      <- url(s"/imposters/${imp.port}/stubs")
+      res    <- send(jsonRequest(HttpMethod.POST, u, RiftProtocol.addFaultStubBody(0, m, fault, ruleId)))
+      _      <- expectSuccess(s"inject fault into imposter ${imp.port}", res)
+      _      <- imp.stubs.update(ruleId +: _)
+    yield ruleId
+
+  // Correlated: track the fault and rebuild the space with faults registered ahead
+  // of the rules, so it wins first-match (rift#223 has no per-stub index). Tracked
+  // in `cs.faults` so it survives a later rule rebuild and is removable via
+  // `removeRule`; `destroy` clears it with the whole flow. Server-first, commit on
+  // success (mirrors corrAddRule's Overlay rebuild).
+  private def corrInjectFault(cs: CorrSpace, m: RequestMatch, fault: FaultKind): IO[MockError, RuleId] =
+    for
+      ruleId <- freshId
+      rules  <- cs.rules.get
+      faults <- cs.faults.get
+      next    = (ruleId, m, fault) +: faults
+      _      <- rebuild(cs, next, rules)
+      _      <- cs.faults.set(next)
+    yield ruleId
 
   // ---------------------------------------------------------------------------
 
@@ -218,9 +251,10 @@ private[rift] final case class RiftMockControl(
       tagged <- tagRules(rules)
       // Mirror serveImposter's release-on-error: if a stub POST fails partway, tear
       // the half-built flow down so it can't orphan stubs on the shared imposter.
-      _        <- registerStubs(port, flowId, tagged).onError(_ => deleteSpace(port, flowId).ignore)
-      rulesRef <- Ref.make(tagged)
-      _        <- correlated.update(_.updated(id, CorrSpace(port, flowId, corr.header, rulesRef)))
+      _         <- registerStubs(port, flowId, tagged).onError(_ => deleteSpace(port, flowId).ignore)
+      rulesRef  <- Ref.make(tagged)
+      faultsRef <- Ref.make(Vector.empty[(RuleId, RequestMatch, FaultKind)])
+      _         <- correlated.update(_.updated(id, CorrSpace(port, flowId, corr.header, rulesRef, faultsRef)))
     yield MockSpace(endpoint.baseUriFor(port), req => req.copy(headers = req.headers.add(corr.header, flowId)), id)
 
   // Create the one shared imposter on first Correlated provision (race-safe).
@@ -251,12 +285,18 @@ private[rift] final case class RiftMockControl(
     }
 
   private def corrRemoveRule(cs: CorrSpace, spaceId: SpaceId, id: RuleId): IO[MockError, Unit] =
-    cs.rules.get.flatMap { v =>
-      if !v.exists(_._1 == id) then ZIO.fail(MockError.RuleNotFound(spaceId, id))
-      else
-        val next = v.filterNot(_._1 == id)
-        rebuildSpaceWith(cs, next) *> cs.rules.set(next) // commit tracking only on success
-    }
+    for
+      rules  <- cs.rules.get
+      faults <- cs.faults.get
+      _ <- // commit tracking only on success; a removed id is either a rule or a fault
+        if rules.exists(_._1 == id) then
+          val next = rules.filterNot(_._1 == id)
+          rebuild(cs, faults, next) *> cs.rules.set(next)
+        else if faults.exists(_._1 == id) then
+          val nextF = faults.filterNot(_._1 == id)
+          rebuild(cs, nextF, rules) *> cs.faults.set(nextF)
+        else ZIO.fail(MockError.RuleNotFound(spaceId, id))
+    yield ()
 
   private def corrReplaceRules(cs: CorrSpace, rules: List[MockRule]): IO[MockError, Unit] =
     tagRules(rules).flatMap(next => rebuildSpaceWith(cs, next) *> cs.rules.set(next))
@@ -272,14 +312,46 @@ private[rift] final case class RiftMockControl(
       recs <- ZIO.fromEither(RiftProtocol.parseRequestsArray(body)).mapError(MockError.CommunicationError(_))
     yield recs
 
-  // rift#223 has no per-stub-in-space delete: re-register `rules` as the space's
-  // stubs after a whole-space teardown. Server-first — the caller commits
-  // tracking only on success. A mid-rebuild failure leaves the space's *server*
-  // stubs partial (surfaced as a CommunicationError); tracking is left unchanged.
-  // (A successful rebuild also clears the space's recorded requests + flow state
-  // — benign at scenario boundaries; see the class doc.)
+  // rift#223 has no per-stub-in-space delete: re-register the space's stubs after a
+  // whole-space teardown. Server-first — the caller commits tracking only on success.
+  // A mid-rebuild failure leaves the space's *server* stubs partial (surfaced as a
+  // CommunicationError); tracking is left unchanged. (A successful rebuild also clears
+  // the space's recorded requests + flow state — benign at scenario boundaries; see
+  // the class doc.) Re-register with the currently-tracked faults (a rule mutation
+  // must not drop an injected fault).
   private def rebuildSpaceWith(cs: CorrSpace, rules: Vector[(RuleId, MockRule)]): IO[MockError, Unit] =
-    deleteSpace(cs.port, cs.flowId) *> registerStubs(cs.port, cs.flowId, rules)
+    cs.faults.get.flatMap(faults => rebuild(cs, faults, rules))
+
+  // Faults are registered ahead of the rules so they win first-match (Mountebank is
+  // first-match-wins, and rift#223 space stubs append in registration order).
+  private def rebuild(
+    cs: CorrSpace,
+    faults: Vector[(RuleId, RequestMatch, FaultKind)],
+    rules: Vector[(RuleId, MockRule)]
+  ): IO[MockError, Unit] =
+    deleteSpace(cs.port, cs.flowId) *>
+      registerFaultStubs(cs.port, cs.flowId, faults) *>
+      registerStubs(cs.port, cs.flowId, rules)
+
+  private def registerFaultStubs(
+    port: Int,
+    flowId: String,
+    faults: Vector[(RuleId, RequestMatch, FaultKind)]
+  ): IO[MockError, Unit] =
+    ZIO.foreachDiscard(faults)((rid, m, fault) => postSpaceFaultStub(port, flowId, m, fault, rid))
+
+  private def postSpaceFaultStub(
+    port: Int,
+    flowId: String,
+    m: RequestMatch,
+    fault: FaultKind,
+    id: RuleId
+  ): IO[MockError, Unit] =
+    for
+      u   <- url(s"/imposters/$port/spaces/${enc(flowId)}/stubs")
+      res <- send(jsonRequest(HttpMethod.POST, u, RiftProtocol.faultStub(m, fault, id)))
+      _   <- expectSuccess(s"add fault stub to $flowId", res)
+    yield ()
 
   // Assign each rule a fresh id, keyed for tracking + re-registration under a space.
   private def tagRules(rules: List[MockRule]): UIO[Vector[(RuleId, MockRule)]] =
@@ -377,7 +449,13 @@ private[rift] final case class RiftMockControl(
 
 private[rift] object RiftMockControl:
   final case class Imposter(port: Int, stubs: Ref[Vector[RuleId]])
-  final case class CorrSpace(port: Int, flowId: String, header: String, rules: Ref[Vector[(RuleId, MockRule)]])
+  final case class CorrSpace(
+    port: Int,
+    flowId: String,
+    header: String,
+    rules: Ref[Vector[(RuleId, MockRule)]],
+    faults: Ref[Vector[(RuleId, RequestMatch, FaultKind)]]
+  )
 
   /**
    * Build an adapter against an endpoint in the given isolation `mode`, taking

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -78,6 +78,46 @@ private[rift] object RiftProtocol:
   def addStubBody(index: Int, rule: MockRule): Json =
     Json.Obj("index" -> Json.Num(index), "stub" -> stub(rule))
 
+  // ---------------------------------------------------------------------------
+  // Fault injection (#128) — the `_rift.fault` response extension (rift#239)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * A stub response carrying a `_rift.fault` extension. The connection kinds
+   * set `_rift.fault.tcp` (Rift aborts the connection at the transport layer,
+   * so the SUT observes a real reset/empty/malformed/random failure — the `is`
+   * below is never sent); [[FaultKind.LatencySpike]] sets `_rift.fault.latency`
+   * (Rift sleeps, then serves this `is` 200). `probability` is pinned to 1 so
+   * the fault always fires.
+   */
+  def faultResponse(fault: FaultKind): Json =
+    val cfg = fault match
+      case FaultKind.LatencySpike(d) =>
+        Json.Obj("latency" -> Json.Obj("probability" -> Json.Num(1), "ms" -> Json.Num(d.toMillis.toInt)))
+      case FaultKind.ConnectionReset => tcpFault("CONNECTION_RESET_BY_PEER")
+      case FaultKind.EmptyResponse   => tcpFault("EMPTY_RESPONSE")
+      case FaultKind.MalformedChunk  => tcpFault("MALFORMED_RESPONSE_CHUNK")
+      case FaultKind.RandomThenClose => tcpFault("RANDOM_DATA_THEN_CLOSE")
+    Json.Obj("is" -> Json.Obj("statusCode" -> Json.Num(200)), "_rift" -> Json.Obj("fault" -> cfg))
+
+  private def tcpFault(token: String): Json = Json.Obj("tcp" -> Json.Str(token))
+
+  /**
+   * A Mountebank stub whose response injects `fault` for requests matching `m`.
+   */
+  def faultStub(m: RequestMatch, fault: FaultKind, id: RuleId): Json =
+    Json.Obj(
+      "id"         -> Json.Str(id.value),
+      "predicates" -> Json.Arr(predicates(m)*),
+      "responses"  -> Json.Arr(faultResponse(fault))
+    )
+
+  /**
+   * The `{index, stub}` body for `POST /imposters/:port/stubs` of a fault stub.
+   */
+  def addFaultStubBody(index: Int, m: RequestMatch, fault: FaultKind, id: RuleId): Json =
+    Json.Obj("index" -> Json.Num(index), "stub" -> faultStub(m, fault, id))
+
   def predicates(m: RequestMatch): List[Json] =
     val methodPred = m.method.map(meth => equalsObj("method" -> Json.Str(methodName(meth))))
     val pathPred = m.path match

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -193,12 +193,55 @@ object RiftMockControlSpec extends ZIOSpecDefault:
         )
       }
     },
-    test("advertises no capabilities; every accessor fails fast") {
+    test("advertises Faults; its accessor succeeds and the other accessors fail fast") {
       withAdapter { (control, _) =>
-        for faultsE <- control.faults.either
+        for
+          faultsE    <- control.faults.either
+          scenariosE <- control.scenarios.either
         yield assertTrue(
-          control.capabilities.isEmpty,
-          faultsE == Left(Unsupported(Capability.Faults, "rift"))
+          control.capabilities == Set(Capability.Faults),
+          faultsE.isRight,
+          scenariosE == Left(Unsupported(Capability.StatefulScenarios, "rift"))
+        )
+      }
+    },
+    test("faults.inject posts a first-match stub carrying _rift.fault.tcp to the space's imposter") {
+      withAdapter { (control, fake) =>
+        for
+          space  <- control.provision(pingSource).orDieWith(e => new RuntimeException(e.toString)).map(_.head)
+          faults <- control.faults.orDieWith(u => new RuntimeException(u.toString))
+          ruleId <- faults
+                      .inject(space, RequestMatch(path = PathMatch.Exact("/boom")), FaultKind.ConnectionReset)
+                      .orDieWith(e => new RuntimeException(e.toString))
+          calls <- fake.stubCalls.get
+          post   = calls.find(c => c.startsWith(s"POST ${portOf(space.baseUri)} "))
+        yield assertTrue(
+          ruleId.value.nonEmpty,
+          post.exists(_.contains("\"index\":0")), // first-match — wins over a normal rule
+          post.exists(_.contains("CONNECTION_RESET_BY_PEER")),
+          post.exists(_.contains("/boom"))
+        )
+      }
+    },
+    test("Correlated faults.inject registers a fault space stub ahead of the rules (first-match) and is removable") {
+      withCorrelated { (control, fake) =>
+        for
+          space  <- control.provision(pingSource).orDieWith(e => new RuntimeException(e.toString)).map(_.head)
+          faults <- control.faults.orDieWith(u => new RuntimeException(u.toString))
+          ruleId <- faults
+                      .inject(space, RequestMatch(path = PathMatch.Exact("/boom")), FaultKind.ConnectionReset)
+                      .orDieWith(e => new RuntimeException(e.toString))
+          stubs <- fake.spaceStubs.get // "$port/$flowId $body" per POST .../spaces/:flow/stubs
+          faultIx =
+            stubs.indexWhere(s => s.contains("_rift") && s.contains("CONNECTION_RESET_BY_PEER") && s.contains("/boom"))
+          // the rebuild re-registers the space's /ping rule AFTER the fault → fault wins first-match
+          rulePast = stubs.zipWithIndex.exists((s, i) => i > faultIx && s.contains("/ping"))
+          rmE     <- control.removeRule(space, ruleId).either // tracked in cs.faults → removable, not RuleNotFound
+        yield assertTrue(
+          ruleId.value.nonEmpty,
+          faultIx >= 0,
+          rulePast,
+          rmE.isRight
         )
       }
     },

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
@@ -76,6 +76,37 @@ object RiftProtocolSpec extends ZIOSpecDefault:
         withDelay / "_behaviors" / "wait" == Json.Num(50)
       )
     },
+    test("a connection FaultKind becomes a stub response with _rift.fault.tcp and a 200 carrier `is`") {
+      def tcp(fault: FaultKind): Json = RiftProtocol.faultResponse(fault) / "_rift" / "fault" / "tcp"
+      assertTrue(
+        tcp(FaultKind.ConnectionReset) == Json.Str("CONNECTION_RESET_BY_PEER"),
+        tcp(FaultKind.EmptyResponse) == Json.Str("EMPTY_RESPONSE"),
+        tcp(FaultKind.MalformedChunk) == Json.Str("MALFORMED_RESPONSE_CHUNK"),
+        tcp(FaultKind.RandomThenClose) == Json.Str("RANDOM_DATA_THEN_CLOSE"),
+        RiftProtocol.faultResponse(FaultKind.ConnectionReset) / "is" / "statusCode" == Json.Num(200)
+      )
+    },
+    test("a LatencySpike becomes _rift.fault.latency with probability 1 and ms; no tcp") {
+      import zio.*
+      val resp    = RiftProtocol.faultResponse(FaultKind.LatencySpike(1.second))
+      val latency = resp / "_rift" / "fault" / "latency"
+      assertTrue(
+        latency / "ms" == Json.Num(1000),
+        latency / "probability" == Json.Num(1),
+        field(resp / "_rift" / "fault", "tcp").isEmpty,
+        resp / "is" / "statusCode" == Json.Num(200)
+      )
+    },
+    test("faultStub carries the request predicates and the fault response under the given id") {
+      val m     = RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/boom"))
+      val stub  = RiftProtocol.faultStub(m, FaultKind.ConnectionReset, RuleId("f1"))
+      val preds = arr(stub / "predicates")
+      assertTrue(
+        stub / "id" == Json.Str("f1"),
+        preds.exists(p => p / "equals" / "path" == Json.Str("/boom")),
+        arr(stub / "responses").head / "_rift" / "fault" / "tcp" == Json.Str("CONNECTION_RESET_BY_PEER")
+      )
+    },
     test("PathMatch.Any emits no path predicate") {
       val stub = RiftProtocol.stub(pingRule.copy(`match` = RequestMatch(method = Some(Method.Post))))
       val keys =

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
@@ -33,8 +33,9 @@ private[wiremock] final case class WireMockControl(
 
   import WireMockControl.{ScenarioRecord, SpaceState}
 
-  def backendName: String           = "wiremock"
-  def capabilities: Set[Capability] = Set(Capability.StatefulScenarios, Capability.StateInspection)
+  def backendName: String = "wiremock"
+  def capabilities: Set[Capability] =
+    Set(Capability.Faults, Capability.StatefulScenarios, Capability.StateInspection)
 
   override def isolation: Isolation = mode match
     case WireMock.Mode.Correlated(_) => Isolation.Correlated
@@ -145,7 +146,7 @@ private[wiremock] final case class WireMockControl(
         })
     }
 
-  def faults: IO[Unsupported, Faults]                   = unsupported(Capability.Faults)
+  def faults: IO[Unsupported, Faults]                   = ZIO.succeed(wmFaults)
   def scenarios: IO[Unsupported, StatefulScenarios]     = ZIO.succeed(statefulScenarios)
   def stateInspection: IO[Unsupported, StateInspection] = ZIO.succeed(stateInspector)
   def scripting: IO[Unsupported, Scripting]             = unsupported(Capability.Scripting)
@@ -222,6 +223,20 @@ private[wiremock] final case class WireMockControl(
               .mapError(e => MockError.CommunicationError(msg(e)))
           case None => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${space.id.value}"))
         )
+      }
+
+  // Faults (#128): a fault stub is a first-match (Overlay) stub carrying WireMock's
+  // native `Fault` (or a fixed delay), tracked in `st.rules` like any other — so
+  // correlation filtering, `removeRule` and `destroy` all apply to it unchanged.
+  private val wmFaults: Faults = new Faults:
+    def inject(space: MockSpace, m: RequestMatch, fault: FaultKind): IO[MockError, RuleId] =
+      withSpace(space) { st =>
+        for
+          ruleId <- freshRuleId
+          stub    = WireMockTranslation.faultStub(space.id, m, fault, Priority.Overlay, st.correlation)
+          _      <- ZIO.attempt(st.server.addStubMapping(stub)).mapError(e => MockError.CommunicationError(msg(e)))
+          _      <- st.rules.update((ruleId, stub) +: _)
+        yield ruleId
       }
 
   // Stop every server this adapter still owns — the layer's scope finalizer.

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockTranslation.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockTranslation.scala
@@ -3,6 +3,7 @@ package zio.bdd.mock.wiremock
 import zio.bdd.mock.*
 
 import com.github.tomakehurst.wiremock.client.{MappingBuilder, ResponseDefinitionBuilder, WireMock as WM}
+import com.github.tomakehurst.wiremock.http.Fault
 import com.github.tomakehurst.wiremock.matching.StringValuePattern
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 
@@ -20,13 +21,45 @@ private[wiremock] object WireMockTranslation:
    * `None` (the space owns its server outright).
    */
   def stub(id: SpaceId, rule: MockRule, priority: Priority, correlation: Option[Correlation]): StubMapping =
-    val base = requestBuilder(id, rule.`match`, correlation)
+    matcher(id, rule.`match`, priority, correlation).willReturn(response(rule.respond)).build()
+
+  /**
+   * Build a fault stub for space `id` matching `m` (#128): same request matcher
+   * as [[stub]] (so correlation/priority behave identically), but the response
+   * injects `fault` via WireMock's native `Fault` enum (connection kinds) or a
+   * fixed delay ([[FaultKind.LatencySpike]]).
+   */
+  def faultStub(
+    id: SpaceId,
+    m: RequestMatch,
+    fault: FaultKind,
+    priority: Priority,
+    correlation: Option[Correlation]
+  ): StubMapping =
+    matcher(id, m, priority, correlation).willReturn(faultResponse(fault)).build()
+
+  // Shared matcher builder for normal and fault stubs: the request matcher
+  // (requestBuilder) plus the Priority-enum precedence and a fresh id.
+  private def matcher(
+    id: SpaceId,
+    m: RequestMatch,
+    priority: Priority,
+    correlation: Option[Correlation]
+  ): MappingBuilder =
+    val base = requestBuilder(id, m, correlation)
     base.atPriority(priority match
       case Priority.Overlay => 1
       case Priority.Base    => 10
     )
     base.withId(UUID.randomUUID())
-    base.willReturn(response(rule.respond)).build()
+    base
+
+  private def faultResponse(fault: FaultKind): ResponseDefinitionBuilder = fault match
+    case FaultKind.ConnectionReset => WM.aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)
+    case FaultKind.EmptyResponse   => WM.aResponse().withFault(Fault.EMPTY_RESPONSE)
+    case FaultKind.MalformedChunk  => WM.aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)
+    case FaultKind.RandomThenClose => WM.aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE)
+    case FaultKind.LatencySpike(d) => WM.aResponse().withStatus(200).withFixedDelay(d.toMillis.toInt)
 
   /**
    * Build one edge of a scenario FSM (#130): the request matcher (plus the

--- a/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
+++ b/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
@@ -148,6 +148,50 @@ object WireMockControlSpec extends ZIOSpecDefault:
           elapsed <- Clock.nanoTime.map(_ - start)
         yield assertTrue(resp.status == 200, elapsed >= 250.millis.toNanos) // ~300ms fixed delay
       } @@ TestAspect.withLiveClock,
+      test("advertises Faults; its accessor succeeds and an unadvertised accessor fails fast") {
+        for
+          control    <- ZIO.service[MockControl]
+          faultsE    <- control.faults.either
+          scriptingE <- control.scripting.either
+        yield assertTrue(
+          control.capabilities.contains(Capability.Faults),
+          faultsE.isRight,
+          scriptingE == Left(Unsupported(Capability.Scripting, "wiremock"))
+        )
+      },
+      test("faults.inject ConnectionReset makes the SUT client observe a transport failure") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          faults  <- control.faults.orDieWith(u => new RuntimeException(u.toString))
+          _       <- die(faults.inject(a, RequestMatch(path = PathMatch.Exact("/boom")), FaultKind.ConnectionReset))
+          ping    <- SutClient.make(a).send(Method.Get, "/ping").exit // the normal rule still serves
+          boom    <- SutClient.make(a).send(Method.Get, "/boom").exit
+        yield assertTrue(ping.isSuccess, boom.isFailure)
+      },
+      test("faults.inject LatencySpike delays an otherwise-normal 200 response") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          faults  <- control.faults.orDieWith(u => new RuntimeException(u.toString))
+          _       <- die(faults.inject(a, RequestMatch(path = PathMatch.Exact("/slow")), FaultKind.LatencySpike(700.millis)))
+          start   <- Clock.nanoTime
+          resp    <- SutClient.make(a).send(Method.Get, "/slow").orDie
+          elapsed <- Clock.nanoTime.map(_ - start)
+        yield assertTrue(resp.status == 200, elapsed >= 400.millis.toNanos)
+      } @@ TestAspect.withLiveClock,
+      test("a fault overrides a normal rule on the same path (precedence) and removeRule restores it") {
+        for
+          control  <- ZIO.service[MockControl]
+          a        <- die(control.provision(pingSource)).map(_.head)   // /ping -> 200 pong
+          ok       <- SutClient.make(a).send(Method.Get, "/ping").exit
+          faults   <- control.faults.orDieWith(u => new RuntimeException(u.toString))
+          rid      <- die(faults.inject(a, RequestMatch(path = PathMatch.Exact("/ping")), FaultKind.ConnectionReset))
+          broken   <- SutClient.make(a).send(Method.Get, "/ping").exit // the fault wins over the rule
+          _        <- die(control.removeRule(a, rid))                  // the fault is tracked → removable
+          restored <- SutClient.make(a).send(Method.Get, "/ping").orDie
+        yield assertTrue(ok.isSuccess, broken.isFailure, restored.status == 200, restored.body == "pong")
+      },
       test("provisionNative(WireMock) serves a raw stub on its own server; a Rift spec is rejected") {
         for
           control <- ZIO.service[MockControl]
@@ -260,6 +304,21 @@ object WireMockControlSpec extends ZIOSpecDefault:
         aGone.isLeft      // A's server was stopped — connection refused
       )
     }.provide(perInstance),
+    test("WireMockTranslation.faultStub maps each kind to the WireMock Fault enum / fixed delay") {
+      import com.github.tomakehurst.wiremock.http.Fault
+      def respOf(kind: FaultKind) =
+        WireMockTranslation
+          .faultStub(SpaceId("s"), RequestMatch(path = PathMatch.Exact("/x")), kind, Priority.Overlay, None)
+          .getResponse
+      assertTrue(
+        respOf(FaultKind.ConnectionReset).getFault == Fault.CONNECTION_RESET_BY_PEER,
+        respOf(FaultKind.EmptyResponse).getFault == Fault.EMPTY_RESPONSE,
+        respOf(FaultKind.MalformedChunk).getFault == Fault.MALFORMED_RESPONSE_CHUNK,
+        respOf(FaultKind.RandomThenClose).getFault == Fault.RANDOM_DATA_THEN_CLOSE,
+        respOf(FaultKind.LatencySpike(1.second)).getFixedDelayMilliseconds.intValue == 1000,
+        respOf(FaultKind.LatencySpike(1.second)).getStatus == 200
+      )
+    },
     suite("traceparent correlation")(
       test("inject stamps a traceparent; a foreign trace-id does not reach the space") {
         for


### PR DESCRIPTION
Adds the portable Faults capability (`FaultKind` + `Faults.inject`) to the MockControl SPI. Rift maps each kind to `_rift.fault` (real connection-level faults from rift v0.6.0 / rift#239; latency for spikes); WireMock maps to its native `Fault` enum / fixed delay. Faults take first-match precedence and are tracked for removal in both isolation modes; both adapters advertise `Capability.Faults`, and the `cap-faults` conformance feature asserts each kind's client-observable failure on both, verified against the real rift v0.6.0 container.

Closes #128
Milestone: M3