### PR TITLE
feat: Scripting / ProxyRecord / Templating capability traits

### DIFF
--- a/conformance/src/main/scala/zio/bdd/mock/conformance/ScriptingScenarios.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/ScriptingScenarios.scala
@@ -1,0 +1,54 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+
+/**
+ * The portable scripting conformance scenarios (#132) — the `cap-scripting`
+ * feature. Gated on [[Capability.Scripting]], so a backend that does not
+ * advertise it (WireMock has no scripting engine) SKIPs them. The script
+ * computes the response from the matched request, proving the backend actually
+ * runs it (Rift via `_rift.script`).
+ */
+object ScriptingScenarios:
+
+  lazy val all: List[ConformanceScenario] = List(scriptedResponse)
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+
+  private def ensure(cond: Boolean, msg: => String): IO[Throwable, Unit] =
+    ZIO.unless(cond)(ZIO.fail(new AssertionError(msg))).unit
+
+  private val emptySource = MockSource.Dsl(MockSpec(Nil))
+
+  private def space(control: MockControl): ZIO[Scope, Throwable, MockSpace] =
+    ZIO.acquireRelease(control.provision(emptySource).mapError(asT).map(_.head))(s => control.destroy(s).ignoreLogged)
+
+  // A Rhai script that computes the body from the request method — so a passing
+  // round-trip proves the backend ran the script (a static stub couldn't echo it).
+  // Rift's script API returns a decision map; `fault: "error"` is its token for "return this
+  // computed { status, body, headers } response" (not an actual error). Here the body is derived
+  // from request.method, so a passing round-trip proves the engine ran the script.
+  private val rhaiEchoMethod =
+    Script(
+      ScriptEngine.Rhai,
+      "fn should_inject(request, flow_store) { #{inject: true, fault: \"error\", status: 200, " +
+        "body: `scripted-${request.method}`, headers: #{\"Content-Type\": \"text/plain\"}} }"
+    )
+
+  private val scriptedResponse =
+    ConformanceScenario(
+      "scripting: the script computes the response from the request",
+      Set(Capability.Scripting),
+      control =>
+        for
+          s         <- space(control)
+          scripting <- control.scripting.mapError(u => new RuntimeException(u.toString))
+          _         <- scripting.inject(s, RequestMatch(path = PathMatch.Exact("/s")), rhaiEchoMethod).mapError(asT)
+          resp      <- SutClient.make(s).send(Method.Get, "/s")
+          _ <- ensure(
+                 resp.status == 200 && resp.body == "scripted-GET",
+                 s"scripting: status=${resp.status} body=${resp.body}"
+               )
+        yield ()
+    )

--- a/conformance/src/main/scala/zio/bdd/mock/conformance/TemplatingScenarios.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/TemplatingScenarios.scala
@@ -1,0 +1,67 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+
+/**
+ * The portable templating conformance scenarios (#132) — the `cap-templating`
+ * feature. Gated on [[Capability.Templating]], so a backend that does not
+ * advertise it SKIPs them. A capture pulls a value out of the request (here the
+ * last path segment) and the response body interpolates it (Rift via a
+ * Mountebank `copy` behavior).
+ */
+object TemplatingScenarios:
+
+  lazy val all: List[ConformanceScenario] = List(pathCapture, bodyCapture)
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+
+  private def ensure(cond: Boolean, msg: => String): IO[Throwable, Unit] =
+    ZIO.unless(cond)(ZIO.fail(new AssertionError(msg))).unit
+
+  private val emptySource = MockSource.Dsl(MockSpec(Nil))
+
+  private def space(control: MockControl): ZIO[Scope, Throwable, MockSpace] =
+    ZIO.acquireRelease(control.provision(emptySource).mapError(asT).map(_.head))(s => control.destroy(s).ignoreLogged)
+
+  private def templatingOf(control: MockControl): IO[Throwable, Templating] =
+    control.templating.mapError(u => new RuntimeException(u.toString))
+
+  private val pathCapture =
+    ConformanceScenario(
+      "templating: interpolates a value captured from the request path",
+      Set(Capability.Templating),
+      control =>
+        for
+          s          <- space(control)
+          templating <- templatingOf(control)
+          template = ResponseTemplate(
+                       body = "Hello ${NAME}",
+                       captures = List(TemplateCapture("${NAME}", TemplateSource.Path, "[^/]+$"))
+                     )
+          _    <- templating.inject(s, RequestMatch(path = PathMatch.Regex("^/greet/[^/]+$")), template).mapError(asT)
+          resp <- SutClient.make(s).send(Method.Get, "/greet/World")
+          _ <-
+            ensure(resp.status == 200 && resp.body == "Hello World", s"path: status=${resp.status} body=${resp.body}")
+        yield ()
+    )
+
+  private val bodyCapture =
+    ConformanceScenario(
+      "templating: interpolates a value captured from the request body",
+      Set(Capability.Templating),
+      control =>
+        for
+          s          <- space(control)
+          templating <- templatingOf(control)
+          template = ResponseTemplate(
+                       body = "echo:${WHO}",
+                       captures = List(TemplateCapture("${WHO}", TemplateSource.Body, "\\w+"))
+                     )
+          _ <- templating
+                 .inject(s, RequestMatch(method = Some(Method.Post), path = PathMatch.Exact("/echo")), template)
+                 .mapError(asT)
+          resp <- SutClient.make(s).send(Method.Post, "/echo", body = Some("Alice"))
+          _    <- ensure(resp.status == 200 && resp.body == "echo:Alice", s"body: status=${resp.status} body=${resp.body}")
+        yield ()
+    )

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
@@ -97,7 +97,7 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
     MockBackendUnderTest(
       "rift",
       (Client.default ++ Provisioning.live) >>> Rift.managed().mapError(asT),
-      Set(Capability.Faults, Capability.StatefulScenarios, Capability.StateInspection),
+      Capability.values.toSet, // Rift advertises every capability (#132)
       Isolation.PerInstance,
       available = riftEnabled
     )
@@ -199,8 +199,33 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         if riftEnabled then all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Pass))
         else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
       )
+    } @@ TestAspect.withLiveClock,
+    test("cap-scripting feature PASSes on Rift; SKIPs on WireMock (un-advertised) (#132)") {
+      riftOnlyCapability("cap-scripting", ScriptingScenarios.all)
+    } @@ TestAspect.withLiveClock,
+    test("cap-templating feature PASSes on Rift; SKIPs on WireMock (un-advertised) (#132)") {
+      riftOnlyCapability("cap-templating", TemplatingScenarios.all)
     } @@ TestAspect.withLiveClock
   )
+
+  // A capability only Rift advertises: WireMock SKIPs every scenario (un-advertised,
+  // a justified SKIP — never FAIL); Rift PASSes under RIFT_IT, else its column is
+  // SKIPPED-unavailable (local, no Docker).
+  private def riftOnlyCapability(label: String, all: List[ConformanceScenario]) =
+    for
+      matrix   <- ConformanceHarness.run(List(wiremock, rift), all)
+      _        <- ZIO.logInfo(s"$label matrix:\n${matrix.render}")
+      rfFails   = nonPass(matrix, "rift", all)
+      _        <- ZIO.logInfo(s"rift non-pass: $rfFails").when(riftEnabled && rfFails.nonEmpty)
+      wmCells   = all.flatMap(s => matrix.cell(s.name, "wiremock").map(_.outcome))
+      riftCells = all.flatMap(s => matrix.cell(s.name, "rift").map(_.outcome))
+    yield assertTrue(
+      all.nonEmpty,
+      wmCells.size == all.size && wmCells.forall(_ == Outcome.Skip),
+      matrix.conformant(wiremock),
+      if riftEnabled then all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Pass))
+      else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
+    )
 
   private def nonPass(matrix: Matrix, backend: String, scenarios: List[ConformanceScenario]): List[String] =
     scenarios.flatMap { s =>

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ProxyRecordConformanceSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ProxyRecordConformanceSpec.scala
@@ -1,0 +1,101 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.rift.Rift
+import zio.http.Client
+import zio.test.*
+
+import org.testcontainers.containers.{GenericContainer, Network}
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * The `cap-proxy` conformance (#132): the full ProxyRecord acceptance — proxy
+ * to a real upstream, record, then replay with the upstream down. Both the Rift
+ * container and a tiny `http-echo` upstream join one shared Docker network, so
+ * Rift reaches the upstream by its container IP on that network — pure
+ * container-to-container, no host networking. After the first call records the
+ * upstream response, the echo container is stopped; a successful replay then
+ * proves the recording is served without contacting the (now-down) upstream.
+ *
+ * Gated on `RIFT_IT` (Docker) like [[zio.bdd.mock.rift.RiftContainerSpec]];
+ * WireMock does not advertise ProxyRecord, so the portable capability is
+ * correctly Rift-only.
+ */
+object ProxyRecordConformanceSpec extends ZIOSpecDefault:
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+
+  private val adminPort     = Rift.DefaultAdminPort
+  private val imposterPorts = (0 until 4).map(Rift.DefaultImposterBase + _).toList
+  private val echoText      = "echo-ok"
+
+  private def acquire[A](mk: => A)(close: A => Unit): ZIO[Scope, Throwable, A] =
+    ZIO.acquireRelease(ZIO.attemptBlocking(mk))(a => ZIO.attemptBlocking(close(a)).orDie)
+
+  private def send(space: MockSpace, label: String): IO[Throwable, SutResponse] =
+    SutClient
+      .make(space)
+      .send(Method.Get, "/echo")
+      .timeoutFail(new RuntimeException(s"SUT $label timed out after 15s"))(15.seconds)
+
+  private def startEcho(net: Network): GenericContainer[?] =
+    val c = new GenericContainer(DockerImageName.parse("hashicorp/http-echo:1.0.0"))
+    c.withNetwork(net)
+    c.withCommand(s"-text=$echoText")
+    c.waitingFor(Wait.forLogMessage(".*server is listening.*", 1))
+    c.start()
+    c
+
+  // The echo container's IP on the shared network — Rift proxies to it directly, so the test
+  // doesn't depend on Rift's Rust proxy resolving a Docker DNS alias.
+  private def ipOf(c: GenericContainer[?]): String =
+    c.getContainerInfo.getNetworkSettings.getNetworks.values.iterator.next.getIpAddress
+
+  private def startRift(net: Network): GenericContainer[?] =
+    val c = new GenericContainer(DockerImageName.parse(Rift.DefaultImage))
+    c.withNetwork(net)
+    (adminPort :: imposterPorts).foreach(p => c.addExposedPort(Integer.valueOf(p)))
+    c.waitingFor(Wait.forHttp("/imposters").forPort(adminPort))
+    c.start()
+    c
+
+  private val proxyTest =
+    test("proxy records the upstream response and replays it after the upstream is down (#132)") {
+      ZIO.scoped {
+        for
+          net    <- acquire(Network.newNetwork())(_.close())
+          echo   <- acquire(startEcho(net))(_.stop()) // stop() is idempotent — also called mid-test below
+          rift   <- acquire(startRift(net))(_.stop())
+          admin   = s"http://${rift.getHost}:${rift.getMappedPort(Integer.valueOf(adminPort))}"
+          hostFor = (p: Int) => s"http://${rift.getHost}:${rift.getMappedPort(Integer.valueOf(p))}"
+          // Build Client + Provisioning + control into the test scope (not a nested one) so the
+          // zio-http admin Client stays alive for the whole test, not just the layer build.
+          env     <- ((Client.default ++ Provisioning.live) >>> Rift.connect(admin, imposterPorts)(hostFor)).build
+          control  = env.get[MockControl]
+          space   <- control.provision(MockSource.Dsl(MockSpec(Nil))).mapError(asT).map(_.head)
+          proxy   <- control.proxyRecord.mapError(u => new RuntimeException(u.toString))
+          upstream = s"http://${ipOf(echo)}:5678"
+          _       <- proxy.proxy(space, RequestMatch(path = PathMatch.Exact("/echo")), upstream).mapError(asT)
+          // First call: Rift proxies to the upstream and records the response. Time it out so a
+          // misconfigured proxy fails fast instead of blocking on the unbounded Java HttpClient.
+          first <- send(space, "first call (proxy + record)")
+          // Upstream goes down. Bound the blocking stop so a stalled daemon fails fast, like the SUT calls.
+          _ <- ZIO
+                 .attemptBlocking(echo.stop())
+                 .timeoutFail(new RuntimeException("echo.stop() timed out after 30s"))(30.seconds)
+          // Second call: served from the recording — the upstream is never contacted.
+          second <- send(space, "second call (replay, upstream down)")
+        yield assertTrue(
+          first.status == 200,
+          first.body.trim == echoText,
+          second.status == 200,
+          second.body.trim == echoText // identical with the upstream down => replayed, not re-proxied
+        )
+      }
+    } @@ TestAspect.withLiveClock
+
+  def spec =
+    if sys.env.contains("RIFT_IT") then suite("ProxyRecordConformance")(proxyTest)
+    else suite("ProxyRecordConformance (skipped — set RIFT_IT=1 to run against a real Rift container)")()

--- a/mock/src/main/scala/zio/bdd/mock/Capability.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Capability.scala
@@ -69,13 +69,39 @@ trait StateInspection:
   def setState(space: MockSpace, name: String, to: ScenarioState): IO[MockError, Unit]
 
 /** Backend scripting hooks. Capability: [[Capability.Scripting]]. */
-trait Scripting
+trait Scripting:
+  /**
+   * Install `script` to compute the response for requests matching `m`,
+   * returning the rule id. The script runs on the backend's engine and may read
+   * the matched request; a backend without a scripting engine does not
+   * advertise this capability.
+   */
+  def inject(space: MockSpace, m: RequestMatch, script: Script): IO[MockError, RuleId]
 
 /**
  * Proxy/record passthrough to a real upstream. Capability:
  * [[Capability.ProxyRecord]].
  */
-trait ProxyRecord
+trait ProxyRecord:
+  /**
+   * Proxy requests matching `m` to `upstream`, recording the first response and
+   * replaying it on subsequent calls — so the SUT keeps getting the recorded
+   * response even after the upstream goes down. Returns the rule id.
+   *
+   * The recording is owned by the backend, not this port: once a request has
+   * recorded a response, removing the proxy rule via [[MockControl.removeRule]]
+   * is unreliable (the backend may have inserted a recorded stub this port does
+   * not track), and on a `Correlated` space any rule mutation rebuilds the
+   * space and discards the recording. Inject a proxy on its own space and don't
+   * mutate rules after the first recorded call.
+   */
+  def proxy(space: MockSpace, m: RequestMatch, upstream: String): IO[MockError, RuleId]
 
 /** Response templating. Capability: [[Capability.Templating]]. */
-trait Templating
+trait Templating:
+  /**
+   * Install a templated response for requests matching `m`: each capture in
+   * `template` pulls a value from the request and substitutes its token into
+   * the response body. Returns the rule id.
+   */
+  def inject(space: MockSpace, m: RequestMatch, template: ResponseTemplate): IO[MockError, RuleId]

--- a/mock/src/main/scala/zio/bdd/mock/model.scala
+++ b/mock/src/main/scala/zio/bdd/mock/model.scala
@@ -195,6 +195,34 @@ enum FaultKind:
   case RandomThenClose
   case LatencySpike(delay: Duration)
 
+/** The engine a [[Scripting]] script runs on (#132). */
+enum ScriptEngine:
+  case Rhai, Lua, JavaScript
+
+/** A backend script that computes the response for matching requests (#132). */
+final case class Script(engine: ScriptEngine, code: String)
+
+/** Where a [[TemplateCapture]] reads its value from on the request (#132). */
+enum TemplateSource:
+  case Path, Body
+
+/**
+ * One templating capture (#132): extract from `source` using `regex` (the
+ * matched text) and substitute every occurrence of the literal `token` in the
+ * response body with it.
+ */
+final case class TemplateCapture(token: String, source: TemplateSource, regex: String)
+
+/**
+ * A templated response (#132): `body` may embed capture `token`s, each replaced
+ * by the value its [[TemplateCapture]] pulls from the request.
+ */
+final case class ResponseTemplate(
+  body: String,
+  captures: List[TemplateCapture],
+  status: Int = 200
+)
+
 /**
  * The unit of isolation. Hides *how* isolation is achieved:
  *   - PerInstance: a unique `baseUri` per space; `inject = identity`.

--- a/mock/src/test/scala/zio/bdd/mock/CapabilityNegotiationSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/CapabilityNegotiationSpec.scala
@@ -28,9 +28,9 @@ object CapabilityNegotiationSpec extends ZIOSpecDefault:
     def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(anyFault)
     def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(StubCaps.scenarios)
     def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(StubCaps.stateInspection)
-    def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(new Scripting {})
-    def proxyRecord: IO[Unsupported, ProxyRecord]         = cap(Capability.ProxyRecord)(new ProxyRecord {})
-    def templating: IO[Unsupported, Templating]           = cap(Capability.Templating)(new Templating {})
+    def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(StubCaps.scripting)
+    def proxyRecord: IO[Unsupported, ProxyRecord]         = cap(Capability.ProxyRecord)(StubCaps.proxyRecord)
+    def templating: IO[Unsupported, Templating]           = cap(Capability.Templating)(StubCaps.templating)
 
   def spec = suite("capability fail-fast negotiation")(
     test("require fails at layer construction, before first use") {

--- a/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
@@ -34,9 +34,9 @@ object MockControlModelSpec extends ZIOSpecDefault:
     def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(anyFault)
     def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(StubCaps.scenarios)
     def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(StubCaps.stateInspection)
-    def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(new Scripting {})
-    def proxyRecord: IO[Unsupported, ProxyRecord]         = cap(Capability.ProxyRecord)(new ProxyRecord {})
-    def templating: IO[Unsupported, Templating]           = cap(Capability.Templating)(new Templating {})
+    def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(StubCaps.scripting)
+    def proxyRecord: IO[Unsupported, ProxyRecord]         = cap(Capability.ProxyRecord)(StubCaps.proxyRecord)
+    def templating: IO[Unsupported, Templating]           = cap(Capability.Templating)(StubCaps.templating)
 
   def spec = suite("MockControl port + canonical model")(
     test("the total port is implementable by a stub adapter") {

--- a/mock/src/test/scala/zio/bdd/mock/StubCaps.scala
+++ b/mock/src/test/scala/zio/bdd/mock/StubCaps.scala
@@ -16,3 +16,7 @@ object StubCaps:
   val stateInspection: StateInspection = new StateInspection:
     def currentState(space: MockSpace, name: String): IO[MockError, ScenarioState]       = ZIO.succeed(ScenarioState.Started)
     def setState(space: MockSpace, name: String, to: ScenarioState): IO[MockError, Unit] = ZIO.unit
+
+  val scripting: Scripting     = (_, _, _) => ZIO.succeed(RuleId("stub"))
+  val proxyRecord: ProxyRecord = (_, _, _) => ZIO.succeed(RuleId("stub"))
+  val templating: Templating   = (_, _, _) => ZIO.succeed(RuleId("stub"))

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -55,7 +55,14 @@ private[rift] final case class RiftMockControl(
 
   def backendName: String = "rift"
   def capabilities: Set[Capability] =
-    Set(Capability.Faults, Capability.StatefulScenarios, Capability.StateInspection)
+    Set(
+      Capability.Faults,
+      Capability.StatefulScenarios,
+      Capability.StateInspection,
+      Capability.Scripting,
+      Capability.ProxyRecord,
+      Capability.Templating
+    )
 
   override def isolation: Isolation = mode match
     case RiftMode.Correlated(_) => Isolation.Correlated
@@ -106,9 +113,9 @@ private[rift] final case class RiftMockControl(
   def faults: IO[Unsupported, Faults]                   = ZIO.succeed(riftFaults)
   def scenarios: IO[Unsupported, StatefulScenarios]     = ZIO.succeed(statefulScenarios)
   def stateInspection: IO[Unsupported, StateInspection] = ZIO.succeed(stateInspector)
-  def scripting: IO[Unsupported, Scripting]             = unsupported(Capability.Scripting)
-  def proxyRecord: IO[Unsupported, ProxyRecord]         = unsupported(Capability.ProxyRecord)
-  def templating: IO[Unsupported, Templating]           = unsupported(Capability.Templating)
+  def scripting: IO[Unsupported, Scripting]             = ZIO.succeed(riftScripting)
+  def proxyRecord: IO[Unsupported, ProxyRecord]         = ZIO.succeed(riftProxyRecord)
+  def templating: IO[Unsupported, Templating]           = ZIO.succeed(riftTemplating)
 
   // ===== Faults (#128) — `_rift.fault` (rift#239) =================================
 
@@ -138,9 +145,52 @@ private[rift] final case class RiftMockControl(
       ruleId <- freshId
       rules  <- cs.rules.get
       faults <- cs.faults.get
+      extras <- cs.extras.get
       next    = (ruleId, m, fault) +: faults
-      _      <- rebuild(cs, next, rules)
+      _      <- rebuild(cs, extras, next, rules)
       _      <- cs.faults.set(next)
+    yield ruleId
+
+  // ===== Optional capabilities (#132): scripting / proxy-record / templating ======
+  // Each installs a special-response stub (`_rift.script`, a Mountebank `proxy`, or
+  // an `is` + `_behaviors.copy`) for matching requests. Like faults, the stub is
+  // first-match (PerInstance: index 0, tracked in `imp.stubs`; Correlated: tracked in
+  // `cs.extras`, re-registered ahead of rules on rebuild) so it wins over a normal
+  // rule, is removable via `removeRule`, and survives a later space rebuild.
+
+  private val riftScripting: Scripting = new Scripting:
+    def inject(space: MockSpace, m: RequestMatch, script: Script): IO[MockError, RuleId] =
+      injectStub(space, rid => RiftProtocol.scriptStub(m, script, rid))
+
+  private val riftProxyRecord: ProxyRecord = new ProxyRecord:
+    def proxy(space: MockSpace, m: RequestMatch, upstream: String): IO[MockError, RuleId] =
+      injectStub(space, rid => RiftProtocol.proxyStub(m, upstream, rid))
+
+  private val riftTemplating: Templating = new Templating:
+    def inject(space: MockSpace, m: RequestMatch, template: ResponseTemplate): IO[MockError, RuleId] =
+      injectStub(space, rid => RiftProtocol.templateStub(m, template, rid))
+
+  private def injectStub(space: MockSpace, buildStub: RuleId => Json): IO[MockError, RuleId] =
+    freshId.flatMap(rid =>
+      dispatch(space)(cs => corrInjectStub(cs, rid, buildStub(rid)))(imp => piInjectStub(imp, rid, buildStub(rid)))
+    )
+
+  private def piInjectStub(imp: Imposter, ruleId: RuleId, stub: Json): IO[MockError, RuleId] =
+    for
+      u   <- url(s"/imposters/${imp.port}/stubs")
+      res <- send(jsonRequest(HttpMethod.POST, u, RiftProtocol.addStubBodyOf(0, stub)))
+      _   <- expectSuccess(s"inject capability stub into imposter ${imp.port}", res)
+      _   <- imp.stubs.update(ruleId +: _)
+    yield ruleId
+
+  private def corrInjectStub(cs: CorrSpace, ruleId: RuleId, stub: Json): IO[MockError, RuleId] =
+    for
+      rules  <- cs.rules.get
+      faults <- cs.faults.get
+      extras <- cs.extras.get
+      next    = (ruleId, stub) +: extras
+      _      <- rebuild(cs, next, faults, rules)
+      _      <- cs.extras.set(next)
     yield ruleId
 
   // ===== StatefulScenarios + StateInspection (#131) ===============================
@@ -153,9 +203,10 @@ private[rift] final case class RiftMockControl(
   // Limitations (untested edges — the conformance gate is PerInstance, one define per
   // space): re-`define` of an existing name APPENDS stubs rather than replacing the
   // prior ones (provision a fresh space per scenario, as the conformance does); and on
-  // a Correlated space a plain-rule mutation (addRule/removeRule/replaceRules) rebuilds
-  // the space — dropping its scenario stubs too. Don't mix rule mutation with scenarios
-  // on one Correlated space.
+  // a Correlated space a plain-rule mutation (addRule/removeRule/replaceRules) — or a
+  // capability injection (faults/script/proxy/template), which rebuilds the same way —
+  // drops the space's scenario stubs (and discards any proxy recording). Don't mix
+  // scenarios with rule mutation or capability injection on one Correlated space.
 
   private val statefulScenarios: StatefulScenarios = new StatefulScenarios:
     def define(space: MockSpace, scenarioDef: ScenarioDef): IO[MockError, Unit] =
@@ -360,8 +411,11 @@ private[rift] final case class RiftMockControl(
       _         <- registerStubs(port, flowId, tagged).onError(_ => deleteSpace(port, flowId).ignore)
       rulesRef  <- Ref.make(tagged)
       faultsRef <- Ref.make(Vector.empty[(RuleId, RequestMatch, FaultKind)])
+      extrasRef <- Ref.make(Vector.empty[(RuleId, Json)])
       scen      <- Ref.make(Map.empty[String, ScenarioState])
-      _         <- correlated.update(_.updated(id, CorrSpace(port, flowId, corr.header, rulesRef, faultsRef, scen)))
+      _ <- correlated.update(
+             _.updated(id, CorrSpace(port, flowId, corr.header, rulesRef, faultsRef, extrasRef, scen))
+           )
     yield MockSpace(endpoint.baseUriFor(port), req => req.copy(headers = req.headers.add(corr.header, flowId)), id)
 
   // Create the one shared imposter on first Correlated provision (race-safe).
@@ -395,13 +449,17 @@ private[rift] final case class RiftMockControl(
     for
       rules  <- cs.rules.get
       faults <- cs.faults.get
-      _ <- // commit tracking only on success; a removed id is either a rule or a fault
+      extras <- cs.extras.get
+      _ <- // commit tracking only on success; a removed id is a rule, a fault, or a capability stub
         if rules.exists(_._1 == id) then
           val next = rules.filterNot(_._1 == id)
-          rebuild(cs, faults, next) *> cs.rules.set(next)
+          rebuild(cs, extras, faults, next) *> cs.rules.set(next)
         else if faults.exists(_._1 == id) then
           val nextF = faults.filterNot(_._1 == id)
-          rebuild(cs, nextF, rules) *> cs.faults.set(nextF)
+          rebuild(cs, extras, nextF, rules) *> cs.faults.set(nextF)
+        else if extras.exists(_._1 == id) then
+          val nextE = extras.filterNot(_._1 == id)
+          rebuild(cs, nextE, faults, rules) *> cs.extras.set(nextE)
         else ZIO.fail(MockError.RuleNotFound(spaceId, id))
     yield ()
 
@@ -427,18 +485,35 @@ private[rift] final case class RiftMockControl(
   // the class doc.) Re-register with the currently-tracked faults (a rule mutation
   // must not drop an injected fault).
   private def rebuildSpaceWith(cs: CorrSpace, rules: Vector[(RuleId, MockRule)]): IO[MockError, Unit] =
-    cs.faults.get.flatMap(faults => rebuild(cs, faults, rules))
+    for
+      extras <- cs.extras.get
+      faults <- cs.faults.get
+      _      <- rebuild(cs, extras, faults, rules)
+    yield ()
 
-  // Faults are registered ahead of the rules so they win first-match (Mountebank is
-  // first-match-wins, and rift#223 space stubs append in registration order).
+  // Capability stubs (extras) and faults are registered ahead of the rules so they
+  // win first-match (Mountebank is first-match-wins, and rift#223 space stubs append
+  // in registration order).
   private def rebuild(
     cs: CorrSpace,
+    extras: Vector[(RuleId, Json)],
     faults: Vector[(RuleId, RequestMatch, FaultKind)],
     rules: Vector[(RuleId, MockRule)]
   ): IO[MockError, Unit] =
     deleteSpace(cs.port, cs.flowId) *>
+      registerRawStubs(cs.port, cs.flowId, extras) *>
       registerFaultStubs(cs.port, cs.flowId, faults) *>
       registerStubs(cs.port, cs.flowId, rules)
+
+  private def registerRawStubs(port: Int, flowId: String, extras: Vector[(RuleId, Json)]): IO[MockError, Unit] =
+    ZIO.foreachDiscard(extras)((_, stub) => postSpaceRawStub(port, flowId, stub))
+
+  private def postSpaceRawStub(port: Int, flowId: String, stub: Json): IO[MockError, Unit] =
+    for
+      u   <- url(s"/imposters/$port/spaces/${enc(flowId)}/stubs")
+      res <- send(jsonRequest(HttpMethod.POST, u, stub))
+      _   <- expectSuccess(s"add capability stub to $flowId", res)
+    yield ()
 
   private def registerFaultStubs(
     port: Int,
@@ -566,6 +641,7 @@ private[rift] object RiftMockControl:
     header: String,
     rules: Ref[Vector[(RuleId, MockRule)]],
     faults: Ref[Vector[(RuleId, RequestMatch, FaultKind)]],
+    extras: Ref[Vector[(RuleId, Json)]], // pre-built capability stubs (#132): script / proxy / template
     scenarios: Ref[Map[String, ScenarioState]]
   )
 

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -163,6 +163,88 @@ private[rift] object RiftProtocol:
   def addStubBodyOf(index: Int, stub: Json): Json =
     Json.Obj("index" -> Json.Num(index), "stub" -> stub)
 
+  // ===== Optional capabilities (#132): script / proxy / templating ===============
+
+  /** A Mountebank stub for `m` carrying a single pre-built response object. */
+  private def capStub(m: RequestMatch, id: RuleId, response: Json): Json =
+    Json.Obj(
+      "id"         -> Json.Str(id.value),
+      "predicates" -> Json.Arr(predicates(m)*),
+      "responses"  -> Json.Arr(response)
+    )
+
+  /** The Rift script-engine token. */
+  def scriptEngineName(engine: ScriptEngine): String = engine match
+    case ScriptEngine.Rhai       => "rhai"
+    case ScriptEngine.Lua        => "lua"
+    case ScriptEngine.JavaScript => "javascript"
+
+  /**
+   * A stub whose response is computed by `script` via the `_rift.script`
+   * extension — the script's `should_inject` decides the response.
+   */
+  def scriptStub(m: RequestMatch, script: Script, id: RuleId): Json =
+    capStub(
+      m,
+      id,
+      Json.Obj(
+        "_rift" -> Json.Obj(
+          "script" -> Json.Obj(
+            "engine" -> Json.Str(scriptEngineName(script.engine)),
+            "code"   -> Json.Str(script.code)
+          )
+        )
+      )
+    )
+
+  /**
+   * A stub that proxies `m` to `upstream` in `proxyOnce` mode — Rift records
+   * the first upstream response as a new stub and replays it thereafter (so it
+   * keeps serving when the upstream is down). `predicateGenerators` keys the
+   * recorded stub on the request method + path, so a later identical request
+   * matches the recording instead of re-proxying.
+   */
+  def proxyStub(m: RequestMatch, upstream: String, id: RuleId): Json =
+    capStub(
+      m,
+      id,
+      Json.Obj(
+        "proxy" -> Json.Obj(
+          "to"   -> Json.Str(upstream),
+          "mode" -> Json.Str("proxyOnce"),
+          "predicateGenerators" -> Json.Arr(
+            Json.Obj("matches" -> Json.Obj("method" -> Json.Bool(true), "path" -> Json.Bool(true)))
+          )
+        )
+      )
+    )
+
+  private def templateSourceName(source: TemplateSource): String = source match
+    case TemplateSource.Path => "path"
+    case TemplateSource.Body => "body"
+
+  /**
+   * A templated `is` response: the body carries each capture's `token` literal,
+   * and a Mountebank `copy` behavior per capture substitutes it with the value
+   * extracted (by regex) from the request.
+   */
+  def templateStub(m: RequestMatch, template: ResponseTemplate, id: RuleId): Json =
+    val copies = template.captures.map(c =>
+      Json.Obj(
+        "from"  -> Json.Str(templateSourceName(c.source)),
+        "into"  -> Json.Str(c.token),
+        "using" -> Json.Obj("method" -> Json.Str("regex"), "selector" -> Json.Str(c.regex))
+      )
+    )
+    capStub(
+      m,
+      id,
+      Json.Obj(
+        "is"         -> Json.Obj("statusCode" -> Json.Num(template.status), "body" -> Json.Str(template.body)),
+        "_behaviors" -> Json.Obj("copy" -> Json.Arr(copies*))
+      )
+    )
+
   def predicates(m: RequestMatch): List[Json] =
     val methodPred = m.method.map(meth => equalsObj("method" -> Json.Str(methodName(meth))))
     val pathPred = m.path match

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -194,17 +194,23 @@ object RiftMockControlSpec extends ZIOSpecDefault:
         )
       }
     },
-    test("advertises Faults + StatefulScenarios + StateInspection; the other accessors fail fast (#131)") {
+    test("advertises all six capabilities and every accessor succeeds (#132)") {
       withAdapter { (control, _) =>
         for
-          faultsE <- control.faults.either
-          scenE   <- control.scenarios.either
-          siE     <- control.stateInspection.either
+          faultsE   <- control.faults.either
+          scenE     <- control.scenarios.either
+          siE       <- control.stateInspection.either
+          scriptE   <- control.scripting.either
+          proxyE    <- control.proxyRecord.either
+          templateE <- control.templating.either
         yield assertTrue(
-          control.capabilities == Set(Capability.Faults, Capability.StatefulScenarios, Capability.StateInspection),
+          control.capabilities == Capability.values.toSet,
           faultsE.isRight,
           scenE.isRight,
-          siE.isRight
+          siE.isRight,
+          scriptE.isRight,
+          proxyE.isRight,
+          templateE.isRight
         )
       }
     },
@@ -223,6 +229,80 @@ object RiftMockControlSpec extends ZIOSpecDefault:
           post.exists(_.contains("\"index\":0")), // first-match — wins over a normal rule
           post.exists(_.contains("CONNECTION_RESET_BY_PEER")),
           post.exists(_.contains("/boom"))
+        )
+      }
+    },
+    test("scripting/proxyRecord/templating each post a first-match capability stub to the imposter (#132)") {
+      withAdapter { (control, fake) =>
+        def asT(e: Any): Throwable = new RuntimeException(e.toString)
+        for
+          space    <- control.provision(pingSource).orDieWith(asT).map(_.head)
+          script   <- control.scripting.orDieWith(asT)
+          proxy    <- control.proxyRecord.orDieWith(asT)
+          template <- control.templating.orDieWith(asT)
+          sid <- script
+                   .inject(space, RequestMatch(path = PathMatch.Exact("/s")), Script(ScriptEngine.Rhai, "code"))
+                   .orDieWith(asT)
+          pid <- proxy.proxy(space, RequestMatch(path = PathMatch.Exact("/p")), "http://up").orDieWith(asT)
+          tid <-
+            template
+              .inject(
+                space,
+                RequestMatch(path = PathMatch.Exact("/t")),
+                ResponseTemplate(body = "x${V}", captures = List(TemplateCapture("${V}", TemplateSource.Body, ".*")))
+              )
+              .orDieWith(asT)
+          calls <- fake.stubCalls.get
+          posts  = calls.filter(_.startsWith(s"POST ${portOf(space.baseUri)} "))
+          // the capability stubs are tracked in imp.stubs, so removeRule reaches them (not RuleNotFound)
+          rmS <- control.removeRule(space, sid).either
+          rmT <- control.removeRule(space, tid).either
+        yield assertTrue(
+          sid.value.nonEmpty && pid.value.nonEmpty && tid.value.nonEmpty,
+          posts.forall(_.contains("\"index\":0")), // all first-match
+          posts.exists(c => c.contains("_rift") && c.contains("script") && c.contains("rhai")),
+          posts.exists(c => c.contains("proxy") && c.contains("proxyOnce") && c.contains("http://up")),
+          posts.exists(c => c.contains("copy") && c.contains("${V}")),
+          rmS.isRight && rmT.isRight
+        )
+      }
+    },
+    test(
+      "Correlated scripting/proxy/templating each register a capability space stub ahead of the rules and are removable (#132)"
+    ) {
+      withCorrelated { (control, fake) =>
+        def asT(e: Any): Throwable = new RuntimeException(e.toString)
+        for
+          space    <- control.provision(pingSource).orDieWith(asT).map(_.head)
+          script   <- control.scripting.orDieWith(asT)
+          proxy    <- control.proxyRecord.orDieWith(asT)
+          template <- control.templating.orDieWith(asT)
+          sid <- script
+                   .inject(space, RequestMatch(path = PathMatch.Exact("/s")), Script(ScriptEngine.Rhai, "code"))
+                   .orDieWith(asT)
+          pid <- proxy.proxy(space, RequestMatch(path = PathMatch.Exact("/p")), "http://up").orDieWith(asT)
+          tid <-
+            template
+              .inject(
+                space,
+                RequestMatch(path = PathMatch.Exact("/t")),
+                ResponseTemplate(body = "x${V}", captures = List(TemplateCapture("${V}", TemplateSource.Body, ".*")))
+              )
+              .orDieWith(asT)
+          stubs   <- fake.spaceStubs.get // "$port/$flowId $body" per POST .../spaces/:flow/stubs
+          scriptIx = stubs.indexWhere(s => s.contains("script") && s.contains("rhai") && s.contains("/s"))
+          // a rebuild re-registers the space's /ping rule AFTER the capability stubs → they win first-match
+          rulePast = stubs.zipWithIndex.exists((s, i) => i > scriptIx && s.contains("/ping"))
+          rmS     <- control.removeRule(space, sid).either // tracked in cs.extras → removable, not RuleNotFound
+          rmP     <- control.removeRule(space, pid).either
+          rmT     <- control.removeRule(space, tid).either
+        yield assertTrue(
+          sid.value.nonEmpty && pid.value.nonEmpty && tid.value.nonEmpty,
+          scriptIx >= 0,
+          rulePast,
+          stubs.exists(s => s.contains("proxyOnce") && s.contains("/p")),
+          stubs.exists(s => s.contains("copy") && s.contains("/t")),
+          rmS.isRight && rmP.isRight && rmT.isRight
         )
       }
     },

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
@@ -138,6 +138,60 @@ object RiftProtocolSpec extends ZIOSpecDefault:
         arr(stub / "responses").head / "_rift" / "fault" / "tcp" == Json.Str("CONNECTION_RESET_BY_PEER")
       )
     },
+    test("scriptStub carries predicates and a _rift.script response (engine + code) (#132)") {
+      val m = RequestMatch(path = PathMatch.Exact("/s"))
+      val stub =
+        RiftProtocol.scriptStub(m, Script(ScriptEngine.Rhai, "fn should_inject(r,f){#{inject:false}}"), RuleId("s1"))
+      val resp = arr(stub / "responses").head
+      assertTrue(
+        stub / "id" == Json.Str("s1"),
+        arr(stub / "predicates").exists(p => p / "equals" / "path" == Json.Str("/s")),
+        resp / "_rift" / "script" / "engine" == Json.Str("rhai"),
+        resp / "_rift" / "script" / "code" == Json.Str("fn should_inject(r,f){#{inject:false}}")
+      )
+    },
+    test("script engine tokens map to rhai/lua/javascript (#132)") {
+      assertTrue(
+        RiftProtocol.scriptEngineName(ScriptEngine.Rhai) == "rhai",
+        RiftProtocol.scriptEngineName(ScriptEngine.Lua) == "lua",
+        RiftProtocol.scriptEngineName(ScriptEngine.JavaScript) == "javascript"
+      )
+    },
+    test(
+      "proxyStub emits a proxy response to the upstream in proxyOnce mode with method+path predicate generators (#132)"
+    ) {
+      val stub = RiftProtocol.proxyStub(RequestMatch(path = PathMatch.Exact("/p")), "http://up:8080", RuleId("p1"))
+      val resp = arr(stub / "responses").head
+      val gen  = arr(resp / "proxy" / "predicateGenerators").head
+      assertTrue(
+        stub / "id" == Json.Str("p1"),
+        resp / "proxy" / "to" == Json.Str("http://up:8080"),
+        resp / "proxy" / "mode" == Json.Str("proxyOnce"),
+        gen / "matches" / "method" == Json.Bool(true),
+        gen / "matches" / "path" == Json.Bool(true)
+      )
+    },
+    test("templateStub emits an `is` body plus a _behaviors.copy per capture; path/body sources map (#132)") {
+      val template = ResponseTemplate(
+        body = "Hello ${NAME} ${WHO}",
+        captures = List(
+          TemplateCapture("${NAME}", TemplateSource.Path, "[^/]+$"),
+          TemplateCapture("${WHO}", TemplateSource.Body, "\\w+")
+        )
+      )
+      val stub     = RiftProtocol.templateStub(RequestMatch(path = PathMatch.Exact("/greet")), template, RuleId("t1"))
+      val resp     = arr(stub / "responses").head
+      val copies   = arr(resp / "_behaviors" / "copy")
+      val pathCopy = copies.find(_ / "into" == Json.Str("${NAME}")).getOrElse(Json.Null)
+      val bodyCopy = copies.find(_ / "into" == Json.Str("${WHO}")).getOrElse(Json.Null)
+      assertTrue(
+        resp / "is" / "body" == Json.Str("Hello ${NAME} ${WHO}"),
+        pathCopy / "from" == Json.Str("path"),
+        pathCopy / "using" / "method" == Json.Str("regex"),
+        pathCopy / "using" / "selector" == Json.Str("[^/]+$"),
+        bodyCopy / "from" == Json.Str("body") // TemplateSource.Body -> "body"
+      )
+    },
     test("PathMatch.Any emits no path predicate") {
       val stub = RiftProtocol.stub(pingRule.copy(`match` = RequestMatch(method = Some(Method.Post))))
       val keys =

--- a/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
+++ b/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
@@ -148,15 +148,22 @@ object WireMockControlSpec extends ZIOSpecDefault:
           elapsed <- Clock.nanoTime.map(_ - start)
         yield assertTrue(resp.status == 200, elapsed >= 250.millis.toNanos) // ~300ms fixed delay
       } @@ TestAspect.withLiveClock,
-      test("advertises Faults; its accessor succeeds and an unadvertised accessor fails fast") {
+      test("advertises Faults but none of the optional Rift-only capabilities (#132); their accessors fail fast") {
         for
           control    <- ZIO.service[MockControl]
           faultsE    <- control.faults.either
           scriptingE <- control.scripting.either
+          proxyE     <- control.proxyRecord.either
+          templateE  <- control.templating.either
         yield assertTrue(
           control.capabilities.contains(Capability.Faults),
+          !control.capabilities.contains(Capability.Scripting),
+          !control.capabilities.contains(Capability.ProxyRecord),
+          !control.capabilities.contains(Capability.Templating),
           faultsE.isRight,
-          scriptingE == Left(Unsupported(Capability.Scripting, "wiremock"))
+          scriptingE == Left(Unsupported(Capability.Scripting, "wiremock")),
+          proxyE == Left(Unsupported(Capability.ProxyRecord, "wiremock")),
+          templateE == Left(Unsupported(Capability.Templating, "wiremock"))
         )
       },
       test("faults.inject ConnectionReset makes the SUT client observe a transport failure") {


### PR DESCRIPTION
Implements the three optional capability traits for the MockControl SPI: `Scripting.inject` (Rift `_rift.script`), `ProxyRecord.proxy` (Mountebank proxyOnce proxy + record/replay), and `Templating.inject` (Mountebank `copy` behavior). Rift advertises all three; WireMock advertises none, so each `cap-*` feature PASSes on Rift and SKIPs (un-advertised) on WireMock.

All three are verified end-to-end against a real rift v0.6.0 container (RIFT_IT), including proxy record→replay with the upstream stopped. The Correlated isolation path is generalized (cs.extras) to keep capability stubs first-match, rebuild-safe, and removable.

Closes #132
Milestone: M3