### PR TITLE
feat: Rift StatefulScenarios adapter

### DIFF
--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
@@ -97,7 +97,7 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
     MockBackendUnderTest(
       "rift",
       (Client.default ++ Provisioning.live) >>> Rift.managed().mapError(asT),
-      Set(Capability.Faults),
+      Set(Capability.Faults, Capability.StatefulScenarios, Capability.StateInspection),
       Isolation.PerInstance,
       available = riftEnabled
     )
@@ -161,21 +161,24 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
       )
     } @@ TestAspect.withLiveClock,
-    test("cap-stateful feature PASSes on WireMock; SKIPs on Rift until #131 (#130)") {
+    test("cap-stateful feature PASSes on both adapters (WireMock + Rift under RIFT_IT) (#131)") {
       val all = CapStatefulScenarios.all
       for
         matrix   <- ConformanceHarness.run(List(wiremock, rift), all)
         _        <- ZIO.logInfo(s"cap-stateful matrix:\n${matrix.render}")
         wmFails   = nonPass(matrix, "wiremock", all)
         _        <- ZIO.logInfo(s"wiremock non-pass: $wmFails").when(wmFails.nonEmpty)
+        riftFails = nonPass(matrix, "rift", all)
+        _        <- ZIO.logInfo(s"rift non-pass: $riftFails").when(riftEnabled && riftFails.nonEmpty)
         riftCells = all.flatMap(s => matrix.cell(s.name, "rift").map(_.outcome))
       yield assertTrue(
         all.nonEmpty,
-        // WireMock now advertises StatefulScenarios + StateInspection -> the whole feature runs and passes.
         all.forall(s => matrix.cell(s.name, "wiremock").exists(_.outcome == Outcome.Pass)),
         matrix.cells.count(_.backend == "wiremock") == all.size,
-        // Rift doesn't advertise these until #131 -> every Rift cell is a justified SKIP.
-        riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
+        // Rift advertises StatefulScenarios + StateInspection now (#131): every scenario PASSes in CI
+        // (RIFT_IT); else the whole column is SKIPPED-unavailable (local, no Docker).
+        if riftEnabled then all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Pass))
+        else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
       )
     } @@ TestAspect.withLiveClock,
     test("fault-injection features pass on every adapter (#128)") {

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -53,8 +53,9 @@ private[rift] final case class RiftMockControl(
 
   import RiftMockControl.{CorrSpace, Imposter}
 
-  def backendName: String           = "rift"
-  def capabilities: Set[Capability] = Set(Capability.Faults)
+  def backendName: String = "rift"
+  def capabilities: Set[Capability] =
+    Set(Capability.Faults, Capability.StatefulScenarios, Capability.StateInspection)
 
   override def isolation: Isolation = mode match
     case RiftMode.Correlated(_) => Isolation.Correlated
@@ -103,8 +104,8 @@ private[rift] final case class RiftMockControl(
     dispatch(space)(corrReceived)(piReceived)
 
   def faults: IO[Unsupported, Faults]                   = ZIO.succeed(riftFaults)
-  def scenarios: IO[Unsupported, StatefulScenarios]     = unsupported(Capability.StatefulScenarios)
-  def stateInspection: IO[Unsupported, StateInspection] = unsupported(Capability.StateInspection)
+  def scenarios: IO[Unsupported, StatefulScenarios]     = ZIO.succeed(statefulScenarios)
+  def stateInspection: IO[Unsupported, StateInspection] = ZIO.succeed(stateInspector)
   def scripting: IO[Unsupported, Scripting]             = unsupported(Capability.Scripting)
   def proxyRecord: IO[Unsupported, ProxyRecord]         = unsupported(Capability.ProxyRecord)
   def templating: IO[Unsupported, Templating]           = unsupported(Capability.Templating)
@@ -142,6 +143,110 @@ private[rift] final case class RiftMockControl(
       _      <- cs.faults.set(next)
     yield ruleId
 
+  // ===== StatefulScenarios + StateInspection (#131) ===============================
+  // Rift partitions scenario state by (flow_id, scenarioName), so locality is native
+  // (no name-namespacing). flow_id = the imposter port (PerInstance) / the X-Mock-Space
+  // value (Correlated), so admin calls pass that flowId to address the same slice the
+  // requests resolve to. `define` installs the stubs in declaration order (Rift is
+  // first-match-by-order) and pins the initial state.
+  //
+  // Limitations (untested edges — the conformance gate is PerInstance, one define per
+  // space): re-`define` of an existing name APPENDS stubs rather than replacing the
+  // prior ones (provision a fresh space per scenario, as the conformance does); and on
+  // a Correlated space a plain-rule mutation (addRule/removeRule/replaceRules) rebuilds
+  // the space — dropping its scenario stubs too. Don't mix rule mutation with scenarios
+  // on one Correlated space.
+
+  private val statefulScenarios: StatefulScenarios = new StatefulScenarios:
+    def define(space: MockSpace, scenarioDef: ScenarioDef): IO[MockError, Unit] =
+      dispatch(space)(cs => corrDefine(cs, scenarioDef))(imp => piDefine(imp, scenarioDef))
+    def reset(space: MockSpace, name: String): IO[MockError, Unit] =
+      dispatch(space)(cs => corrReset(cs, space.id, name))(imp => piReset(imp, space.id, name))
+
+  private val stateInspector: StateInspection = new StateInspection:
+    def currentState(space: MockSpace, name: String): IO[MockError, ScenarioState] =
+      dispatch(space)(cs => readState(cs.port, cs.flowId, space.id, name))(imp =>
+        readState(imp.port, imp.port.toString, space.id, name)
+      )
+    def setState(space: MockSpace, name: String, to: ScenarioState): IO[MockError, Unit] =
+      dispatch(space)(cs => guardDefined(cs.scenarios, space.id, name)(putState(cs.port, cs.flowId, name, to)))(imp =>
+        guardDefined(imp.scenarios, space.id, name)(putState(imp.port, imp.port.toString, name, to))
+      )
+
+  private def piDefine(imp: Imposter, sc: ScenarioDef): IO[MockError, Unit] =
+    for
+      _ <- ZIO.foreachDiscard(sc.rules) { r =>
+             for
+               ruleId <- freshId
+               index  <- imp.stubs.get.map(_.size)
+               u      <- url(s"/imposters/${imp.port}/stubs")
+               stub    = RiftProtocol.statefulStub(sc.name, r.whenState, r.thenState, MockRule(r.request, r.respond))
+               res    <- send(jsonRequest(HttpMethod.POST, u, RiftProtocol.addStubBodyOf(index, stub)))
+               _      <- expectSuccess(s"add scenario stub to imposter ${imp.port}", res)
+               _      <- imp.stubs.update(_ :+ ruleId)
+             yield ()
+           }
+      // Always pin the initial state: it puts the scenario in its declared start
+      // state (so a re-define resets it) and registers an explicit FlowStore entry.
+      _ <- putState(imp.port, imp.port.toString, sc.name, sc.initial)
+      _ <- imp.scenarios.update(_ + (sc.name -> sc.initial))
+    yield ()
+
+  private def corrDefine(cs: CorrSpace, sc: ScenarioDef): IO[MockError, Unit] =
+    for
+      _ <- ZIO.foreachDiscard(sc.rules) { r =>
+             val stub = RiftProtocol.statefulStub(sc.name, r.whenState, r.thenState, MockRule(r.request, r.respond))
+             for
+               u   <- url(s"/imposters/${cs.port}/spaces/${enc(cs.flowId)}/stubs")
+               res <- send(jsonRequest(HttpMethod.POST, u, stub))
+               _   <- expectSuccess(s"add scenario stub to space ${cs.flowId}", res)
+             yield ()
+           }
+      _ <- putState(cs.port, cs.flowId, sc.name, sc.initial)
+      _ <- cs.scenarios.update(_ + (sc.name -> sc.initial))
+    yield ()
+
+  private def piReset(imp: Imposter, spaceId: SpaceId, name: String): IO[MockError, Unit] =
+    imp.scenarios.get.flatMap(_.get(name) match
+      case Some(initial) => putState(imp.port, imp.port.toString, name, initial)
+      case None          => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${spaceId.value}"))
+    )
+
+  private def corrReset(cs: CorrSpace, spaceId: SpaceId, name: String): IO[MockError, Unit] =
+    cs.scenarios.get.flatMap(_.get(name) match
+      case Some(initial) => putState(cs.port, cs.flowId, name, initial)
+      case None          => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${spaceId.value}"))
+    )
+
+  private def guardDefined(
+    scenarios: Ref[Map[String, ScenarioState]],
+    spaceId: SpaceId,
+    name: String
+  )(action: => IO[MockError, Unit]): IO[MockError, Unit] =
+    scenarios.get.flatMap(s =>
+      if s.contains(name) then action
+      else ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${spaceId.value}"))
+    )
+
+  private def putState(port: Int, flowId: String, name: String, state: ScenarioState): IO[MockError, Unit] =
+    for
+      u   <- url(s"/imposters/$port/scenarios/${enc(name)}/state")
+      body = Json.Obj("state" -> Json.Str(state.value), "flowId" -> Json.Str(flowId))
+      res <- send(jsonRequest(HttpMethod.PUT, u, body))
+      _   <- expectSuccess(s"set scenario '$name' state on imposter $port", res)
+    yield ()
+
+  private def readState(port: Int, flowId: String, spaceId: SpaceId, name: String): IO[MockError, ScenarioState] =
+    for
+      u    <- url(s"/imposters/$port/scenarios?flowId=${enc(flowId)}")
+      res  <- send(Request(method = HttpMethod.GET, url = u))
+      body <- expectSuccess(s"read scenarios for imposter $port", res)
+      st   <- ZIO.fromEither(RiftProtocol.parseScenarioState(body, name)).mapError(MockError.CommunicationError(_))
+      out <- st match
+               case Some(s) => ZIO.succeed(ScenarioState(s))
+               case None    => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${spaceId.value}"))
+    yield out
+
   // ---------------------------------------------------------------------------
 
   private def serveSpace(src: NormalizedSource): IO[MockError, MockSpace] =
@@ -174,9 +279,10 @@ private[rift] final case class RiftMockControl(
           _            <- postImposter(port, body)
           ruleIds      <- freshIds(count)
           stubs        <- Ref.make(ruleIds)
+          scen         <- Ref.make(Map.empty[String, ScenarioState])
           id            = SpaceId(s"${src.name}-$port")
           space         = MockSpace(endpoint.baseUriFor(port), identity, id)
-          _            <- spaces.update(_.updated(id, Imposter(port, stubs)))
+          _            <- spaces.update(_.updated(id, Imposter(port, stubs, scen)))
         yield space
       stand.onError(_ => endpoint.releasePort(port))
     }
@@ -254,7 +360,8 @@ private[rift] final case class RiftMockControl(
       _         <- registerStubs(port, flowId, tagged).onError(_ => deleteSpace(port, flowId).ignore)
       rulesRef  <- Ref.make(tagged)
       faultsRef <- Ref.make(Vector.empty[(RuleId, RequestMatch, FaultKind)])
-      _         <- correlated.update(_.updated(id, CorrSpace(port, flowId, corr.header, rulesRef, faultsRef)))
+      scen      <- Ref.make(Map.empty[String, ScenarioState])
+      _         <- correlated.update(_.updated(id, CorrSpace(port, flowId, corr.header, rulesRef, faultsRef, scen)))
     yield MockSpace(endpoint.baseUriFor(port), req => req.copy(headers = req.headers.add(corr.header, flowId)), id)
 
   // Create the one shared imposter on first Correlated provision (race-safe).
@@ -448,13 +555,18 @@ private[rift] final case class RiftMockControl(
     else ZIO.fail(MockError.CommunicationError(s"$action: Rift returned HTTP $code: ${body.take(1000)}"))
 
 private[rift] object RiftMockControl:
-  final case class Imposter(port: Int, stubs: Ref[Vector[RuleId]])
+  final case class Imposter(
+    port: Int,
+    stubs: Ref[Vector[RuleId]],
+    scenarios: Ref[Map[String, ScenarioState]] // defined scenario name -> initial state (for reset)
+  )
   final case class CorrSpace(
     port: Int,
     flowId: String,
     header: String,
     rules: Ref[Vector[(RuleId, MockRule)]],
-    faults: Ref[Vector[(RuleId, RequestMatch, FaultKind)]]
+    faults: Ref[Vector[(RuleId, RequestMatch, FaultKind)]],
+    scenarios: Ref[Map[String, ScenarioState]]
   )
 
   /**

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -22,6 +22,24 @@ private[rift] object RiftProtocol:
   private val unmatched404: Json = Json.Obj("statusCode" -> Json.Num(404))
 
   /**
+   * The `_rift.flowState` extension that backs declarative scenarios
+   * (rift#190). Rift only attaches a real (in-memory) flow store at
+   * imposter-creation when either scenario stubs are present OR this config is
+   * — otherwise stubs added later via `POST /stubs` hit a NoOp store and their
+   * state never advances. We provision empty then add scenario stubs in
+   * `define`, so every imposter carries it. `flowIdSource` partitions state:
+   * the imposter port (PerInstance) or a correlation header (Correlated).
+   */
+  private def flowStateExt(flowIdSource: String): (String, Json) =
+    "_rift" -> Json.Obj(
+      "flowState" -> Json.Obj(
+        "backend"                -> Json.Str("inmemory"),
+        "ttlSeconds"             -> Json.Num(300),
+        "mountebankStateMapping" -> Json.Obj("flowIdSource" -> Json.Str(flowIdSource))
+      )
+    )
+
+  /**
    * A full `POST /imposters` body for one space: one imposter, recording on.
    */
   def imposter(port: Int, name: String, rules: List[MockRule]): Json =
@@ -31,7 +49,8 @@ private[rift] object RiftProtocol:
       "name"            -> Json.Str(name),
       "recordRequests"  -> Json.Bool(true),
       "defaultResponse" -> unmatched404,
-      "stubs"           -> Json.Arr(rules.map(stub)*)
+      "stubs"           -> Json.Arr(rules.map(stub)*),
+      flowStateExt("imposter_port")
     )
 
   /**
@@ -51,13 +70,7 @@ private[rift] object RiftProtocol:
       "recordRequests"  -> Json.Bool(true),
       "defaultResponse" -> unmatched404,
       "stubs"           -> Json.Arr(),
-      "_rift" -> Json.Obj(
-        "flowState" -> Json.Obj(
-          "backend"                -> Json.Str("inmemory"),
-          "ttlSeconds"             -> Json.Num(300),
-          "mountebankStateMapping" -> Json.Obj("flowIdSource" -> Json.Str(s"header:$correlationHeader"))
-        )
-      )
+      flowStateExt(s"header:$correlationHeader")
     )
 
   /** A single Mountebank stub: predicates (ANDed) + one response. */
@@ -65,6 +78,31 @@ private[rift] object RiftProtocol:
     val idField = rule.id.map(id => "id" -> Json.Str(id.value)).toList
     Json.Obj(
       (idField ++ List(
+        "predicates" -> Json.Arr(predicates(rule.`match`)*),
+        "responses"  -> Json.Arr(response(rule.respond))
+      ))*
+    )
+
+  /**
+   * One edge of a scenario FSM (#131): a normal stub carrying Rift's
+   * declarative scenario fields (rift#190). The stub is eligible only while
+   * `(flow_id, scenarioName)` state equals `whenState`, and serves `respond`
+   * then transitions to `thenState` (`None` = stay — `newScenarioState` is
+   * omitted). State is partitioned by `flow_id`, so two spaces sharing a
+   * scenario name keep independent state natively (no name-namespacing needed).
+   */
+  def statefulStub(
+    scenarioName: String,
+    whenState: ScenarioState,
+    thenState: Option[ScenarioState],
+    rule: MockRule
+  ): Json =
+    val transition = thenState.map(s => "newScenarioState" -> Json.Str(s.value)).toList
+    Json.Obj(
+      (List(
+        "scenarioName"          -> Json.Str(scenarioName),
+        "requiredScenarioState" -> Json.Str(whenState.value)
+      ) ++ transition ++ List(
         "predicates" -> Json.Arr(predicates(rule.`match`)*),
         "responses"  -> Json.Arr(response(rule.respond))
       ))*
@@ -117,6 +155,13 @@ private[rift] object RiftProtocol:
    */
   def addFaultStubBody(index: Int, m: RequestMatch, fault: FaultKind, id: RuleId): Json =
     Json.Obj("index" -> Json.Num(index), "stub" -> faultStub(m, fault, id))
+
+  /**
+   * The `{index, stub}` body for a pre-built stub JSON (e.g. a
+   * [[statefulStub]]).
+   */
+  def addStubBodyOf(index: Int, stub: Json): Json =
+    Json.Obj("index" -> Json.Num(index), "stub" -> stub)
 
   def predicates(m: RequestMatch): List[Json] =
     val methodPred = m.method.map(meth => equalsObj("method" -> Json.Str(methodName(meth))))
@@ -181,6 +226,17 @@ private[rift] object RiftProtocol:
     body: Option[String] = None
   ) derives JsonDecoder
   private case class WireView(requests: Option[List[WireReq]] = None) derives JsonDecoder
+
+  private case class WireScenario(name: String, state: String) derives JsonDecoder
+  private case class WireScenarios(scenarios: List[WireScenario] = Nil) derives JsonDecoder
+
+  /**
+   * The current state of scenario `name` from a `GET
+   * /imposters/:port/scenarios` body (rift#190); `None` if the scenario isn't
+   * declared on the imposter.
+   */
+  def parseScenarioState(viewJson: String, name: String): Either[String, Option[String]] =
+    viewJson.fromJson[WireScenarios].map(_.scenarios.find(_.name == name).map(_.state))
 
   /** Parse the `requests[]` of a `GET /imposters/:port` view. */
   def parseRecorded(viewJson: String): Either[String, List[RecordedRequest]] =

--- a/rift/src/test/scala/zio/bdd/mock/rift/FakeRift.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/FakeRift.scala
@@ -24,7 +24,10 @@ final case class FakeRift(
   requestMatches: Ref[Chunk[String]],
   filtered: Ref[String],
   views: Ref[Map[Int, String]],
-  failProvision: Ref[Boolean]
+  failProvision: Ref[Boolean],
+  scenarioPuts: Ref[Chunk[String]],
+  scenarioGets: Ref[Chunk[String]],
+  scenariosView: Ref[String]
 ):
   /**
    * Preset the `GET /imposters/:port` view (e.g. to inject recorded requests).
@@ -35,6 +38,11 @@ final case class FakeRift(
    * Preset the body returned by `GET /imposters/:port/requests?match=…` (#201).
    */
   def setFiltered(json: String): UIO[Unit] = filtered.set(json)
+
+  /**
+   * Preset the body returned by `GET /imposters/:port/scenarios` (rift#190).
+   */
+  def setScenarios(json: String): UIO[Unit] = scenariosView.set(json)
 
   val routes: Routes[Any, Response] =
     Routes(
@@ -88,6 +96,16 @@ final case class FakeRift(
       Method.DELETE / "imposters" / int("port") / "stubs" / int("index") -> handler {
         (port: Int, index: Int, _: Request) =>
           stubCalls.update(_ :+ s"DELETE $port/$index").as(Response.ok)
+      },
+      // Scenario state set (rift#190): PUT /imposters/:port/scenarios/:name/state
+      Method.PUT / "imposters" / int("port") / "scenarios" / string("name") / "state" -> handler {
+        (port: Int, name: String, req: Request) =>
+          req.body.asString.orDie.flatMap(b => scenarioPuts.update(_ :+ s"$port/$name $b")).as(Response.ok)
+      },
+      // Scenario list + state (rift#190): GET /imposters/:port/scenarios[?flowId=]
+      Method.GET / "imposters" / int("port") / "scenarios" -> handler { (port: Int, req: Request) =>
+        val flow = req.url.queryParams.queryParam("flowId").getOrElse("")
+        (scenarioGets.update(_ :+ s"$port?$flow") *> scenariosView.get).map(v => Response(body = Body.fromString(v)))
       }
     )
 
@@ -106,7 +124,10 @@ object FakeRift:
       fl <- Ref.make("[]")
       e  <- Ref.make(Map.empty[Int, String])
       f  <- Ref.make(false)
-    yield FakeRift(a, b, c, d, ss, sd, rm, fl, e, f)
+      sp <- Ref.make(Chunk.empty[String])
+      sg <- Ref.make(Chunk.empty[String])
+      sv <- Ref.make("""{"flowId":"","scenarios":[]}""")
+    yield FakeRift(a, b, c, d, ss, sd, rm, fl, e, f, sp, sg, sv)
 
   def portOf(body: String): Option[Int] =
     import zio.json.*

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -2,6 +2,7 @@ package zio.bdd.mock.rift
 
 import zio.*
 import zio.bdd.mock.*
+import zio.bdd.mock.dsl.*
 import zio.http.Client
 import zio.test.*
 
@@ -193,15 +194,17 @@ object RiftMockControlSpec extends ZIOSpecDefault:
         )
       }
     },
-    test("advertises Faults; its accessor succeeds and the other accessors fail fast") {
+    test("advertises Faults + StatefulScenarios + StateInspection; the other accessors fail fast (#131)") {
       withAdapter { (control, _) =>
         for
-          faultsE    <- control.faults.either
-          scenariosE <- control.scenarios.either
+          faultsE <- control.faults.either
+          scenE   <- control.scenarios.either
+          siE     <- control.stateInspection.either
         yield assertTrue(
-          control.capabilities == Set(Capability.Faults),
+          control.capabilities == Set(Capability.Faults, Capability.StatefulScenarios, Capability.StateInspection),
           faultsE.isRight,
-          scenariosE == Left(Unsupported(Capability.StatefulScenarios, "rift"))
+          scenE.isRight,
+          siE.isRight
         )
       }
     },
@@ -242,6 +245,57 @@ object RiftMockControlSpec extends ZIOSpecDefault:
           faultIx >= 0,
           rulePast,
           rmE.isRight
+        )
+      }
+    },
+    // The container proves end-to-end stateful behaviour (RiftContainerSpec / cap-stateful under RIFT_IT);
+    // here we assert the adapter issues the right scenario admin calls — no Docker, no wrong-path regression.
+    test("define/setState/currentState/reset issue the right Rift scenario admin calls (#131)") {
+      val invoice =
+        scenario("invoice")
+          .when("Started", get("/inv"))
+          .respond(ok.text("created"))
+          .goTo("Paid")
+          .when("Paid", get("/inv"))
+          .respond(ok.text("paid"))
+          .stay
+          .build
+      withAdapter { (control, fake) =>
+        for
+          space <-
+            control.provision(MockSource.Dsl(MockSpec(Nil))).orDieWith(e => RuntimeException(e.toString)).map(_.head)
+          port    = portOf(space.baseUri)
+          ss     <- control.scenarios.orDieWith(u => RuntimeException(u.toString))
+          si     <- control.stateInspection.orDieWith(u => RuntimeException(u.toString))
+          _      <- ss.define(space, invoice).orDieWith(e => RuntimeException(e.toString))
+          stubs  <- fake.stubCalls.get
+          _      <- fake.setScenarios(s"""{"flowId":"$port","scenarios":[{"name":"invoice","state":"Paid"}]}""")
+          cur    <- si.currentState(space, "invoice").orDieWith(e => RuntimeException(e.toString))
+          gets   <- fake.scenarioGets.get
+          _      <- si.setState(space, "invoice", ScenarioState("Paid")).orDieWith(e => RuntimeException(e.toString))
+          _      <- ss.reset(space, "invoice").orDieWith(e => RuntimeException(e.toString))
+          puts   <- fake.scenarioPuts.get
+          ghost  <- si.currentState(space, "ghost").either
+          ghostR <- ss.reset(space, "ghost").either
+        yield assertTrue(
+          // define posts both FSM edges with the scenario fields; rule 0 is at index 0 (first-match order)
+          stubs.count(_.contains("\"scenarioName\":\"invoice\"")) == 2,
+          stubs.exists(s => s.contains("\"index\":0") && s.contains("\"requiredScenarioState\":\"Started\"")),
+          stubs.exists(_.contains("\"newScenarioState\":\"Paid\"")), // the advance edge
+          // define pins the initial state via PUT /scenarios/invoice/state {state, flowId=port}
+          puts.exists(p =>
+            p.startsWith(s"$port/invoice ") && p.contains("\"state\":\"Started\"") && p.contains(
+              s"\"flowId\":\"$port\""
+            )
+          ),
+          // currentState reads GET /scenarios?flowId=port and parses the view
+          cur == ScenarioState("Paid"),
+          gets.exists(_ == s"$port?$port"),
+          // setState PUTs the new state
+          puts.exists(_.contains("\"state\":\"Paid\"")),
+          // an unknown scenario fails with InvalidDefinition (Ref guard + absent in the view)
+          ghost == Left(MockError.InvalidDefinition(s"no scenario 'ghost' on space ${space.id.value}")),
+          ghostR == Left(MockError.InvalidDefinition(s"no scenario 'ghost' on space ${space.id.value}"))
         )
       }
     },

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
@@ -21,13 +21,44 @@ object RiftProtocolSpec extends ZIOSpecDefault:
   )
 
   def spec = suite("RiftProtocol (canonical <-> Mountebank)")(
-    test("imposter carries port, http protocol, recordRequests, and one stub per rule") {
+    test("statefulStub carries the scenario FSM fields; stay omits newScenarioState (#131)") {
+      val invRule = (path: String, body: String) =>
+        MockRule(RequestMatch(path = PathMatch.Exact(path)), ResponseDef(status = 200, body = Body.Text(body)))
+      val advance = RiftProtocol.statefulStub(
+        "invoice",
+        ScenarioState("Started"),
+        Some(ScenarioState("Paid")),
+        invRule("/inv", "created")
+      )
+      val stay = RiftProtocol.statefulStub("invoice", ScenarioState("Paid"), None, invRule("/inv", "paid"))
+      assertTrue(
+        advance / "scenarioName" == Json.Str("invoice"),
+        advance / "requiredScenarioState" == Json.Str("Started"),
+        advance / "newScenarioState" == Json.Str("Paid"),
+        arr(advance / "responses").head / "is" / "body" == Json.Str("created"),
+        stay / "requiredScenarioState" == Json.Str("Paid"),
+        stay / "newScenarioState" == Json.Null // stay -> no transition field
+      )
+    },
+    test("parseScenarioState reads a scenario's state from the admin view; None when absent (#131)") {
+      val view =
+        """{"flowId":"4545","scenarios":[{"name":"invoice","state":"Paid"},{"name":"other","state":"Started"}]}"""
+      assertTrue(
+        RiftProtocol.parseScenarioState(view, "invoice") == Right(Some("Paid")),
+        RiftProtocol.parseScenarioState(view, "missing") == Right(None),
+        RiftProtocol.parseScenarioState("not json", "invoice").isLeft // malformed -> Left (becomes CommunicationError)
+      )
+    },
+    test("imposter carries port, http protocol, recordRequests, a stub per rule, and a flow store (#131)") {
       val j = RiftProtocol.imposter(4545, "ping", List(pingRule))
       assertTrue(
         j / "port" == Json.Num(4545),
         j / "protocol" == Json.Str("http"),
         j / "recordRequests" == Json.Bool(true),
-        arr(j / "stubs").size == 1
+        arr(j / "stubs").size == 1,
+        // an in-memory flow store keyed by port, so scenario stubs added later actually advance
+        j / "_rift" / "flowState" / "backend" == Json.Str("inmemory"),
+        j / "_rift" / "flowState" / "mountebankStateMapping" / "flowIdSource" == Json.Str("imposter_port")
       )
     },
     test("an exact path + method rule becomes equals predicates and an `is` response") {


### PR DESCRIPTION
The Rift `StatefulScenarios` + `StateInspection` adapter — maps the portable single-token FSM onto Rift's declarative scenarios (rift#190, shipped in v0.5.0). This completes the cap-stateful feature on **both** adapters (WireMock #130 + Rift).

## Mapping
- Each `StatefulRule` → a Rift stub carrying `scenarioName` + `requiredScenarioState` (= whenState) + `newScenarioState` (= thenState, omitted for stay).
- **Locality is native**: Rift partitions scenario state by `(flow_id, scenarioName)`, so two spaces sharing a scenario name keep independent state with no name-namespacing (unlike WireMock). **First-match is native** (stub list order).
- **flow addressing**: PerInstance uses `flowId = imposter port` (Rift's default `imposter_port` source); Correlated uses the `X-Mock-Space` value. Admin calls pass that flowId so they target the same slice requests resolve to.
- **StateInspection**: `currentState` GETs `/imposters/:port/scenarios`, `setState`/`reset` PUT `/scenarios/:name/state`; `define` pins the initial state. Unknown scenario → `InvalidDefinition`.

## Verification
- The cap-stateful matrix test now asserts all 7 scenarios **PASS on Rift under RIFT_IT** (eligibility+transition, unmatched-no-change, reset, locality, first-match, concurrency, StateInspection); WireMock stays green.
- `RiftProtocolSpec` unit-tests the wire logic (`statefulStub` field emission incl. the stay/omit branch; `parseScenarioState`); a **FakeRift-backed `RiftMockControlSpec` test** asserts the adapter issues the right scenario admin calls (paths/methods/bodies/flowId) — catching a wrong-route regression with no container.

## Notes
- There is no local Docker, so the Rift **end-to-end** behaviour is validated only by the `rift-it` CI job against the real container; local green proves the protocol wire logic + admin-call routing.
- The **PerInstance** path is the conformance gate. **Correlated** stateful is implemented but CI-unverified, and re-`define` appends rather than replaces — both documented as known limitations in the adapter.
- Rebased onto the epic after master (rift v0.6.0 + multi-value headers #162) merged in; the one conflict (Correlated inject + the new per-space scenario Ref) was resolved combining both. 827 tests pass.

Closes #131
Milestone: M3