### PR TITLE
M3: stateful scenarios, fault injection, and optional capability traits

### DIFF
--- a/conformance/src/main/scala/zio/bdd/mock/conformance/CapStatefulScenarios.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/CapStatefulScenarios.scala
@@ -1,0 +1,172 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.dsl.*
+
+/**
+ * The `cap-stateful` conformance feature (#129): the normative single-token-FSM
+ * semantics, programmed against the neutral [[StatefulScenarios]] /
+ * [[StateInspection]] capabilities. Each scenario is capability-gated, so it
+ * runs (and validates the semantics) only on a backend that advertises the
+ * capability — until #130 (WireMock) / #131 (Rift) land, every backend
+ * justifiably SKIPs.
+ */
+object CapStatefulScenarios:
+
+  lazy val all: List[ConformanceScenario] = core ++ inspection
+
+  // ---- helpers ------------------------------------------------------------------
+
+  private def asT(e: MockError): Throwable    = new RuntimeException(s"MockError: $e")
+  private def asTU(u: Unsupported): Throwable = new RuntimeException(s"Unsupported: $u")
+
+  private def ensure(cond: Boolean, msg: => String): IO[Throwable, Unit] =
+    ZIO.unless(cond)(ZIO.fail(new AssertionError(msg))).unit
+
+  // An empty space; the scenario's own rules are installed by `define`.
+  private val emptySpace: MockSource = MockSource.Dsl(MockSpec(Nil))
+
+  private def space(control: MockControl): ZIO[Scope, Throwable, MockSpace] =
+    ZIO.acquireRelease(control.provision(emptySpace).mapError(asT).map(_.head))(s => control.destroy(s).ignoreLogged)
+
+  // Started --GET /inv--> "created" --> Paid --GET /inv--> "paid" (stays).
+  private val invoice: ScenarioDef =
+    scenario("invoice")
+      .when("Started", get("/inv"))
+      .respond(ok.text("created"))
+      .goTo("Paid")
+      .when("Paid", get("/inv"))
+      .respond(ok.text("paid"))
+      .stay
+      .build
+
+  // Two rules eligible in "Started" for the same request: the first declared wins.
+  private val firstMatch: ScenarioDef =
+    scenario("fm")
+      .when("Started", get("/fm"))
+      .respond(ok.text("first"))
+      .stay
+      .when("Started", get("/fm"))
+      .respond(ok.text("second"))
+      .stay
+      .build
+
+  private def scen(name: String, requires: Set[Capability])(
+    check: MockControl => ZIO[Scope, Throwable, Unit]
+  ): ConformanceScenario =
+    ConformanceScenario(name, requires, check)
+
+  private val needsStateful = Set(Capability.StatefulScenarios)
+  private val needsBoth     = Set(Capability.StatefulScenarios, Capability.StateInspection)
+
+  // ---- core (StatefulScenarios) -------------------------------------------------
+
+  private val core = List(
+    scen("stateful: eligibility + transition advance the FSM", needsStateful) { control =>
+      ZIO.scoped {
+        for
+          ss <- control.scenarios.mapError(asTU)
+          s  <- space(control)
+          _  <- ss.define(s, invoice).mapError(asT)
+          r1 <- SutClient.make(s).send(Method.Get, "/inv") // Started -> "created", -> Paid
+          r2 <- SutClient.make(s).send(Method.Get, "/inv") // Paid    -> "paid"
+          _  <- ensure(r1.body == "created" && r2.body == "paid", s"transition: r1=${r1.body} r2=${r2.body}")
+        yield ()
+      }
+    },
+    scen("stateful: a request matching no eligible rule leaves the state unchanged", needsStateful) { control =>
+      ZIO.scoped {
+        for
+          ss   <- control.scenarios.mapError(asTU)
+          s    <- space(control)
+          _    <- ss.define(s, invoice).mapError(asT)
+          miss <- SutClient.make(s).send(Method.Get, "/other") // no eligible rule -> no transition
+          hit  <- SutClient.make(s).send(Method.Get, "/inv")   // still in Started -> "created"
+          _    <- ensure(miss.status == 404 && hit.body == "created", s"no-change: miss=${miss.status} hit=${hit.body}")
+        yield ()
+      }
+    },
+    scen("stateful: reset returns the FSM to its initial state", needsStateful) { control =>
+      ZIO.scoped {
+        for
+          ss <- control.scenarios.mapError(asTU)
+          s  <- space(control)
+          _  <- ss.define(s, invoice).mapError(asT)
+          _  <- SutClient.make(s).send(Method.Get, "/inv") // advance to Paid
+          _  <- ss.reset(s, "invoice").mapError(asT)
+          r  <- SutClient.make(s).send(Method.Get, "/inv") // back in Started -> "created"
+          _  <- ensure(r.body == "created", s"reset: r=${r.body}")
+        yield ()
+      }
+    },
+    scen("stateful: two spaces sharing a scenario name keep independent state (locality)", needsStateful) { control =>
+      ZIO.scoped {
+        for
+          ss <- control.scenarios.mapError(asTU)
+          a  <- space(control)
+          b  <- space(control)
+          _  <- ss.define(a, invoice).mapError(asT)
+          _  <- ss.define(b, invoice).mapError(asT)
+          _  <- SutClient.make(a).send(Method.Get, "/inv") // advance A to Paid
+          aR <- SutClient.make(a).send(Method.Get, "/inv") // A -> "paid"
+          bR <- SutClient.make(b).send(Method.Get, "/inv") // B untouched -> "created"
+          _  <- ensure(aR.body == "paid" && bR.body == "created", s"locality: a=${aR.body} b=${bR.body}")
+        yield ()
+      }
+    },
+    scen("stateful: among rules eligible in the same state, the first declared wins (first-match)", needsStateful) {
+      control =>
+        ZIO.scoped {
+          for
+            ss <- control.scenarios.mapError(asTU)
+            s  <- space(control)
+            _  <- ss.define(s, firstMatch).mapError(asT)
+            r  <- SutClient.make(s).send(Method.Get, "/fm") // both rules eligible -> first wins
+            _  <- ensure(r.body == "first", s"first-match: r=${r.body}")
+          yield ()
+        }
+    },
+    scen("stateful: concurrent advances on independent spaces stay isolated (concurrency)", needsStateful) { control =>
+      ZIO.scoped {
+        for
+          ss     <- control.scenarios.mapError(asTU)
+          spaces <- ZIO.foreachPar(1 to 8)(_ => space(control))
+          _      <- ZIO.foreachPar(spaces)(s => ss.define(s, invoice).mapError(asT))
+          // concurrently advance the even-indexed spaces to Paid; the odd ones stay in Started
+          _ <- ZIO.foreachPar(spaces.zipWithIndex.filter((_, i) => i % 2 == 0)) { (s, _) =>
+                 SutClient.make(s).send(Method.Get, "/inv")
+               }
+          bodies <-
+            ZIO.foreachPar(spaces.zipWithIndex)((s, i) => SutClient.make(s).send(Method.Get, "/inv").map(i -> _.body))
+          _ <- ensure(
+                 bodies.forall((i, b) => b == (if i % 2 == 0 then "paid" else "created")),
+                 s"concurrency: $bodies"
+               )
+        yield ()
+      }
+    }
+  )
+
+  // ---- StateInspection (gated separately) ---------------------------------------
+
+  private val inspection = List(
+    scen("inspection: currentState reflects the FSM; setState forces a transition", needsBoth) { control =>
+      ZIO.scoped {
+        for
+          ss   <- control.scenarios.mapError(asTU)
+          si   <- control.stateInspection.mapError(asTU)
+          s    <- space(control)
+          _    <- ss.define(s, invoice).mapError(asT)
+          init <- si.currentState(s, "invoice").mapError(asT)
+          _    <- si.setState(s, "invoice", ScenarioState("Paid")).mapError(asT)
+          now  <- si.currentState(s, "invoice").mapError(asT)
+          r    <- SutClient.make(s).send(Method.Get, "/inv") // forced to Paid -> "paid"
+          _ <- ensure(
+                 init == ScenarioState.Started && now == ScenarioState("Paid") && r.body == "paid",
+                 s"inspection: init=$init now=$now r=${r.body}"
+               )
+        yield ()
+      }
+    }
+  )

--- a/conformance/src/main/scala/zio/bdd/mock/conformance/FaultScenarios.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/FaultScenarios.scala
@@ -1,0 +1,93 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+
+/**
+ * The portable fault-injection conformance scenarios (#128) — the `cap-faults`
+ * feature. Each is programmed against the neutral [[MockControl]] (never a
+ * concrete backend) and gated on [[Capability.Faults]], so a backend that does
+ * not advertise Faults SKIPs them. Asserting via a real [[SutClient]]
+ * round-trip makes each fault kind produce its specified *client-observable*
+ * failure identically on every advertising adapter (WireMock natively; Rift via
+ * `_rift.fault`, rift#239).
+ *
+ *   - The four connection kinds abort the transport, so the SUT's client throws
+ *     (the `send` effect FAILs) — observed as `Exit.isFailure`, not a status.
+ *   - [[FaultKind.LatencySpike]] delays an otherwise-normal 200 response —
+ *     observed as a status-200 round-trip whose latency exceeds a baseline.
+ */
+object FaultScenarios:
+
+  lazy val all: List[ConformanceScenario] =
+    List(
+      connectionFault("faults: ConnectionReset aborts the client connection", FaultKind.ConnectionReset),
+      connectionFault("faults: EmptyResponse aborts the client connection", FaultKind.EmptyResponse),
+      connectionFault("faults: MalformedChunk aborts the client connection", FaultKind.MalformedChunk),
+      connectionFault("faults: RandomThenClose aborts the client connection", FaultKind.RandomThenClose),
+      latencySpike
+    )
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+
+  private def ensure(cond: Boolean, msg: => String): IO[Throwable, Unit] =
+    ZIO.unless(cond)(ZIO.fail(new AssertionError(msg))).unit
+
+  // A baseline space serving GET /ping -> pong, torn down with the scenario scope.
+  private val pingSource =
+    MockSource.Dsl(
+      MockSpec(List(MockRule(RequestMatch(path = PathMatch.Exact("/ping")), ResponseDef(body = Body.Text("pong")))))
+    )
+
+  private def space(control: MockControl): ZIO[Scope, Throwable, MockSpace] =
+    ZIO.acquireRelease(control.provision(pingSource).mapError(asT).map(_.head))(s => control.destroy(s).ignoreLogged)
+
+  private def faultsOf(control: MockControl): IO[Throwable, Faults] =
+    control.faults.mapError(u => new RuntimeException(u.toString))
+
+  private def connectionFault(name: String, kind: FaultKind): ConformanceScenario =
+    ConformanceScenario(
+      name,
+      Set(Capability.Faults),
+      control =>
+        for
+          s      <- space(control)
+          faults <- faultsOf(control)
+          _      <- faults.inject(s, RequestMatch(path = PathMatch.Exact("/boom")), kind).mapError(asT)
+          result <- SutClient.make(s).send(Method.Get, "/boom").exit
+          _      <- ensure(result.isFailure, s"$name: expected a client-side transport failure, got $result")
+        yield ()
+    )
+
+  private val latencySpike =
+    ConformanceScenario(
+      "faults: LatencySpike delays an otherwise-normal response",
+      Set(Capability.Faults),
+      control =>
+        // Measure /slow against a no-fault /ping baseline on the same space, so the
+        // delta cancels connection/JIT noise (mirrors the core delay scenario): a 1s
+        // spike with a 500ms floor and the MIN of two baselines keeps jitter from
+        // flipping a genuinely-applied delay to a false failure.
+        def elapsed(s: MockSpace, path: String): ZIO[Any, Throwable, (SutResponse, Duration)] =
+          for
+            t0 <- Clock.nanoTime
+            r  <- SutClient.make(s).send(Method.Get, path)
+            t1 <- Clock.nanoTime
+          yield (r, Duration.fromNanos(t1 - t0))
+        for
+          s      <- space(control)
+          faults <- faultsOf(control)
+          _ <- faults
+                 .inject(s, RequestMatch(path = PathMatch.Exact("/slow")), FaultKind.LatencySpike(1.second))
+                 .mapError(asT)
+          base1   <- elapsed(s, "/ping")
+          base2   <- elapsed(s, "/ping")
+          slow    <- elapsed(s, "/slow")
+          baseline = math.min(base1._2.toNanos, base2._2.toNanos)
+          delta    = Duration.fromNanos(slow._2.toNanos - baseline)
+          _ <- ensure(
+                 slow._1.status == 200 && delta >= 500.millis,
+                 s"latency: status=${slow._1.status} slow=${slow._2.toMillis}ms baseline=${baseline / 1000000}ms delta=${delta.toMillis}ms"
+               )
+        yield ()
+    )

--- a/conformance/src/main/scala/zio/bdd/mock/conformance/ScriptingScenarios.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/ScriptingScenarios.scala
@@ -1,0 +1,54 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+
+/**
+ * The portable scripting conformance scenarios (#132) — the `cap-scripting`
+ * feature. Gated on [[Capability.Scripting]], so a backend that does not
+ * advertise it (WireMock has no scripting engine) SKIPs them. The script
+ * computes the response from the matched request, proving the backend actually
+ * runs it (Rift via `_rift.script`).
+ */
+object ScriptingScenarios:
+
+  lazy val all: List[ConformanceScenario] = List(scriptedResponse)
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+
+  private def ensure(cond: Boolean, msg: => String): IO[Throwable, Unit] =
+    ZIO.unless(cond)(ZIO.fail(new AssertionError(msg))).unit
+
+  private val emptySource = MockSource.Dsl(MockSpec(Nil))
+
+  private def space(control: MockControl): ZIO[Scope, Throwable, MockSpace] =
+    ZIO.acquireRelease(control.provision(emptySource).mapError(asT).map(_.head))(s => control.destroy(s).ignoreLogged)
+
+  // A Rhai script that computes the body from the request method — so a passing
+  // round-trip proves the backend ran the script (a static stub couldn't echo it).
+  // Rift's script API returns a decision map; `fault: "error"` is its token for "return this
+  // computed { status, body, headers } response" (not an actual error). Here the body is derived
+  // from request.method, so a passing round-trip proves the engine ran the script.
+  private val rhaiEchoMethod =
+    Script(
+      ScriptEngine.Rhai,
+      "fn should_inject(request, flow_store) { #{inject: true, fault: \"error\", status: 200, " +
+        "body: `scripted-${request.method}`, headers: #{\"Content-Type\": \"text/plain\"}} }"
+    )
+
+  private val scriptedResponse =
+    ConformanceScenario(
+      "scripting: the script computes the response from the request",
+      Set(Capability.Scripting),
+      control =>
+        for
+          s         <- space(control)
+          scripting <- control.scripting.mapError(u => new RuntimeException(u.toString))
+          _         <- scripting.inject(s, RequestMatch(path = PathMatch.Exact("/s")), rhaiEchoMethod).mapError(asT)
+          resp      <- SutClient.make(s).send(Method.Get, "/s")
+          _ <- ensure(
+                 resp.status == 200 && resp.body == "scripted-GET",
+                 s"scripting: status=${resp.status} body=${resp.body}"
+               )
+        yield ()
+    )

--- a/conformance/src/main/scala/zio/bdd/mock/conformance/TemplatingScenarios.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/TemplatingScenarios.scala
@@ -1,0 +1,67 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+
+/**
+ * The portable templating conformance scenarios (#132) — the `cap-templating`
+ * feature. Gated on [[Capability.Templating]], so a backend that does not
+ * advertise it SKIPs them. A capture pulls a value out of the request (here the
+ * last path segment) and the response body interpolates it (Rift via a
+ * Mountebank `copy` behavior).
+ */
+object TemplatingScenarios:
+
+  lazy val all: List[ConformanceScenario] = List(pathCapture, bodyCapture)
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+
+  private def ensure(cond: Boolean, msg: => String): IO[Throwable, Unit] =
+    ZIO.unless(cond)(ZIO.fail(new AssertionError(msg))).unit
+
+  private val emptySource = MockSource.Dsl(MockSpec(Nil))
+
+  private def space(control: MockControl): ZIO[Scope, Throwable, MockSpace] =
+    ZIO.acquireRelease(control.provision(emptySource).mapError(asT).map(_.head))(s => control.destroy(s).ignoreLogged)
+
+  private def templatingOf(control: MockControl): IO[Throwable, Templating] =
+    control.templating.mapError(u => new RuntimeException(u.toString))
+
+  private val pathCapture =
+    ConformanceScenario(
+      "templating: interpolates a value captured from the request path",
+      Set(Capability.Templating),
+      control =>
+        for
+          s          <- space(control)
+          templating <- templatingOf(control)
+          template = ResponseTemplate(
+                       body = "Hello ${NAME}",
+                       captures = List(TemplateCapture("${NAME}", TemplateSource.Path, "[^/]+$"))
+                     )
+          _    <- templating.inject(s, RequestMatch(path = PathMatch.Regex("^/greet/[^/]+$")), template).mapError(asT)
+          resp <- SutClient.make(s).send(Method.Get, "/greet/World")
+          _ <-
+            ensure(resp.status == 200 && resp.body == "Hello World", s"path: status=${resp.status} body=${resp.body}")
+        yield ()
+    )
+
+  private val bodyCapture =
+    ConformanceScenario(
+      "templating: interpolates a value captured from the request body",
+      Set(Capability.Templating),
+      control =>
+        for
+          s          <- space(control)
+          templating <- templatingOf(control)
+          template = ResponseTemplate(
+                       body = "echo:${WHO}",
+                       captures = List(TemplateCapture("${WHO}", TemplateSource.Body, "\\w+"))
+                     )
+          _ <- templating
+                 .inject(s, RequestMatch(method = Some(Method.Post), path = PathMatch.Exact("/echo")), template)
+                 .mapError(asT)
+          resp <- SutClient.make(s).send(Method.Post, "/echo", body = Some("Alice"))
+          _    <- ensure(resp.status == 200 && resp.body == "echo:Alice", s"body: status=${resp.status} body=${resp.body}")
+        yield ()
+    )

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
@@ -85,7 +85,12 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
   // ---- the backends ----
 
   private val wiremock =
-    MockBackendUnderTest("wiremock", Provisioning.live >>> WireMock.correlated(), Set.empty, Isolation.Correlated)
+    MockBackendUnderTest(
+      "wiremock",
+      Provisioning.live >>> WireMock.correlated(),
+      Set(Capability.StatefulScenarios, Capability.StateInspection),
+      Isolation.Correlated
+    )
 
   private val riftEnabled = sys.env.contains("RIFT_IT")
   private val rift =
@@ -156,17 +161,21 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
       )
     } @@ TestAspect.withLiveClock,
-    test("cap-stateful feature is defined + capability-gated; SKIPs until an adapter advertises it (#129)") {
+    test("cap-stateful feature PASSes on WireMock; SKIPs on Rift until #131 (#130)") {
       val all = CapStatefulScenarios.all
       for
-        matrix <- ConformanceHarness.run(List(wiremock, rift), all)
-        _      <- ZIO.logInfo(s"cap-stateful matrix:\n${matrix.render}")
+        matrix   <- ConformanceHarness.run(List(wiremock, rift), all)
+        _        <- ZIO.logInfo(s"cap-stateful matrix:\n${matrix.render}")
+        wmFails   = nonPass(matrix, "wiremock", all)
+        _        <- ZIO.logInfo(s"wiremock non-pass: $wmFails").when(wmFails.nonEmpty)
+        riftCells = all.flatMap(s => matrix.cell(s.name, "rift").map(_.outcome))
       yield assertTrue(
         all.nonEmpty,
-        // Neither adapter advertises StatefulScenarios/StateInspection yet -> every cell is a justified SKIP.
-        all.forall(s => matrix.cell(s.name, "wiremock").exists(_.outcome == Outcome.Skip)),
-        all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Skip)),
-        matrix.conformant(wiremock) // justified (capability-gated) skips keep the column conformant
+        // WireMock now advertises StatefulScenarios + StateInspection -> the whole feature runs and passes.
+        all.forall(s => matrix.cell(s.name, "wiremock").exists(_.outcome == Outcome.Pass)),
+        matrix.cells.count(_.backend == "wiremock") == all.size,
+        // Rift doesn't advertise these until #131 -> every Rift cell is a justified SKIP.
+        riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
       )
     } @@ TestAspect.withLiveClock
   )

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
@@ -97,7 +97,7 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
     MockBackendUnderTest(
       "rift",
       (Client.default ++ Provisioning.live) >>> Rift.managed().mapError(asT),
-      Set(Capability.Faults, Capability.StatefulScenarios, Capability.StateInspection),
+      Capability.values.toSet, // Rift advertises every capability (#132)
       Isolation.PerInstance,
       available = riftEnabled
     )
@@ -199,8 +199,33 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         if riftEnabled then all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Pass))
         else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
       )
+    } @@ TestAspect.withLiveClock,
+    test("cap-scripting feature PASSes on Rift; SKIPs on WireMock (un-advertised) (#132)") {
+      riftOnlyCapability("cap-scripting", ScriptingScenarios.all)
+    } @@ TestAspect.withLiveClock,
+    test("cap-templating feature PASSes on Rift; SKIPs on WireMock (un-advertised) (#132)") {
+      riftOnlyCapability("cap-templating", TemplatingScenarios.all)
     } @@ TestAspect.withLiveClock
   )
+
+  // A capability only Rift advertises: WireMock SKIPs every scenario (un-advertised,
+  // a justified SKIP — never FAIL); Rift PASSes under RIFT_IT, else its column is
+  // SKIPPED-unavailable (local, no Docker).
+  private def riftOnlyCapability(label: String, all: List[ConformanceScenario]) =
+    for
+      matrix   <- ConformanceHarness.run(List(wiremock, rift), all)
+      _        <- ZIO.logInfo(s"$label matrix:\n${matrix.render}")
+      rfFails   = nonPass(matrix, "rift", all)
+      _        <- ZIO.logInfo(s"rift non-pass: $rfFails").when(riftEnabled && rfFails.nonEmpty)
+      wmCells   = all.flatMap(s => matrix.cell(s.name, "wiremock").map(_.outcome))
+      riftCells = all.flatMap(s => matrix.cell(s.name, "rift").map(_.outcome))
+    yield assertTrue(
+      all.nonEmpty,
+      wmCells.size == all.size && wmCells.forall(_ == Outcome.Skip),
+      matrix.conformant(wiremock),
+      if riftEnabled then all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Pass))
+      else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
+    )
 
   private def nonPass(matrix: Matrix, backend: String, scenarios: List[ConformanceScenario]): List[String] =
     scenarios.flatMap { s =>

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
@@ -97,7 +97,7 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
     MockBackendUnderTest(
       "rift",
       (Client.default ++ Provisioning.live) >>> Rift.managed().mapError(asT),
-      Set(Capability.Faults),
+      Set(Capability.Faults, Capability.StatefulScenarios, Capability.StateInspection),
       Isolation.PerInstance,
       available = riftEnabled
     )
@@ -161,21 +161,24 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
       )
     } @@ TestAspect.withLiveClock,
-    test("cap-stateful feature PASSes on WireMock; SKIPs on Rift until #131 (#130)") {
+    test("cap-stateful feature PASSes on both adapters (WireMock + Rift under RIFT_IT) (#131)") {
       val all = CapStatefulScenarios.all
       for
         matrix   <- ConformanceHarness.run(List(wiremock, rift), all)
         _        <- ZIO.logInfo(s"cap-stateful matrix:\n${matrix.render}")
         wmFails   = nonPass(matrix, "wiremock", all)
         _        <- ZIO.logInfo(s"wiremock non-pass: $wmFails").when(wmFails.nonEmpty)
+        riftFails = nonPass(matrix, "rift", all)
+        _        <- ZIO.logInfo(s"rift non-pass: $riftFails").when(riftEnabled && riftFails.nonEmpty)
         riftCells = all.flatMap(s => matrix.cell(s.name, "rift").map(_.outcome))
       yield assertTrue(
         all.nonEmpty,
-        // WireMock now advertises StatefulScenarios + StateInspection -> the whole feature runs and passes.
         all.forall(s => matrix.cell(s.name, "wiremock").exists(_.outcome == Outcome.Pass)),
         matrix.cells.count(_.backend == "wiremock") == all.size,
-        // Rift doesn't advertise these until #131 -> every Rift cell is a justified SKIP.
-        riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
+        // Rift advertises StatefulScenarios + StateInspection now (#131): every scenario PASSes in CI
+        // (RIFT_IT); else the whole column is SKIPPED-unavailable (local, no Docker).
+        if riftEnabled then all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Pass))
+        else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
       )
     } @@ TestAspect.withLiveClock,
     test("fault-injection features pass on every adapter (#128)") {

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
@@ -88,7 +88,7 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
     MockBackendUnderTest(
       "wiremock",
       Provisioning.live >>> WireMock.correlated(),
-      Set(Capability.StatefulScenarios, Capability.StateInspection),
+      Set(Capability.Faults, Capability.StatefulScenarios, Capability.StateInspection),
       Isolation.Correlated
     )
 
@@ -97,7 +97,7 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
     MockBackendUnderTest(
       "rift",
       (Client.default ++ Provisioning.live) >>> Rift.managed().mapError(asT),
-      Set.empty,
+      Set(Capability.Faults),
       Isolation.PerInstance,
       available = riftEnabled
     )
@@ -114,7 +114,7 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         matrix
           .cell(injectFault, "wiremock")
           .map(_.outcome)
-          .contains(Outcome.Skip),   // Faults un-advertised → SKIP, not FAIL
+          .contains(Outcome.Pass),   // Faults advertised (#128) → the accessor succeeds → PASS
         matrix.conformant(wiremock), // zero FAIL, skip justified by capability
         // Rift: conformant when available (CI with RIFT_IT), else the column is SKIPPED-unavailable (local, no Docker)
         if riftEnabled then matrix.conformant(rift)
@@ -176,6 +176,25 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         matrix.cells.count(_.backend == "wiremock") == all.size,
         // Rift doesn't advertise these until #131 -> every Rift cell is a justified SKIP.
         riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
+      )
+    } @@ TestAspect.withLiveClock,
+    test("fault-injection features pass on every adapter (#128)") {
+      val all = FaultScenarios.all
+      for
+        matrix   <- ConformanceHarness.run(List(wiremock, rift), all)
+        _        <- ZIO.logInfo(s"faults matrix:\n${matrix.render}")
+        wmFails   = nonPass(matrix, "wiremock", all)
+        _        <- ZIO.logInfo(s"wiremock non-pass: $wmFails").when(wmFails.nonEmpty)
+        rfFails   = nonPass(matrix, "rift", all)
+        _        <- ZIO.logInfo(s"rift non-pass: $rfFails").when(rfFails.nonEmpty)
+        riftCells = all.flatMap(s => matrix.cell(s.name, "rift").map(_.outcome))
+      yield assertTrue(
+        all.nonEmpty,
+        all.forall(s => matrix.cell(s.name, "wiremock").exists(_.outcome == Outcome.Pass)),
+        matrix.cells.count(_.backend == "wiremock") == all.size,
+        // Rift: every fault kind PASSes in CI (RIFT_IT, real container); else the column is SKIPPED-unavailable.
+        if riftEnabled then all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Pass))
+        else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
       )
     } @@ TestAspect.withLiveClock
   )

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
@@ -155,6 +155,19 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
         if riftEnabled then all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Pass))
         else riftCells.size == all.size && riftCells.forall(_ == Outcome.Skip)
       )
+    } @@ TestAspect.withLiveClock,
+    test("cap-stateful feature is defined + capability-gated; SKIPs until an adapter advertises it (#129)") {
+      val all = CapStatefulScenarios.all
+      for
+        matrix <- ConformanceHarness.run(List(wiremock, rift), all)
+        _      <- ZIO.logInfo(s"cap-stateful matrix:\n${matrix.render}")
+      yield assertTrue(
+        all.nonEmpty,
+        // Neither adapter advertises StatefulScenarios/StateInspection yet -> every cell is a justified SKIP.
+        all.forall(s => matrix.cell(s.name, "wiremock").exists(_.outcome == Outcome.Skip)),
+        all.forall(s => matrix.cell(s.name, "rift").exists(_.outcome == Outcome.Skip)),
+        matrix.conformant(wiremock) // justified (capability-gated) skips keep the column conformant
+      )
     } @@ TestAspect.withLiveClock
   )
 

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ProxyRecordConformanceSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ProxyRecordConformanceSpec.scala
@@ -1,0 +1,101 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.rift.Rift
+import zio.http.Client
+import zio.test.*
+
+import org.testcontainers.containers.{GenericContainer, Network}
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * The `cap-proxy` conformance (#132): the full ProxyRecord acceptance — proxy
+ * to a real upstream, record, then replay with the upstream down. Both the Rift
+ * container and a tiny `http-echo` upstream join one shared Docker network, so
+ * Rift reaches the upstream by its container IP on that network — pure
+ * container-to-container, no host networking. After the first call records the
+ * upstream response, the echo container is stopped; a successful replay then
+ * proves the recording is served without contacting the (now-down) upstream.
+ *
+ * Gated on `RIFT_IT` (Docker) like [[zio.bdd.mock.rift.RiftContainerSpec]];
+ * WireMock does not advertise ProxyRecord, so the portable capability is
+ * correctly Rift-only.
+ */
+object ProxyRecordConformanceSpec extends ZIOSpecDefault:
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+
+  private val adminPort     = Rift.DefaultAdminPort
+  private val imposterPorts = (0 until 4).map(Rift.DefaultImposterBase + _).toList
+  private val echoText      = "echo-ok"
+
+  private def acquire[A](mk: => A)(close: A => Unit): ZIO[Scope, Throwable, A] =
+    ZIO.acquireRelease(ZIO.attemptBlocking(mk))(a => ZIO.attemptBlocking(close(a)).orDie)
+
+  private def send(space: MockSpace, label: String): IO[Throwable, SutResponse] =
+    SutClient
+      .make(space)
+      .send(Method.Get, "/echo")
+      .timeoutFail(new RuntimeException(s"SUT $label timed out after 15s"))(15.seconds)
+
+  private def startEcho(net: Network): GenericContainer[?] =
+    val c = new GenericContainer(DockerImageName.parse("hashicorp/http-echo:1.0.0"))
+    c.withNetwork(net)
+    c.withCommand(s"-text=$echoText")
+    c.waitingFor(Wait.forLogMessage(".*server is listening.*", 1))
+    c.start()
+    c
+
+  // The echo container's IP on the shared network — Rift proxies to it directly, so the test
+  // doesn't depend on Rift's Rust proxy resolving a Docker DNS alias.
+  private def ipOf(c: GenericContainer[?]): String =
+    c.getContainerInfo.getNetworkSettings.getNetworks.values.iterator.next.getIpAddress
+
+  private def startRift(net: Network): GenericContainer[?] =
+    val c = new GenericContainer(DockerImageName.parse(Rift.DefaultImage))
+    c.withNetwork(net)
+    (adminPort :: imposterPorts).foreach(p => c.addExposedPort(Integer.valueOf(p)))
+    c.waitingFor(Wait.forHttp("/imposters").forPort(adminPort))
+    c.start()
+    c
+
+  private val proxyTest =
+    test("proxy records the upstream response and replays it after the upstream is down (#132)") {
+      ZIO.scoped {
+        for
+          net    <- acquire(Network.newNetwork())(_.close())
+          echo   <- acquire(startEcho(net))(_.stop()) // stop() is idempotent — also called mid-test below
+          rift   <- acquire(startRift(net))(_.stop())
+          admin   = s"http://${rift.getHost}:${rift.getMappedPort(Integer.valueOf(adminPort))}"
+          hostFor = (p: Int) => s"http://${rift.getHost}:${rift.getMappedPort(Integer.valueOf(p))}"
+          // Build Client + Provisioning + control into the test scope (not a nested one) so the
+          // zio-http admin Client stays alive for the whole test, not just the layer build.
+          env     <- ((Client.default ++ Provisioning.live) >>> Rift.connect(admin, imposterPorts)(hostFor)).build
+          control  = env.get[MockControl]
+          space   <- control.provision(MockSource.Dsl(MockSpec(Nil))).mapError(asT).map(_.head)
+          proxy   <- control.proxyRecord.mapError(u => new RuntimeException(u.toString))
+          upstream = s"http://${ipOf(echo)}:5678"
+          _       <- proxy.proxy(space, RequestMatch(path = PathMatch.Exact("/echo")), upstream).mapError(asT)
+          // First call: Rift proxies to the upstream and records the response. Time it out so a
+          // misconfigured proxy fails fast instead of blocking on the unbounded Java HttpClient.
+          first <- send(space, "first call (proxy + record)")
+          // Upstream goes down. Bound the blocking stop so a stalled daemon fails fast, like the SUT calls.
+          _ <- ZIO
+                 .attemptBlocking(echo.stop())
+                 .timeoutFail(new RuntimeException("echo.stop() timed out after 30s"))(30.seconds)
+          // Second call: served from the recording — the upstream is never contacted.
+          second <- send(space, "second call (replay, upstream down)")
+        yield assertTrue(
+          first.status == 200,
+          first.body.trim == echoText,
+          second.status == 200,
+          second.body.trim == echoText // identical with the upstream down => replayed, not re-proxied
+        )
+      }
+    } @@ TestAspect.withLiveClock
+
+  def spec =
+    if sys.env.contains("RIFT_IT") then suite("ProxyRecordConformance")(proxyTest)
+    else suite("ProxyRecordConformance (skipped — set RIFT_IT=1 to run against a real Rift container)")()

--- a/mock/src/main/scala/zio/bdd/mock/Capability.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Capability.scala
@@ -31,7 +31,15 @@ enum Isolation:
  * Fault injection (latency, errors, connection resets). Capability:
  * [[Capability.Faults]].
  */
-trait Faults
+trait Faults:
+  /**
+   * Inject `fault` for requests matching `m` in `space`, returning the id of
+   * the fault rule (removable via [[MockControl.removeRule]]). The four
+   * connection kinds make the SUT's client observe a transport-level failure;
+   * [[FaultKind.LatencySpike]] delays an otherwise normal 200 response. The
+   * fault takes precedence over a normal rule on the same match.
+   */
+  def inject(space: MockSpace, m: RequestMatch, fault: FaultKind): IO[MockError, RuleId]
 
 /**
  * Single-token FSM per scenario (#129): a request eligible in the scenario's

--- a/mock/src/main/scala/zio/bdd/mock/Capability.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Capability.scala
@@ -1,5 +1,7 @@
 package zio.bdd.mock
 
+import zio.IO
+
 /**
  * Optional capabilities an adapter MAY implement beyond the total core port. An
  * adapter advertises a capability via [[MockControl.capabilities]]; for each
@@ -23,7 +25,7 @@ enum Isolation:
   case PerInstance, Correlated
 
 // Capability interfaces returned by the typed accessors on [[MockControl]].
-// Empty markers here — their operations are fleshed out in M3 (#128/#129/#132).
+// Faults/Scripting/ProxyRecord/Templating remain markers until their M3 issues.
 
 /**
  * Fault injection (latency, errors, connection resets). Capability:
@@ -32,16 +34,31 @@ enum Isolation:
 trait Faults
 
 /**
- * Single-state-token FSM per scenario. Capability:
- * [[Capability.StatefulScenarios]].
+ * Single-token FSM per scenario (#129): a request eligible in the scenario's
+ * current state serves its response and (optionally) transitions the state.
+ * Capability: [[Capability.StatefulScenarios]].
  */
-trait StatefulScenarios
+trait StatefulScenarios:
+  /**
+   * Install (replacing any existing) the named scenario on `space`, in its
+   * initial state.
+   */
+  def define(space: MockSpace, scenario: ScenarioDef): IO[MockError, Unit]
+
+  /** Return the named scenario on `space` to its initial state. */
+  def reset(space: MockSpace, name: String): IO[MockError, Unit]
 
 /**
- * Arrange/assert scenario state without driving requests. Capability:
- * [[Capability.StateInspection]].
+ * Arrange/assert scenario state without driving requests — split from
+ * [[StatefulScenarios]] because not every backend exposes direct state poking.
+ * Capability: [[Capability.StateInspection]].
  */
-trait StateInspection
+trait StateInspection:
+  /** The scenario's current state on `space`. */
+  def currentState(space: MockSpace, name: String): IO[MockError, ScenarioState]
+
+  /** Force the scenario on `space` to state `to`. */
+  def setState(space: MockSpace, name: String, to: ScenarioState): IO[MockError, Unit]
 
 /** Backend scripting hooks. Capability: [[Capability.Scripting]]. */
 trait Scripting

--- a/mock/src/main/scala/zio/bdd/mock/Capability.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Capability.scala
@@ -69,13 +69,39 @@ trait StateInspection:
   def setState(space: MockSpace, name: String, to: ScenarioState): IO[MockError, Unit]
 
 /** Backend scripting hooks. Capability: [[Capability.Scripting]]. */
-trait Scripting
+trait Scripting:
+  /**
+   * Install `script` to compute the response for requests matching `m`,
+   * returning the rule id. The script runs on the backend's engine and may read
+   * the matched request; a backend without a scripting engine does not
+   * advertise this capability.
+   */
+  def inject(space: MockSpace, m: RequestMatch, script: Script): IO[MockError, RuleId]
 
 /**
  * Proxy/record passthrough to a real upstream. Capability:
  * [[Capability.ProxyRecord]].
  */
-trait ProxyRecord
+trait ProxyRecord:
+  /**
+   * Proxy requests matching `m` to `upstream`, recording the first response and
+   * replaying it on subsequent calls — so the SUT keeps getting the recorded
+   * response even after the upstream goes down. Returns the rule id.
+   *
+   * The recording is owned by the backend, not this port: once a request has
+   * recorded a response, removing the proxy rule via [[MockControl.removeRule]]
+   * is unreliable (the backend may have inserted a recorded stub this port does
+   * not track), and on a `Correlated` space any rule mutation rebuilds the
+   * space and discards the recording. Inject a proxy on its own space and don't
+   * mutate rules after the first recorded call.
+   */
+  def proxy(space: MockSpace, m: RequestMatch, upstream: String): IO[MockError, RuleId]
 
 /** Response templating. Capability: [[Capability.Templating]]. */
-trait Templating
+trait Templating:
+  /**
+   * Install a templated response for requests matching `m`: each capture in
+   * `template` pulls a value from the request and substitutes its token into
+   * the response body. Returns the rule id.
+   */
+  def inject(space: MockSpace, m: RequestMatch, template: ResponseTemplate): IO[MockError, RuleId]

--- a/mock/src/main/scala/zio/bdd/mock/Dsl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Dsl.scala
@@ -119,3 +119,50 @@ object dsl:
 
   /** Build a DSL [[MockSource]] straight from rules. */
   def dslSource(rules: MockRule*): MockSource = mock(rules*).source
+
+  // --- stateful scenario builder (#129) -------------------------------------
+  // Fluent FSM builder: scenario("invoice").startingAt("Created")
+  //   .when("Created", get("/x")).respond(ok.text("a")).goTo("Paid")
+  //   .when("Paid", get("/x")).respond(ok.text("b")).stay
+  //   .build  ->  a ScenarioDef structurally identical to the hand-written one.
+
+  /**
+   * Begin a [[ScenarioDef]] named `name`, starting in
+   * [[ScenarioState.Started]].
+   */
+  def scenario(name: String): ScenarioBuilder = ScenarioBuilder(name, ScenarioState.Started, Vector.empty)
+
+  final case class ScenarioBuilder private[dsl] (
+    name: String,
+    initial: ScenarioState,
+    rules: Vector[StatefulRule]
+  ):
+    /** Override the initial state (default [[ScenarioState.Started]]). */
+    def startingAt(state: String): ScenarioBuilder = copy(initial = ScenarioState(state))
+
+    /**
+     * Begin an edge that fires while the FSM is in `state` and a request
+     * matches `request` (continue with `.respond`).
+     */
+    def when(state: String, request: RequestMatch): WhenStep = WhenStep(this, ScenarioState(state), request)
+
+    def build: ScenarioDef = ScenarioDef(name, rules.toList, initial)
+
+  final case class WhenStep private[dsl] (sb: ScenarioBuilder, whenState: ScenarioState, request: RequestMatch):
+    /** ...serves `response` (continue with `.goTo`/`.stay`). */
+    def respond(response: ResponseDef): RespondedStep = RespondedStep(sb, whenState, request, response)
+
+  final case class RespondedStep private[dsl] (
+    sb: ScenarioBuilder,
+    whenState: ScenarioState,
+    request: RequestMatch,
+    response: ResponseDef
+  ):
+    /** ...then transition to `state`. */
+    def goTo(state: String): ScenarioBuilder = add(Some(ScenarioState(state)))
+
+    /** ...and stay in the current state. */
+    def stay: ScenarioBuilder = add(None)
+
+    private def add(thenState: Option[ScenarioState]): ScenarioBuilder =
+      sb.copy(rules = sb.rules :+ StatefulRule(whenState, request, response, thenState))

--- a/mock/src/main/scala/zio/bdd/mock/model.scala
+++ b/mock/src/main/scala/zio/bdd/mock/model.scala
@@ -182,6 +182,20 @@ final case class ScenarioDef(
 )
 
 /**
+ * A client-observable fault the [[Faults]] capability injects for matching
+ * requests (#128). The four connection kinds produce a transport-level failure
+ * (the SUT's HTTP client throws); [[LatencySpike]] instead delays an otherwise
+ * normal response. The names mirror WireMock's `Fault` enum so both adapters
+ * (WireMock natively, Rift via `_rift.fault.tcp`) realise the same behaviour.
+ */
+enum FaultKind:
+  case ConnectionReset
+  case EmptyResponse
+  case MalformedChunk
+  case RandomThenClose
+  case LatencySpike(delay: Duration)
+
+/**
  * The unit of isolation. Hides *how* isolation is achieved:
  *   - PerInstance: a unique `baseUri` per space; `inject = identity`.
  *   - Correlated: a shared `baseUri`; `inject` stamps a correlation header.

--- a/mock/src/main/scala/zio/bdd/mock/model.scala
+++ b/mock/src/main/scala/zio/bdd/mock/model.scala
@@ -110,6 +110,36 @@ final case class MockRule(
 )
 
 /**
+ * A scenario FSM state token. The default initial state is
+ * [[ScenarioState.Started]].
+ */
+opaque type ScenarioState = String
+object ScenarioState:
+  val Started: ScenarioState                     = "Started"
+  def apply(value: String): ScenarioState        = value
+  extension (s: ScenarioState) def value: String = s
+
+/**
+ * One edge of a single-token scenario FSM (#129): while the scenario is in
+ * `whenState` and a request matches `request`, serve `respond` and transition
+ * to `thenState` — `None` stays in `whenState`. The portable subset both
+ * adapters (#130 WireMock, #131 Rift) honour.
+ */
+final case class StatefulRule(
+  whenState: ScenarioState,
+  request: RequestMatch,
+  respond: ResponseDef,
+  thenState: Option[ScenarioState] = None
+)
+
+/** A named single-token FSM: starts in `initial`, advances via its `rules`. */
+final case class ScenarioDef(
+  name: String,
+  rules: List[StatefulRule],
+  initial: ScenarioState = ScenarioState.Started
+)
+
+/**
  * The unit of isolation. Hides *how* isolation is achieved:
  *   - PerInstance: a unique `baseUri` per space; `inject = identity`.
  *   - Correlated: a shared `baseUri`; `inject` stamps a correlation header.

--- a/mock/src/main/scala/zio/bdd/mock/model.scala
+++ b/mock/src/main/scala/zio/bdd/mock/model.scala
@@ -195,6 +195,34 @@ enum FaultKind:
   case RandomThenClose
   case LatencySpike(delay: Duration)
 
+/** The engine a [[Scripting]] script runs on (#132). */
+enum ScriptEngine:
+  case Rhai, Lua, JavaScript
+
+/** A backend script that computes the response for matching requests (#132). */
+final case class Script(engine: ScriptEngine, code: String)
+
+/** Where a [[TemplateCapture]] reads its value from on the request (#132). */
+enum TemplateSource:
+  case Path, Body
+
+/**
+ * One templating capture (#132): extract from `source` using `regex` (the
+ * matched text) and substitute every occurrence of the literal `token` in the
+ * response body with it.
+ */
+final case class TemplateCapture(token: String, source: TemplateSource, regex: String)
+
+/**
+ * A templated response (#132): `body` may embed capture `token`s, each replaced
+ * by the value its [[TemplateCapture]] pulls from the request.
+ */
+final case class ResponseTemplate(
+  body: String,
+  captures: List[TemplateCapture],
+  status: Int = 200
+)
+
 /**
  * The unit of isolation. Hides *how* isolation is achieved:
  *   - PerInstance: a unique `baseUri` per space; `inject = identity`.

--- a/mock/src/test/scala/zio/bdd/mock/CapabilityNegotiationSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/CapabilityNegotiationSpec.scala
@@ -24,8 +24,8 @@ object CapabilityNegotiationSpec extends ZIOSpecDefault:
       if caps(c) then ZIO.succeed(a) else ZIO.fail(Unsupported(c, backendName))
 
     def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(new Faults {})
-    def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(new StatefulScenarios {})
-    def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(new StateInspection {})
+    def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(StubCaps.scenarios)
+    def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(StubCaps.stateInspection)
     def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(new Scripting {})
     def proxyRecord: IO[Unsupported, ProxyRecord]         = cap(Capability.ProxyRecord)(new ProxyRecord {})
     def templating: IO[Unsupported, Templating]           = cap(Capability.Templating)(new Templating {})

--- a/mock/src/test/scala/zio/bdd/mock/CapabilityNegotiationSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/CapabilityNegotiationSpec.scala
@@ -23,7 +23,9 @@ object CapabilityNegotiationSpec extends ZIOSpecDefault:
     private def cap[A](c: Capability)(a: => A): IO[Unsupported, A] =
       if caps(c) then ZIO.succeed(a) else ZIO.fail(Unsupported(c, backendName))
 
-    def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(new Faults {})
+    private val anyFault: Faults = (_, _, _) => ZIO.succeed(RuleId("fault"))
+
+    def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(anyFault)
     def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(StubCaps.scenarios)
     def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(StubCaps.stateInspection)
     def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(new Scripting {})

--- a/mock/src/test/scala/zio/bdd/mock/CapabilityNegotiationSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/CapabilityNegotiationSpec.scala
@@ -28,9 +28,9 @@ object CapabilityNegotiationSpec extends ZIOSpecDefault:
     def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(anyFault)
     def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(StubCaps.scenarios)
     def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(StubCaps.stateInspection)
-    def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(new Scripting {})
-    def proxyRecord: IO[Unsupported, ProxyRecord]         = cap(Capability.ProxyRecord)(new ProxyRecord {})
-    def templating: IO[Unsupported, Templating]           = cap(Capability.Templating)(new Templating {})
+    def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(StubCaps.scripting)
+    def proxyRecord: IO[Unsupported, ProxyRecord]         = cap(Capability.ProxyRecord)(StubCaps.proxyRecord)
+    def templating: IO[Unsupported, Templating]           = cap(Capability.Templating)(StubCaps.templating)
 
   def spec = suite("capability fail-fast negotiation")(
     test("require fails at layer construction, before first use") {

--- a/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
@@ -34,9 +34,9 @@ object MockControlModelSpec extends ZIOSpecDefault:
     def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(anyFault)
     def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(StubCaps.scenarios)
     def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(StubCaps.stateInspection)
-    def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(new Scripting {})
-    def proxyRecord: IO[Unsupported, ProxyRecord]         = cap(Capability.ProxyRecord)(new ProxyRecord {})
-    def templating: IO[Unsupported, Templating]           = cap(Capability.Templating)(new Templating {})
+    def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(StubCaps.scripting)
+    def proxyRecord: IO[Unsupported, ProxyRecord]         = cap(Capability.ProxyRecord)(StubCaps.proxyRecord)
+    def templating: IO[Unsupported, Templating]           = cap(Capability.Templating)(StubCaps.templating)
 
   def spec = suite("MockControl port + canonical model")(
     test("the total port is implementable by a stub adapter") {

--- a/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
@@ -30,8 +30,8 @@ object MockControlModelSpec extends ZIOSpecDefault:
       if caps(c) then ZIO.succeed(a) else ZIO.fail(Unsupported(c, backend))
 
     def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(new Faults {})
-    def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(new StatefulScenarios {})
-    def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(new StateInspection {})
+    def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(StubCaps.scenarios)
+    def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(StubCaps.stateInspection)
     def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(new Scripting {})
     def proxyRecord: IO[Unsupported, ProxyRecord]         = cap(Capability.ProxyRecord)(new ProxyRecord {})
     def templating: IO[Unsupported, Templating]           = cap(Capability.Templating)(new Templating {})

--- a/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/MockControlModelSpec.scala
@@ -29,7 +29,9 @@ object MockControlModelSpec extends ZIOSpecDefault:
     private def cap[A](c: Capability)(a: => A): IO[Unsupported, A] =
       if caps(c) then ZIO.succeed(a) else ZIO.fail(Unsupported(c, backend))
 
-    def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(new Faults {})
+    private val anyFault: Faults = (_, _, _) => ZIO.succeed(RuleId("fault"))
+
+    def faults: IO[Unsupported, Faults]                   = cap(Capability.Faults)(anyFault)
     def scenarios: IO[Unsupported, StatefulScenarios]     = cap(Capability.StatefulScenarios)(StubCaps.scenarios)
     def stateInspection: IO[Unsupported, StateInspection] = cap(Capability.StateInspection)(StubCaps.stateInspection)
     def scripting: IO[Unsupported, Scripting]             = cap(Capability.Scripting)(new Scripting {})

--- a/mock/src/test/scala/zio/bdd/mock/StatefulDslSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/StatefulDslSpec.scala
@@ -1,0 +1,65 @@
+package zio.bdd.mock
+
+import zio.bdd.mock.dsl.*
+import zio.test.*
+
+/**
+ * The stateful-scenario model + fluent DSL (#129): the builder is pure
+ * convenience, so its output must be structurally identical to the same
+ * [[ScenarioDef]] written by hand (the same contract the rest of the DSL
+ * keeps).
+ */
+object StatefulDslSpec extends ZIOSpecDefault:
+
+  def spec = suite("StatefulScenarios model + DSL")(
+    test("ScenarioState.Started is the default initial state") {
+      assertTrue(
+        ScenarioState.Started.value == "Started",
+        ScenarioDef("s", rules = Nil).initial == ScenarioState.Started
+      )
+    },
+    test("the fluent builder yields a ScenarioDef structurally identical to the hand-written one") {
+      val built =
+        scenario("invoice")
+          .startingAt("Created")
+          .when("Created", get("/invoice"))
+          .respond(ok.text("created"))
+          .goTo("Paid")
+          .when("Paid", get("/invoice"))
+          .respond(ok.text("paid"))
+          .stay
+          .build
+
+      val handWritten =
+        ScenarioDef(
+          "invoice",
+          List(
+            StatefulRule(
+              ScenarioState("Created"),
+              RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/invoice")),
+              ResponseDef(status = 200, body = Body.Text("created")),
+              Some(ScenarioState("Paid"))
+            ),
+            StatefulRule(
+              ScenarioState("Paid"),
+              RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/invoice")),
+              ResponseDef(status = 200, body = Body.Text("paid")),
+              None // .stay
+            )
+          ),
+          ScenarioState("Created") // initial (.startingAt)
+        )
+
+      assertTrue(built == handWritten)
+    },
+    test("goTo sets thenState; stay leaves it None; the default starting state is Started") {
+      val d = scenario("s").when("Started", get("/x")).respond(ok).stay.build
+      val g = scenario("s").when("Started", get("/x")).respond(ok).goTo("Done").build
+      assertTrue(
+        d.initial == ScenarioState.Started,
+        d.rules.head.whenState == ScenarioState.Started,
+        d.rules.head.thenState.isEmpty,
+        g.rules.head.thenState.contains(ScenarioState("Done"))
+      )
+    }
+  )

--- a/mock/src/test/scala/zio/bdd/mock/StubCaps.scala
+++ b/mock/src/test/scala/zio/bdd/mock/StubCaps.scala
@@ -1,0 +1,18 @@
+package zio.bdd.mock
+
+import zio.*
+
+/**
+ * Minimal capability-instance stubs for tests that only need an advertised
+ * accessor to return *some* valid instance (the negotiation tests don't drive
+ * the capability's behaviour — they assert advertised ⇒ Right / un-advertised ⇒
+ * Unsupported).
+ */
+object StubCaps:
+  val scenarios: StatefulScenarios = new StatefulScenarios:
+    def define(space: MockSpace, scenario: ScenarioDef): IO[MockError, Unit] = ZIO.unit
+    def reset(space: MockSpace, name: String): IO[MockError, Unit]           = ZIO.unit
+
+  val stateInspection: StateInspection = new StateInspection:
+    def currentState(space: MockSpace, name: String): IO[MockError, ScenarioState]       = ZIO.succeed(ScenarioState.Started)
+    def setState(space: MockSpace, name: String, to: ScenarioState): IO[MockError, Unit] = ZIO.unit

--- a/mock/src/test/scala/zio/bdd/mock/StubCaps.scala
+++ b/mock/src/test/scala/zio/bdd/mock/StubCaps.scala
@@ -16,3 +16,7 @@ object StubCaps:
   val stateInspection: StateInspection = new StateInspection:
     def currentState(space: MockSpace, name: String): IO[MockError, ScenarioState]       = ZIO.succeed(ScenarioState.Started)
     def setState(space: MockSpace, name: String, to: ScenarioState): IO[MockError, Unit] = ZIO.unit
+
+  val scripting: Scripting     = (_, _, _) => ZIO.succeed(RuleId("stub"))
+  val proxyRecord: ProxyRecord = (_, _, _) => ZIO.succeed(RuleId("stub"))
+  val templating: Templating   = (_, _, _) => ZIO.succeed(RuleId("stub"))

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -53,8 +53,9 @@ private[rift] final case class RiftMockControl(
 
   import RiftMockControl.{CorrSpace, Imposter}
 
-  def backendName: String           = "rift"
-  def capabilities: Set[Capability] = Set(Capability.Faults)
+  def backendName: String = "rift"
+  def capabilities: Set[Capability] =
+    Set(Capability.Faults, Capability.StatefulScenarios, Capability.StateInspection)
 
   override def isolation: Isolation = mode match
     case RiftMode.Correlated(_) => Isolation.Correlated
@@ -103,8 +104,8 @@ private[rift] final case class RiftMockControl(
     dispatch(space)(corrReceived)(piReceived)
 
   def faults: IO[Unsupported, Faults]                   = ZIO.succeed(riftFaults)
-  def scenarios: IO[Unsupported, StatefulScenarios]     = unsupported(Capability.StatefulScenarios)
-  def stateInspection: IO[Unsupported, StateInspection] = unsupported(Capability.StateInspection)
+  def scenarios: IO[Unsupported, StatefulScenarios]     = ZIO.succeed(statefulScenarios)
+  def stateInspection: IO[Unsupported, StateInspection] = ZIO.succeed(stateInspector)
   def scripting: IO[Unsupported, Scripting]             = unsupported(Capability.Scripting)
   def proxyRecord: IO[Unsupported, ProxyRecord]         = unsupported(Capability.ProxyRecord)
   def templating: IO[Unsupported, Templating]           = unsupported(Capability.Templating)
@@ -142,6 +143,110 @@ private[rift] final case class RiftMockControl(
       _      <- cs.faults.set(next)
     yield ruleId
 
+  // ===== StatefulScenarios + StateInspection (#131) ===============================
+  // Rift partitions scenario state by (flow_id, scenarioName), so locality is native
+  // (no name-namespacing). flow_id = the imposter port (PerInstance) / the X-Mock-Space
+  // value (Correlated), so admin calls pass that flowId to address the same slice the
+  // requests resolve to. `define` installs the stubs in declaration order (Rift is
+  // first-match-by-order) and pins the initial state.
+  //
+  // Limitations (untested edges — the conformance gate is PerInstance, one define per
+  // space): re-`define` of an existing name APPENDS stubs rather than replacing the
+  // prior ones (provision a fresh space per scenario, as the conformance does); and on
+  // a Correlated space a plain-rule mutation (addRule/removeRule/replaceRules) rebuilds
+  // the space — dropping its scenario stubs too. Don't mix rule mutation with scenarios
+  // on one Correlated space.
+
+  private val statefulScenarios: StatefulScenarios = new StatefulScenarios:
+    def define(space: MockSpace, scenarioDef: ScenarioDef): IO[MockError, Unit] =
+      dispatch(space)(cs => corrDefine(cs, scenarioDef))(imp => piDefine(imp, scenarioDef))
+    def reset(space: MockSpace, name: String): IO[MockError, Unit] =
+      dispatch(space)(cs => corrReset(cs, space.id, name))(imp => piReset(imp, space.id, name))
+
+  private val stateInspector: StateInspection = new StateInspection:
+    def currentState(space: MockSpace, name: String): IO[MockError, ScenarioState] =
+      dispatch(space)(cs => readState(cs.port, cs.flowId, space.id, name))(imp =>
+        readState(imp.port, imp.port.toString, space.id, name)
+      )
+    def setState(space: MockSpace, name: String, to: ScenarioState): IO[MockError, Unit] =
+      dispatch(space)(cs => guardDefined(cs.scenarios, space.id, name)(putState(cs.port, cs.flowId, name, to)))(imp =>
+        guardDefined(imp.scenarios, space.id, name)(putState(imp.port, imp.port.toString, name, to))
+      )
+
+  private def piDefine(imp: Imposter, sc: ScenarioDef): IO[MockError, Unit] =
+    for
+      _ <- ZIO.foreachDiscard(sc.rules) { r =>
+             for
+               ruleId <- freshId
+               index  <- imp.stubs.get.map(_.size)
+               u      <- url(s"/imposters/${imp.port}/stubs")
+               stub    = RiftProtocol.statefulStub(sc.name, r.whenState, r.thenState, MockRule(r.request, r.respond))
+               res    <- send(jsonRequest(HttpMethod.POST, u, RiftProtocol.addStubBodyOf(index, stub)))
+               _      <- expectSuccess(s"add scenario stub to imposter ${imp.port}", res)
+               _      <- imp.stubs.update(_ :+ ruleId)
+             yield ()
+           }
+      // Always pin the initial state: it puts the scenario in its declared start
+      // state (so a re-define resets it) and registers an explicit FlowStore entry.
+      _ <- putState(imp.port, imp.port.toString, sc.name, sc.initial)
+      _ <- imp.scenarios.update(_ + (sc.name -> sc.initial))
+    yield ()
+
+  private def corrDefine(cs: CorrSpace, sc: ScenarioDef): IO[MockError, Unit] =
+    for
+      _ <- ZIO.foreachDiscard(sc.rules) { r =>
+             val stub = RiftProtocol.statefulStub(sc.name, r.whenState, r.thenState, MockRule(r.request, r.respond))
+             for
+               u   <- url(s"/imposters/${cs.port}/spaces/${enc(cs.flowId)}/stubs")
+               res <- send(jsonRequest(HttpMethod.POST, u, stub))
+               _   <- expectSuccess(s"add scenario stub to space ${cs.flowId}", res)
+             yield ()
+           }
+      _ <- putState(cs.port, cs.flowId, sc.name, sc.initial)
+      _ <- cs.scenarios.update(_ + (sc.name -> sc.initial))
+    yield ()
+
+  private def piReset(imp: Imposter, spaceId: SpaceId, name: String): IO[MockError, Unit] =
+    imp.scenarios.get.flatMap(_.get(name) match
+      case Some(initial) => putState(imp.port, imp.port.toString, name, initial)
+      case None          => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${spaceId.value}"))
+    )
+
+  private def corrReset(cs: CorrSpace, spaceId: SpaceId, name: String): IO[MockError, Unit] =
+    cs.scenarios.get.flatMap(_.get(name) match
+      case Some(initial) => putState(cs.port, cs.flowId, name, initial)
+      case None          => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${spaceId.value}"))
+    )
+
+  private def guardDefined(
+    scenarios: Ref[Map[String, ScenarioState]],
+    spaceId: SpaceId,
+    name: String
+  )(action: => IO[MockError, Unit]): IO[MockError, Unit] =
+    scenarios.get.flatMap(s =>
+      if s.contains(name) then action
+      else ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${spaceId.value}"))
+    )
+
+  private def putState(port: Int, flowId: String, name: String, state: ScenarioState): IO[MockError, Unit] =
+    for
+      u   <- url(s"/imposters/$port/scenarios/${enc(name)}/state")
+      body = Json.Obj("state" -> Json.Str(state.value), "flowId" -> Json.Str(flowId))
+      res <- send(jsonRequest(HttpMethod.PUT, u, body))
+      _   <- expectSuccess(s"set scenario '$name' state on imposter $port", res)
+    yield ()
+
+  private def readState(port: Int, flowId: String, spaceId: SpaceId, name: String): IO[MockError, ScenarioState] =
+    for
+      u    <- url(s"/imposters/$port/scenarios?flowId=${enc(flowId)}")
+      res  <- send(Request(method = HttpMethod.GET, url = u))
+      body <- expectSuccess(s"read scenarios for imposter $port", res)
+      st   <- ZIO.fromEither(RiftProtocol.parseScenarioState(body, name)).mapError(MockError.CommunicationError(_))
+      out <- st match
+               case Some(s) => ZIO.succeed(ScenarioState(s))
+               case None    => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${spaceId.value}"))
+    yield out
+
   // ---------------------------------------------------------------------------
 
   private def serveSpace(src: NormalizedSource): IO[MockError, MockSpace] =
@@ -174,9 +279,10 @@ private[rift] final case class RiftMockControl(
           _            <- postImposter(port, body)
           ruleIds      <- freshIds(count)
           stubs        <- Ref.make(ruleIds)
+          scen         <- Ref.make(Map.empty[String, ScenarioState])
           id            = SpaceId(s"${src.name}-$port")
           space         = MockSpace(endpoint.baseUriFor(port), identity, id)
-          _            <- spaces.update(_.updated(id, Imposter(port, stubs)))
+          _            <- spaces.update(_.updated(id, Imposter(port, stubs, scen)))
         yield space
       stand.onError(_ => endpoint.releasePort(port))
     }
@@ -254,7 +360,8 @@ private[rift] final case class RiftMockControl(
       _         <- registerStubs(port, flowId, tagged).onError(_ => deleteSpace(port, flowId).ignore)
       rulesRef  <- Ref.make(tagged)
       faultsRef <- Ref.make(Vector.empty[(RuleId, RequestMatch, FaultKind)])
-      _         <- correlated.update(_.updated(id, CorrSpace(port, flowId, corr.header, rulesRef, faultsRef)))
+      scen      <- Ref.make(Map.empty[String, ScenarioState])
+      _         <- correlated.update(_.updated(id, CorrSpace(port, flowId, corr.header, rulesRef, faultsRef, scen)))
     yield MockSpace(endpoint.baseUriFor(port), req => req.copy(headers = req.headers.add(corr.header, flowId)), id)
 
   // Create the one shared imposter on first Correlated provision (race-safe).
@@ -448,13 +555,18 @@ private[rift] final case class RiftMockControl(
     else ZIO.fail(MockError.CommunicationError(s"$action: Rift returned HTTP $code: ${body.take(1000)}"))
 
 private[rift] object RiftMockControl:
-  final case class Imposter(port: Int, stubs: Ref[Vector[RuleId]])
+  final case class Imposter(
+    port: Int,
+    stubs: Ref[Vector[RuleId]],
+    scenarios: Ref[Map[String, ScenarioState]] // defined scenario name -> initial state (for reset)
+  )
   final case class CorrSpace(
     port: Int,
     flowId: String,
     header: String,
     rules: Ref[Vector[(RuleId, MockRule)]],
-    faults: Ref[Vector[(RuleId, RequestMatch, FaultKind)]]
+    faults: Ref[Vector[(RuleId, RequestMatch, FaultKind)]],
+    scenarios: Ref[Map[String, ScenarioState]]
   )
 
   /**

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -55,7 +55,14 @@ private[rift] final case class RiftMockControl(
 
   def backendName: String = "rift"
   def capabilities: Set[Capability] =
-    Set(Capability.Faults, Capability.StatefulScenarios, Capability.StateInspection)
+    Set(
+      Capability.Faults,
+      Capability.StatefulScenarios,
+      Capability.StateInspection,
+      Capability.Scripting,
+      Capability.ProxyRecord,
+      Capability.Templating
+    )
 
   override def isolation: Isolation = mode match
     case RiftMode.Correlated(_) => Isolation.Correlated
@@ -106,9 +113,9 @@ private[rift] final case class RiftMockControl(
   def faults: IO[Unsupported, Faults]                   = ZIO.succeed(riftFaults)
   def scenarios: IO[Unsupported, StatefulScenarios]     = ZIO.succeed(statefulScenarios)
   def stateInspection: IO[Unsupported, StateInspection] = ZIO.succeed(stateInspector)
-  def scripting: IO[Unsupported, Scripting]             = unsupported(Capability.Scripting)
-  def proxyRecord: IO[Unsupported, ProxyRecord]         = unsupported(Capability.ProxyRecord)
-  def templating: IO[Unsupported, Templating]           = unsupported(Capability.Templating)
+  def scripting: IO[Unsupported, Scripting]             = ZIO.succeed(riftScripting)
+  def proxyRecord: IO[Unsupported, ProxyRecord]         = ZIO.succeed(riftProxyRecord)
+  def templating: IO[Unsupported, Templating]           = ZIO.succeed(riftTemplating)
 
   // ===== Faults (#128) — `_rift.fault` (rift#239) =================================
 
@@ -138,9 +145,52 @@ private[rift] final case class RiftMockControl(
       ruleId <- freshId
       rules  <- cs.rules.get
       faults <- cs.faults.get
+      extras <- cs.extras.get
       next    = (ruleId, m, fault) +: faults
-      _      <- rebuild(cs, next, rules)
+      _      <- rebuild(cs, extras, next, rules)
       _      <- cs.faults.set(next)
+    yield ruleId
+
+  // ===== Optional capabilities (#132): scripting / proxy-record / templating ======
+  // Each installs a special-response stub (`_rift.script`, a Mountebank `proxy`, or
+  // an `is` + `_behaviors.copy`) for matching requests. Like faults, the stub is
+  // first-match (PerInstance: index 0, tracked in `imp.stubs`; Correlated: tracked in
+  // `cs.extras`, re-registered ahead of rules on rebuild) so it wins over a normal
+  // rule, is removable via `removeRule`, and survives a later space rebuild.
+
+  private val riftScripting: Scripting = new Scripting:
+    def inject(space: MockSpace, m: RequestMatch, script: Script): IO[MockError, RuleId] =
+      injectStub(space, rid => RiftProtocol.scriptStub(m, script, rid))
+
+  private val riftProxyRecord: ProxyRecord = new ProxyRecord:
+    def proxy(space: MockSpace, m: RequestMatch, upstream: String): IO[MockError, RuleId] =
+      injectStub(space, rid => RiftProtocol.proxyStub(m, upstream, rid))
+
+  private val riftTemplating: Templating = new Templating:
+    def inject(space: MockSpace, m: RequestMatch, template: ResponseTemplate): IO[MockError, RuleId] =
+      injectStub(space, rid => RiftProtocol.templateStub(m, template, rid))
+
+  private def injectStub(space: MockSpace, buildStub: RuleId => Json): IO[MockError, RuleId] =
+    freshId.flatMap(rid =>
+      dispatch(space)(cs => corrInjectStub(cs, rid, buildStub(rid)))(imp => piInjectStub(imp, rid, buildStub(rid)))
+    )
+
+  private def piInjectStub(imp: Imposter, ruleId: RuleId, stub: Json): IO[MockError, RuleId] =
+    for
+      u   <- url(s"/imposters/${imp.port}/stubs")
+      res <- send(jsonRequest(HttpMethod.POST, u, RiftProtocol.addStubBodyOf(0, stub)))
+      _   <- expectSuccess(s"inject capability stub into imposter ${imp.port}", res)
+      _   <- imp.stubs.update(ruleId +: _)
+    yield ruleId
+
+  private def corrInjectStub(cs: CorrSpace, ruleId: RuleId, stub: Json): IO[MockError, RuleId] =
+    for
+      rules  <- cs.rules.get
+      faults <- cs.faults.get
+      extras <- cs.extras.get
+      next    = (ruleId, stub) +: extras
+      _      <- rebuild(cs, next, faults, rules)
+      _      <- cs.extras.set(next)
     yield ruleId
 
   // ===== StatefulScenarios + StateInspection (#131) ===============================
@@ -153,9 +203,10 @@ private[rift] final case class RiftMockControl(
   // Limitations (untested edges — the conformance gate is PerInstance, one define per
   // space): re-`define` of an existing name APPENDS stubs rather than replacing the
   // prior ones (provision a fresh space per scenario, as the conformance does); and on
-  // a Correlated space a plain-rule mutation (addRule/removeRule/replaceRules) rebuilds
-  // the space — dropping its scenario stubs too. Don't mix rule mutation with scenarios
-  // on one Correlated space.
+  // a Correlated space a plain-rule mutation (addRule/removeRule/replaceRules) — or a
+  // capability injection (faults/script/proxy/template), which rebuilds the same way —
+  // drops the space's scenario stubs (and discards any proxy recording). Don't mix
+  // scenarios with rule mutation or capability injection on one Correlated space.
 
   private val statefulScenarios: StatefulScenarios = new StatefulScenarios:
     def define(space: MockSpace, scenarioDef: ScenarioDef): IO[MockError, Unit] =
@@ -360,8 +411,11 @@ private[rift] final case class RiftMockControl(
       _         <- registerStubs(port, flowId, tagged).onError(_ => deleteSpace(port, flowId).ignore)
       rulesRef  <- Ref.make(tagged)
       faultsRef <- Ref.make(Vector.empty[(RuleId, RequestMatch, FaultKind)])
+      extrasRef <- Ref.make(Vector.empty[(RuleId, Json)])
       scen      <- Ref.make(Map.empty[String, ScenarioState])
-      _         <- correlated.update(_.updated(id, CorrSpace(port, flowId, corr.header, rulesRef, faultsRef, scen)))
+      _ <- correlated.update(
+             _.updated(id, CorrSpace(port, flowId, corr.header, rulesRef, faultsRef, extrasRef, scen))
+           )
     yield MockSpace(endpoint.baseUriFor(port), req => req.copy(headers = req.headers.add(corr.header, flowId)), id)
 
   // Create the one shared imposter on first Correlated provision (race-safe).
@@ -395,13 +449,17 @@ private[rift] final case class RiftMockControl(
     for
       rules  <- cs.rules.get
       faults <- cs.faults.get
-      _ <- // commit tracking only on success; a removed id is either a rule or a fault
+      extras <- cs.extras.get
+      _ <- // commit tracking only on success; a removed id is a rule, a fault, or a capability stub
         if rules.exists(_._1 == id) then
           val next = rules.filterNot(_._1 == id)
-          rebuild(cs, faults, next) *> cs.rules.set(next)
+          rebuild(cs, extras, faults, next) *> cs.rules.set(next)
         else if faults.exists(_._1 == id) then
           val nextF = faults.filterNot(_._1 == id)
-          rebuild(cs, nextF, rules) *> cs.faults.set(nextF)
+          rebuild(cs, extras, nextF, rules) *> cs.faults.set(nextF)
+        else if extras.exists(_._1 == id) then
+          val nextE = extras.filterNot(_._1 == id)
+          rebuild(cs, nextE, faults, rules) *> cs.extras.set(nextE)
         else ZIO.fail(MockError.RuleNotFound(spaceId, id))
     yield ()
 
@@ -427,18 +485,35 @@ private[rift] final case class RiftMockControl(
   // the class doc.) Re-register with the currently-tracked faults (a rule mutation
   // must not drop an injected fault).
   private def rebuildSpaceWith(cs: CorrSpace, rules: Vector[(RuleId, MockRule)]): IO[MockError, Unit] =
-    cs.faults.get.flatMap(faults => rebuild(cs, faults, rules))
+    for
+      extras <- cs.extras.get
+      faults <- cs.faults.get
+      _      <- rebuild(cs, extras, faults, rules)
+    yield ()
 
-  // Faults are registered ahead of the rules so they win first-match (Mountebank is
-  // first-match-wins, and rift#223 space stubs append in registration order).
+  // Capability stubs (extras) and faults are registered ahead of the rules so they
+  // win first-match (Mountebank is first-match-wins, and rift#223 space stubs append
+  // in registration order).
   private def rebuild(
     cs: CorrSpace,
+    extras: Vector[(RuleId, Json)],
     faults: Vector[(RuleId, RequestMatch, FaultKind)],
     rules: Vector[(RuleId, MockRule)]
   ): IO[MockError, Unit] =
     deleteSpace(cs.port, cs.flowId) *>
+      registerRawStubs(cs.port, cs.flowId, extras) *>
       registerFaultStubs(cs.port, cs.flowId, faults) *>
       registerStubs(cs.port, cs.flowId, rules)
+
+  private def registerRawStubs(port: Int, flowId: String, extras: Vector[(RuleId, Json)]): IO[MockError, Unit] =
+    ZIO.foreachDiscard(extras)((_, stub) => postSpaceRawStub(port, flowId, stub))
+
+  private def postSpaceRawStub(port: Int, flowId: String, stub: Json): IO[MockError, Unit] =
+    for
+      u   <- url(s"/imposters/$port/spaces/${enc(flowId)}/stubs")
+      res <- send(jsonRequest(HttpMethod.POST, u, stub))
+      _   <- expectSuccess(s"add capability stub to $flowId", res)
+    yield ()
 
   private def registerFaultStubs(
     port: Int,
@@ -566,6 +641,7 @@ private[rift] object RiftMockControl:
     header: String,
     rules: Ref[Vector[(RuleId, MockRule)]],
     faults: Ref[Vector[(RuleId, RequestMatch, FaultKind)]],
+    extras: Ref[Vector[(RuleId, Json)]], // pre-built capability stubs (#132): script / proxy / template
     scenarios: Ref[Map[String, ScenarioState]]
   )
 

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -54,7 +54,7 @@ private[rift] final case class RiftMockControl(
   import RiftMockControl.{CorrSpace, Imposter}
 
   def backendName: String           = "rift"
-  def capabilities: Set[Capability] = Set.empty
+  def capabilities: Set[Capability] = Set(Capability.Faults)
 
   override def isolation: Isolation = mode match
     case RiftMode.Correlated(_) => Isolation.Correlated
@@ -102,12 +102,45 @@ private[rift] final case class RiftMockControl(
   def received(space: MockSpace): IO[MockError, List[RecordedRequest]] =
     dispatch(space)(corrReceived)(piReceived)
 
-  def faults: IO[Unsupported, Faults]                   = unsupported(Capability.Faults)
+  def faults: IO[Unsupported, Faults]                   = ZIO.succeed(riftFaults)
   def scenarios: IO[Unsupported, StatefulScenarios]     = unsupported(Capability.StatefulScenarios)
   def stateInspection: IO[Unsupported, StateInspection] = unsupported(Capability.StateInspection)
   def scripting: IO[Unsupported, Scripting]             = unsupported(Capability.Scripting)
   def proxyRecord: IO[Unsupported, ProxyRecord]         = unsupported(Capability.ProxyRecord)
   def templating: IO[Unsupported, Templating]           = unsupported(Capability.Templating)
+
+  // ===== Faults (#128) — `_rift.fault` (rift#239) =================================
+
+  private val riftFaults: Faults = new Faults:
+    def inject(space: MockSpace, m: RequestMatch, fault: FaultKind): IO[MockError, RuleId] =
+      dispatch(space)(cs => corrInjectFault(cs, m, fault))(imp => piInjectFault(imp, m, fault))
+
+  // PerInstance: first-match (index 0) so the fault wins over any normal rule on
+  // the same match; tracked in `imp.stubs` so it stays index-aligned with the
+  // server and is removable via `removeRule`.
+  private def piInjectFault(imp: Imposter, m: RequestMatch, fault: FaultKind): IO[MockError, RuleId] =
+    for
+      ruleId <- freshId
+      u      <- url(s"/imposters/${imp.port}/stubs")
+      res    <- send(jsonRequest(HttpMethod.POST, u, RiftProtocol.addFaultStubBody(0, m, fault, ruleId)))
+      _      <- expectSuccess(s"inject fault into imposter ${imp.port}", res)
+      _      <- imp.stubs.update(ruleId +: _)
+    yield ruleId
+
+  // Correlated: track the fault and rebuild the space with faults registered ahead
+  // of the rules, so it wins first-match (rift#223 has no per-stub index). Tracked
+  // in `cs.faults` so it survives a later rule rebuild and is removable via
+  // `removeRule`; `destroy` clears it with the whole flow. Server-first, commit on
+  // success (mirrors corrAddRule's Overlay rebuild).
+  private def corrInjectFault(cs: CorrSpace, m: RequestMatch, fault: FaultKind): IO[MockError, RuleId] =
+    for
+      ruleId <- freshId
+      rules  <- cs.rules.get
+      faults <- cs.faults.get
+      next    = (ruleId, m, fault) +: faults
+      _      <- rebuild(cs, next, rules)
+      _      <- cs.faults.set(next)
+    yield ruleId
 
   // ---------------------------------------------------------------------------
 
@@ -218,9 +251,10 @@ private[rift] final case class RiftMockControl(
       tagged <- tagRules(rules)
       // Mirror serveImposter's release-on-error: if a stub POST fails partway, tear
       // the half-built flow down so it can't orphan stubs on the shared imposter.
-      _        <- registerStubs(port, flowId, tagged).onError(_ => deleteSpace(port, flowId).ignore)
-      rulesRef <- Ref.make(tagged)
-      _        <- correlated.update(_.updated(id, CorrSpace(port, flowId, corr.header, rulesRef)))
+      _         <- registerStubs(port, flowId, tagged).onError(_ => deleteSpace(port, flowId).ignore)
+      rulesRef  <- Ref.make(tagged)
+      faultsRef <- Ref.make(Vector.empty[(RuleId, RequestMatch, FaultKind)])
+      _         <- correlated.update(_.updated(id, CorrSpace(port, flowId, corr.header, rulesRef, faultsRef)))
     yield MockSpace(endpoint.baseUriFor(port), req => req.copy(headers = req.headers.add(corr.header, flowId)), id)
 
   // Create the one shared imposter on first Correlated provision (race-safe).
@@ -251,12 +285,18 @@ private[rift] final case class RiftMockControl(
     }
 
   private def corrRemoveRule(cs: CorrSpace, spaceId: SpaceId, id: RuleId): IO[MockError, Unit] =
-    cs.rules.get.flatMap { v =>
-      if !v.exists(_._1 == id) then ZIO.fail(MockError.RuleNotFound(spaceId, id))
-      else
-        val next = v.filterNot(_._1 == id)
-        rebuildSpaceWith(cs, next) *> cs.rules.set(next) // commit tracking only on success
-    }
+    for
+      rules  <- cs.rules.get
+      faults <- cs.faults.get
+      _ <- // commit tracking only on success; a removed id is either a rule or a fault
+        if rules.exists(_._1 == id) then
+          val next = rules.filterNot(_._1 == id)
+          rebuild(cs, faults, next) *> cs.rules.set(next)
+        else if faults.exists(_._1 == id) then
+          val nextF = faults.filterNot(_._1 == id)
+          rebuild(cs, nextF, rules) *> cs.faults.set(nextF)
+        else ZIO.fail(MockError.RuleNotFound(spaceId, id))
+    yield ()
 
   private def corrReplaceRules(cs: CorrSpace, rules: List[MockRule]): IO[MockError, Unit] =
     tagRules(rules).flatMap(next => rebuildSpaceWith(cs, next) *> cs.rules.set(next))
@@ -272,14 +312,46 @@ private[rift] final case class RiftMockControl(
       recs <- ZIO.fromEither(RiftProtocol.parseRequestsArray(body)).mapError(MockError.CommunicationError(_))
     yield recs
 
-  // rift#223 has no per-stub-in-space delete: re-register `rules` as the space's
-  // stubs after a whole-space teardown. Server-first — the caller commits
-  // tracking only on success. A mid-rebuild failure leaves the space's *server*
-  // stubs partial (surfaced as a CommunicationError); tracking is left unchanged.
-  // (A successful rebuild also clears the space's recorded requests + flow state
-  // — benign at scenario boundaries; see the class doc.)
+  // rift#223 has no per-stub-in-space delete: re-register the space's stubs after a
+  // whole-space teardown. Server-first — the caller commits tracking only on success.
+  // A mid-rebuild failure leaves the space's *server* stubs partial (surfaced as a
+  // CommunicationError); tracking is left unchanged. (A successful rebuild also clears
+  // the space's recorded requests + flow state — benign at scenario boundaries; see
+  // the class doc.) Re-register with the currently-tracked faults (a rule mutation
+  // must not drop an injected fault).
   private def rebuildSpaceWith(cs: CorrSpace, rules: Vector[(RuleId, MockRule)]): IO[MockError, Unit] =
-    deleteSpace(cs.port, cs.flowId) *> registerStubs(cs.port, cs.flowId, rules)
+    cs.faults.get.flatMap(faults => rebuild(cs, faults, rules))
+
+  // Faults are registered ahead of the rules so they win first-match (Mountebank is
+  // first-match-wins, and rift#223 space stubs append in registration order).
+  private def rebuild(
+    cs: CorrSpace,
+    faults: Vector[(RuleId, RequestMatch, FaultKind)],
+    rules: Vector[(RuleId, MockRule)]
+  ): IO[MockError, Unit] =
+    deleteSpace(cs.port, cs.flowId) *>
+      registerFaultStubs(cs.port, cs.flowId, faults) *>
+      registerStubs(cs.port, cs.flowId, rules)
+
+  private def registerFaultStubs(
+    port: Int,
+    flowId: String,
+    faults: Vector[(RuleId, RequestMatch, FaultKind)]
+  ): IO[MockError, Unit] =
+    ZIO.foreachDiscard(faults)((rid, m, fault) => postSpaceFaultStub(port, flowId, m, fault, rid))
+
+  private def postSpaceFaultStub(
+    port: Int,
+    flowId: String,
+    m: RequestMatch,
+    fault: FaultKind,
+    id: RuleId
+  ): IO[MockError, Unit] =
+    for
+      u   <- url(s"/imposters/$port/spaces/${enc(flowId)}/stubs")
+      res <- send(jsonRequest(HttpMethod.POST, u, RiftProtocol.faultStub(m, fault, id)))
+      _   <- expectSuccess(s"add fault stub to $flowId", res)
+    yield ()
 
   // Assign each rule a fresh id, keyed for tracking + re-registration under a space.
   private def tagRules(rules: List[MockRule]): UIO[Vector[(RuleId, MockRule)]] =
@@ -377,7 +449,13 @@ private[rift] final case class RiftMockControl(
 
 private[rift] object RiftMockControl:
   final case class Imposter(port: Int, stubs: Ref[Vector[RuleId]])
-  final case class CorrSpace(port: Int, flowId: String, header: String, rules: Ref[Vector[(RuleId, MockRule)]])
+  final case class CorrSpace(
+    port: Int,
+    flowId: String,
+    header: String,
+    rules: Ref[Vector[(RuleId, MockRule)]],
+    faults: Ref[Vector[(RuleId, RequestMatch, FaultKind)]]
+  )
 
   /**
    * Build an adapter against an endpoint in the given isolation `mode`, taking

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -163,6 +163,88 @@ private[rift] object RiftProtocol:
   def addStubBodyOf(index: Int, stub: Json): Json =
     Json.Obj("index" -> Json.Num(index), "stub" -> stub)
 
+  // ===== Optional capabilities (#132): script / proxy / templating ===============
+
+  /** A Mountebank stub for `m` carrying a single pre-built response object. */
+  private def capStub(m: RequestMatch, id: RuleId, response: Json): Json =
+    Json.Obj(
+      "id"         -> Json.Str(id.value),
+      "predicates" -> Json.Arr(predicates(m)*),
+      "responses"  -> Json.Arr(response)
+    )
+
+  /** The Rift script-engine token. */
+  def scriptEngineName(engine: ScriptEngine): String = engine match
+    case ScriptEngine.Rhai       => "rhai"
+    case ScriptEngine.Lua        => "lua"
+    case ScriptEngine.JavaScript => "javascript"
+
+  /**
+   * A stub whose response is computed by `script` via the `_rift.script`
+   * extension — the script's `should_inject` decides the response.
+   */
+  def scriptStub(m: RequestMatch, script: Script, id: RuleId): Json =
+    capStub(
+      m,
+      id,
+      Json.Obj(
+        "_rift" -> Json.Obj(
+          "script" -> Json.Obj(
+            "engine" -> Json.Str(scriptEngineName(script.engine)),
+            "code"   -> Json.Str(script.code)
+          )
+        )
+      )
+    )
+
+  /**
+   * A stub that proxies `m` to `upstream` in `proxyOnce` mode — Rift records
+   * the first upstream response as a new stub and replays it thereafter (so it
+   * keeps serving when the upstream is down). `predicateGenerators` keys the
+   * recorded stub on the request method + path, so a later identical request
+   * matches the recording instead of re-proxying.
+   */
+  def proxyStub(m: RequestMatch, upstream: String, id: RuleId): Json =
+    capStub(
+      m,
+      id,
+      Json.Obj(
+        "proxy" -> Json.Obj(
+          "to"   -> Json.Str(upstream),
+          "mode" -> Json.Str("proxyOnce"),
+          "predicateGenerators" -> Json.Arr(
+            Json.Obj("matches" -> Json.Obj("method" -> Json.Bool(true), "path" -> Json.Bool(true)))
+          )
+        )
+      )
+    )
+
+  private def templateSourceName(source: TemplateSource): String = source match
+    case TemplateSource.Path => "path"
+    case TemplateSource.Body => "body"
+
+  /**
+   * A templated `is` response: the body carries each capture's `token` literal,
+   * and a Mountebank `copy` behavior per capture substitutes it with the value
+   * extracted (by regex) from the request.
+   */
+  def templateStub(m: RequestMatch, template: ResponseTemplate, id: RuleId): Json =
+    val copies = template.captures.map(c =>
+      Json.Obj(
+        "from"  -> Json.Str(templateSourceName(c.source)),
+        "into"  -> Json.Str(c.token),
+        "using" -> Json.Obj("method" -> Json.Str("regex"), "selector" -> Json.Str(c.regex))
+      )
+    )
+    capStub(
+      m,
+      id,
+      Json.Obj(
+        "is"         -> Json.Obj("statusCode" -> Json.Num(template.status), "body" -> Json.Str(template.body)),
+        "_behaviors" -> Json.Obj("copy" -> Json.Arr(copies*))
+      )
+    )
+
   def predicates(m: RequestMatch): List[Json] =
     val methodPred = m.method.map(meth => equalsObj("method" -> Json.Str(methodName(meth))))
     val pathPred = m.path match

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -78,6 +78,46 @@ private[rift] object RiftProtocol:
   def addStubBody(index: Int, rule: MockRule): Json =
     Json.Obj("index" -> Json.Num(index), "stub" -> stub(rule))
 
+  // ---------------------------------------------------------------------------
+  // Fault injection (#128) — the `_rift.fault` response extension (rift#239)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * A stub response carrying a `_rift.fault` extension. The connection kinds
+   * set `_rift.fault.tcp` (Rift aborts the connection at the transport layer,
+   * so the SUT observes a real reset/empty/malformed/random failure — the `is`
+   * below is never sent); [[FaultKind.LatencySpike]] sets `_rift.fault.latency`
+   * (Rift sleeps, then serves this `is` 200). `probability` is pinned to 1 so
+   * the fault always fires.
+   */
+  def faultResponse(fault: FaultKind): Json =
+    val cfg = fault match
+      case FaultKind.LatencySpike(d) =>
+        Json.Obj("latency" -> Json.Obj("probability" -> Json.Num(1), "ms" -> Json.Num(d.toMillis.toInt)))
+      case FaultKind.ConnectionReset => tcpFault("CONNECTION_RESET_BY_PEER")
+      case FaultKind.EmptyResponse   => tcpFault("EMPTY_RESPONSE")
+      case FaultKind.MalformedChunk  => tcpFault("MALFORMED_RESPONSE_CHUNK")
+      case FaultKind.RandomThenClose => tcpFault("RANDOM_DATA_THEN_CLOSE")
+    Json.Obj("is" -> Json.Obj("statusCode" -> Json.Num(200)), "_rift" -> Json.Obj("fault" -> cfg))
+
+  private def tcpFault(token: String): Json = Json.Obj("tcp" -> Json.Str(token))
+
+  /**
+   * A Mountebank stub whose response injects `fault` for requests matching `m`.
+   */
+  def faultStub(m: RequestMatch, fault: FaultKind, id: RuleId): Json =
+    Json.Obj(
+      "id"         -> Json.Str(id.value),
+      "predicates" -> Json.Arr(predicates(m)*),
+      "responses"  -> Json.Arr(faultResponse(fault))
+    )
+
+  /**
+   * The `{index, stub}` body for `POST /imposters/:port/stubs` of a fault stub.
+   */
+  def addFaultStubBody(index: Int, m: RequestMatch, fault: FaultKind, id: RuleId): Json =
+    Json.Obj("index" -> Json.Num(index), "stub" -> faultStub(m, fault, id))
+
   def predicates(m: RequestMatch): List[Json] =
     val methodPred = m.method.map(meth => equalsObj("method" -> Json.Str(methodName(meth))))
     val pathPred = m.path match

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -22,6 +22,24 @@ private[rift] object RiftProtocol:
   private val unmatched404: Json = Json.Obj("statusCode" -> Json.Num(404))
 
   /**
+   * The `_rift.flowState` extension that backs declarative scenarios
+   * (rift#190). Rift only attaches a real (in-memory) flow store at
+   * imposter-creation when either scenario stubs are present OR this config is
+   * — otherwise stubs added later via `POST /stubs` hit a NoOp store and their
+   * state never advances. We provision empty then add scenario stubs in
+   * `define`, so every imposter carries it. `flowIdSource` partitions state:
+   * the imposter port (PerInstance) or a correlation header (Correlated).
+   */
+  private def flowStateExt(flowIdSource: String): (String, Json) =
+    "_rift" -> Json.Obj(
+      "flowState" -> Json.Obj(
+        "backend"                -> Json.Str("inmemory"),
+        "ttlSeconds"             -> Json.Num(300),
+        "mountebankStateMapping" -> Json.Obj("flowIdSource" -> Json.Str(flowIdSource))
+      )
+    )
+
+  /**
    * A full `POST /imposters` body for one space: one imposter, recording on.
    */
   def imposter(port: Int, name: String, rules: List[MockRule]): Json =
@@ -31,7 +49,8 @@ private[rift] object RiftProtocol:
       "name"            -> Json.Str(name),
       "recordRequests"  -> Json.Bool(true),
       "defaultResponse" -> unmatched404,
-      "stubs"           -> Json.Arr(rules.map(stub)*)
+      "stubs"           -> Json.Arr(rules.map(stub)*),
+      flowStateExt("imposter_port")
     )
 
   /**
@@ -51,13 +70,7 @@ private[rift] object RiftProtocol:
       "recordRequests"  -> Json.Bool(true),
       "defaultResponse" -> unmatched404,
       "stubs"           -> Json.Arr(),
-      "_rift" -> Json.Obj(
-        "flowState" -> Json.Obj(
-          "backend"                -> Json.Str("inmemory"),
-          "ttlSeconds"             -> Json.Num(300),
-          "mountebankStateMapping" -> Json.Obj("flowIdSource" -> Json.Str(s"header:$correlationHeader"))
-        )
-      )
+      flowStateExt(s"header:$correlationHeader")
     )
 
   /** A single Mountebank stub: predicates (ANDed) + one response. */
@@ -65,6 +78,31 @@ private[rift] object RiftProtocol:
     val idField = rule.id.map(id => "id" -> Json.Str(id.value)).toList
     Json.Obj(
       (idField ++ List(
+        "predicates" -> Json.Arr(predicates(rule.`match`)*),
+        "responses"  -> Json.Arr(response(rule.respond))
+      ))*
+    )
+
+  /**
+   * One edge of a scenario FSM (#131): a normal stub carrying Rift's
+   * declarative scenario fields (rift#190). The stub is eligible only while
+   * `(flow_id, scenarioName)` state equals `whenState`, and serves `respond`
+   * then transitions to `thenState` (`None` = stay — `newScenarioState` is
+   * omitted). State is partitioned by `flow_id`, so two spaces sharing a
+   * scenario name keep independent state natively (no name-namespacing needed).
+   */
+  def statefulStub(
+    scenarioName: String,
+    whenState: ScenarioState,
+    thenState: Option[ScenarioState],
+    rule: MockRule
+  ): Json =
+    val transition = thenState.map(s => "newScenarioState" -> Json.Str(s.value)).toList
+    Json.Obj(
+      (List(
+        "scenarioName"          -> Json.Str(scenarioName),
+        "requiredScenarioState" -> Json.Str(whenState.value)
+      ) ++ transition ++ List(
         "predicates" -> Json.Arr(predicates(rule.`match`)*),
         "responses"  -> Json.Arr(response(rule.respond))
       ))*
@@ -117,6 +155,13 @@ private[rift] object RiftProtocol:
    */
   def addFaultStubBody(index: Int, m: RequestMatch, fault: FaultKind, id: RuleId): Json =
     Json.Obj("index" -> Json.Num(index), "stub" -> faultStub(m, fault, id))
+
+  /**
+   * The `{index, stub}` body for a pre-built stub JSON (e.g. a
+   * [[statefulStub]]).
+   */
+  def addStubBodyOf(index: Int, stub: Json): Json =
+    Json.Obj("index" -> Json.Num(index), "stub" -> stub)
 
   def predicates(m: RequestMatch): List[Json] =
     val methodPred = m.method.map(meth => equalsObj("method" -> Json.Str(methodName(meth))))
@@ -181,6 +226,17 @@ private[rift] object RiftProtocol:
     body: Option[String] = None
   ) derives JsonDecoder
   private case class WireView(requests: Option[List[WireReq]] = None) derives JsonDecoder
+
+  private case class WireScenario(name: String, state: String) derives JsonDecoder
+  private case class WireScenarios(scenarios: List[WireScenario] = Nil) derives JsonDecoder
+
+  /**
+   * The current state of scenario `name` from a `GET
+   * /imposters/:port/scenarios` body (rift#190); `None` if the scenario isn't
+   * declared on the imposter.
+   */
+  def parseScenarioState(viewJson: String, name: String): Either[String, Option[String]] =
+    viewJson.fromJson[WireScenarios].map(_.scenarios.find(_.name == name).map(_.state))
 
   /** Parse the `requests[]` of a `GET /imposters/:port` view. */
   def parseRecorded(viewJson: String): Either[String, List[RecordedRequest]] =

--- a/rift/src/test/scala/zio/bdd/mock/rift/FakeRift.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/FakeRift.scala
@@ -24,7 +24,10 @@ final case class FakeRift(
   requestMatches: Ref[Chunk[String]],
   filtered: Ref[String],
   views: Ref[Map[Int, String]],
-  failProvision: Ref[Boolean]
+  failProvision: Ref[Boolean],
+  scenarioPuts: Ref[Chunk[String]],
+  scenarioGets: Ref[Chunk[String]],
+  scenariosView: Ref[String]
 ):
   /**
    * Preset the `GET /imposters/:port` view (e.g. to inject recorded requests).
@@ -35,6 +38,11 @@ final case class FakeRift(
    * Preset the body returned by `GET /imposters/:port/requests?match=…` (#201).
    */
   def setFiltered(json: String): UIO[Unit] = filtered.set(json)
+
+  /**
+   * Preset the body returned by `GET /imposters/:port/scenarios` (rift#190).
+   */
+  def setScenarios(json: String): UIO[Unit] = scenariosView.set(json)
 
   val routes: Routes[Any, Response] =
     Routes(
@@ -88,6 +96,16 @@ final case class FakeRift(
       Method.DELETE / "imposters" / int("port") / "stubs" / int("index") -> handler {
         (port: Int, index: Int, _: Request) =>
           stubCalls.update(_ :+ s"DELETE $port/$index").as(Response.ok)
+      },
+      // Scenario state set (rift#190): PUT /imposters/:port/scenarios/:name/state
+      Method.PUT / "imposters" / int("port") / "scenarios" / string("name") / "state" -> handler {
+        (port: Int, name: String, req: Request) =>
+          req.body.asString.orDie.flatMap(b => scenarioPuts.update(_ :+ s"$port/$name $b")).as(Response.ok)
+      },
+      // Scenario list + state (rift#190): GET /imposters/:port/scenarios[?flowId=]
+      Method.GET / "imposters" / int("port") / "scenarios" -> handler { (port: Int, req: Request) =>
+        val flow = req.url.queryParams.queryParam("flowId").getOrElse("")
+        (scenarioGets.update(_ :+ s"$port?$flow") *> scenariosView.get).map(v => Response(body = Body.fromString(v)))
       }
     )
 
@@ -106,7 +124,10 @@ object FakeRift:
       fl <- Ref.make("[]")
       e  <- Ref.make(Map.empty[Int, String])
       f  <- Ref.make(false)
-    yield FakeRift(a, b, c, d, ss, sd, rm, fl, e, f)
+      sp <- Ref.make(Chunk.empty[String])
+      sg <- Ref.make(Chunk.empty[String])
+      sv <- Ref.make("""{"flowId":"","scenarios":[]}""")
+    yield FakeRift(a, b, c, d, ss, sd, rm, fl, e, f, sp, sg, sv)
 
   def portOf(body: String): Option[Int] =
     import zio.json.*

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -2,6 +2,7 @@ package zio.bdd.mock.rift
 
 import zio.*
 import zio.bdd.mock.*
+import zio.bdd.mock.dsl.*
 import zio.http.Client
 import zio.test.*
 
@@ -193,15 +194,17 @@ object RiftMockControlSpec extends ZIOSpecDefault:
         )
       }
     },
-    test("advertises Faults; its accessor succeeds and the other accessors fail fast") {
+    test("advertises Faults + StatefulScenarios + StateInspection; the other accessors fail fast (#131)") {
       withAdapter { (control, _) =>
         for
-          faultsE    <- control.faults.either
-          scenariosE <- control.scenarios.either
+          faultsE <- control.faults.either
+          scenE   <- control.scenarios.either
+          siE     <- control.stateInspection.either
         yield assertTrue(
-          control.capabilities == Set(Capability.Faults),
+          control.capabilities == Set(Capability.Faults, Capability.StatefulScenarios, Capability.StateInspection),
           faultsE.isRight,
-          scenariosE == Left(Unsupported(Capability.StatefulScenarios, "rift"))
+          scenE.isRight,
+          siE.isRight
         )
       }
     },
@@ -242,6 +245,57 @@ object RiftMockControlSpec extends ZIOSpecDefault:
           faultIx >= 0,
           rulePast,
           rmE.isRight
+        )
+      }
+    },
+    // The container proves end-to-end stateful behaviour (RiftContainerSpec / cap-stateful under RIFT_IT);
+    // here we assert the adapter issues the right scenario admin calls — no Docker, no wrong-path regression.
+    test("define/setState/currentState/reset issue the right Rift scenario admin calls (#131)") {
+      val invoice =
+        scenario("invoice")
+          .when("Started", get("/inv"))
+          .respond(ok.text("created"))
+          .goTo("Paid")
+          .when("Paid", get("/inv"))
+          .respond(ok.text("paid"))
+          .stay
+          .build
+      withAdapter { (control, fake) =>
+        for
+          space <-
+            control.provision(MockSource.Dsl(MockSpec(Nil))).orDieWith(e => RuntimeException(e.toString)).map(_.head)
+          port    = portOf(space.baseUri)
+          ss     <- control.scenarios.orDieWith(u => RuntimeException(u.toString))
+          si     <- control.stateInspection.orDieWith(u => RuntimeException(u.toString))
+          _      <- ss.define(space, invoice).orDieWith(e => RuntimeException(e.toString))
+          stubs  <- fake.stubCalls.get
+          _      <- fake.setScenarios(s"""{"flowId":"$port","scenarios":[{"name":"invoice","state":"Paid"}]}""")
+          cur    <- si.currentState(space, "invoice").orDieWith(e => RuntimeException(e.toString))
+          gets   <- fake.scenarioGets.get
+          _      <- si.setState(space, "invoice", ScenarioState("Paid")).orDieWith(e => RuntimeException(e.toString))
+          _      <- ss.reset(space, "invoice").orDieWith(e => RuntimeException(e.toString))
+          puts   <- fake.scenarioPuts.get
+          ghost  <- si.currentState(space, "ghost").either
+          ghostR <- ss.reset(space, "ghost").either
+        yield assertTrue(
+          // define posts both FSM edges with the scenario fields; rule 0 is at index 0 (first-match order)
+          stubs.count(_.contains("\"scenarioName\":\"invoice\"")) == 2,
+          stubs.exists(s => s.contains("\"index\":0") && s.contains("\"requiredScenarioState\":\"Started\"")),
+          stubs.exists(_.contains("\"newScenarioState\":\"Paid\"")), // the advance edge
+          // define pins the initial state via PUT /scenarios/invoice/state {state, flowId=port}
+          puts.exists(p =>
+            p.startsWith(s"$port/invoice ") && p.contains("\"state\":\"Started\"") && p.contains(
+              s"\"flowId\":\"$port\""
+            )
+          ),
+          // currentState reads GET /scenarios?flowId=port and parses the view
+          cur == ScenarioState("Paid"),
+          gets.exists(_ == s"$port?$port"),
+          // setState PUTs the new state
+          puts.exists(_.contains("\"state\":\"Paid\"")),
+          // an unknown scenario fails with InvalidDefinition (Ref guard + absent in the view)
+          ghost == Left(MockError.InvalidDefinition(s"no scenario 'ghost' on space ${space.id.value}")),
+          ghostR == Left(MockError.InvalidDefinition(s"no scenario 'ghost' on space ${space.id.value}"))
         )
       }
     },

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -194,17 +194,23 @@ object RiftMockControlSpec extends ZIOSpecDefault:
         )
       }
     },
-    test("advertises Faults + StatefulScenarios + StateInspection; the other accessors fail fast (#131)") {
+    test("advertises all six capabilities and every accessor succeeds (#132)") {
       withAdapter { (control, _) =>
         for
-          faultsE <- control.faults.either
-          scenE   <- control.scenarios.either
-          siE     <- control.stateInspection.either
+          faultsE   <- control.faults.either
+          scenE     <- control.scenarios.either
+          siE       <- control.stateInspection.either
+          scriptE   <- control.scripting.either
+          proxyE    <- control.proxyRecord.either
+          templateE <- control.templating.either
         yield assertTrue(
-          control.capabilities == Set(Capability.Faults, Capability.StatefulScenarios, Capability.StateInspection),
+          control.capabilities == Capability.values.toSet,
           faultsE.isRight,
           scenE.isRight,
-          siE.isRight
+          siE.isRight,
+          scriptE.isRight,
+          proxyE.isRight,
+          templateE.isRight
         )
       }
     },
@@ -223,6 +229,80 @@ object RiftMockControlSpec extends ZIOSpecDefault:
           post.exists(_.contains("\"index\":0")), // first-match — wins over a normal rule
           post.exists(_.contains("CONNECTION_RESET_BY_PEER")),
           post.exists(_.contains("/boom"))
+        )
+      }
+    },
+    test("scripting/proxyRecord/templating each post a first-match capability stub to the imposter (#132)") {
+      withAdapter { (control, fake) =>
+        def asT(e: Any): Throwable = new RuntimeException(e.toString)
+        for
+          space    <- control.provision(pingSource).orDieWith(asT).map(_.head)
+          script   <- control.scripting.orDieWith(asT)
+          proxy    <- control.proxyRecord.orDieWith(asT)
+          template <- control.templating.orDieWith(asT)
+          sid <- script
+                   .inject(space, RequestMatch(path = PathMatch.Exact("/s")), Script(ScriptEngine.Rhai, "code"))
+                   .orDieWith(asT)
+          pid <- proxy.proxy(space, RequestMatch(path = PathMatch.Exact("/p")), "http://up").orDieWith(asT)
+          tid <-
+            template
+              .inject(
+                space,
+                RequestMatch(path = PathMatch.Exact("/t")),
+                ResponseTemplate(body = "x${V}", captures = List(TemplateCapture("${V}", TemplateSource.Body, ".*")))
+              )
+              .orDieWith(asT)
+          calls <- fake.stubCalls.get
+          posts  = calls.filter(_.startsWith(s"POST ${portOf(space.baseUri)} "))
+          // the capability stubs are tracked in imp.stubs, so removeRule reaches them (not RuleNotFound)
+          rmS <- control.removeRule(space, sid).either
+          rmT <- control.removeRule(space, tid).either
+        yield assertTrue(
+          sid.value.nonEmpty && pid.value.nonEmpty && tid.value.nonEmpty,
+          posts.forall(_.contains("\"index\":0")), // all first-match
+          posts.exists(c => c.contains("_rift") && c.contains("script") && c.contains("rhai")),
+          posts.exists(c => c.contains("proxy") && c.contains("proxyOnce") && c.contains("http://up")),
+          posts.exists(c => c.contains("copy") && c.contains("${V}")),
+          rmS.isRight && rmT.isRight
+        )
+      }
+    },
+    test(
+      "Correlated scripting/proxy/templating each register a capability space stub ahead of the rules and are removable (#132)"
+    ) {
+      withCorrelated { (control, fake) =>
+        def asT(e: Any): Throwable = new RuntimeException(e.toString)
+        for
+          space    <- control.provision(pingSource).orDieWith(asT).map(_.head)
+          script   <- control.scripting.orDieWith(asT)
+          proxy    <- control.proxyRecord.orDieWith(asT)
+          template <- control.templating.orDieWith(asT)
+          sid <- script
+                   .inject(space, RequestMatch(path = PathMatch.Exact("/s")), Script(ScriptEngine.Rhai, "code"))
+                   .orDieWith(asT)
+          pid <- proxy.proxy(space, RequestMatch(path = PathMatch.Exact("/p")), "http://up").orDieWith(asT)
+          tid <-
+            template
+              .inject(
+                space,
+                RequestMatch(path = PathMatch.Exact("/t")),
+                ResponseTemplate(body = "x${V}", captures = List(TemplateCapture("${V}", TemplateSource.Body, ".*")))
+              )
+              .orDieWith(asT)
+          stubs   <- fake.spaceStubs.get // "$port/$flowId $body" per POST .../spaces/:flow/stubs
+          scriptIx = stubs.indexWhere(s => s.contains("script") && s.contains("rhai") && s.contains("/s"))
+          // a rebuild re-registers the space's /ping rule AFTER the capability stubs → they win first-match
+          rulePast = stubs.zipWithIndex.exists((s, i) => i > scriptIx && s.contains("/ping"))
+          rmS     <- control.removeRule(space, sid).either // tracked in cs.extras → removable, not RuleNotFound
+          rmP     <- control.removeRule(space, pid).either
+          rmT     <- control.removeRule(space, tid).either
+        yield assertTrue(
+          sid.value.nonEmpty && pid.value.nonEmpty && tid.value.nonEmpty,
+          scriptIx >= 0,
+          rulePast,
+          stubs.exists(s => s.contains("proxyOnce") && s.contains("/p")),
+          stubs.exists(s => s.contains("copy") && s.contains("/t")),
+          rmS.isRight && rmP.isRight && rmT.isRight
         )
       }
     },

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -193,12 +193,55 @@ object RiftMockControlSpec extends ZIOSpecDefault:
         )
       }
     },
-    test("advertises no capabilities; every accessor fails fast") {
+    test("advertises Faults; its accessor succeeds and the other accessors fail fast") {
       withAdapter { (control, _) =>
-        for faultsE <- control.faults.either
+        for
+          faultsE    <- control.faults.either
+          scenariosE <- control.scenarios.either
         yield assertTrue(
-          control.capabilities.isEmpty,
-          faultsE == Left(Unsupported(Capability.Faults, "rift"))
+          control.capabilities == Set(Capability.Faults),
+          faultsE.isRight,
+          scenariosE == Left(Unsupported(Capability.StatefulScenarios, "rift"))
+        )
+      }
+    },
+    test("faults.inject posts a first-match stub carrying _rift.fault.tcp to the space's imposter") {
+      withAdapter { (control, fake) =>
+        for
+          space  <- control.provision(pingSource).orDieWith(e => new RuntimeException(e.toString)).map(_.head)
+          faults <- control.faults.orDieWith(u => new RuntimeException(u.toString))
+          ruleId <- faults
+                      .inject(space, RequestMatch(path = PathMatch.Exact("/boom")), FaultKind.ConnectionReset)
+                      .orDieWith(e => new RuntimeException(e.toString))
+          calls <- fake.stubCalls.get
+          post   = calls.find(c => c.startsWith(s"POST ${portOf(space.baseUri)} "))
+        yield assertTrue(
+          ruleId.value.nonEmpty,
+          post.exists(_.contains("\"index\":0")), // first-match — wins over a normal rule
+          post.exists(_.contains("CONNECTION_RESET_BY_PEER")),
+          post.exists(_.contains("/boom"))
+        )
+      }
+    },
+    test("Correlated faults.inject registers a fault space stub ahead of the rules (first-match) and is removable") {
+      withCorrelated { (control, fake) =>
+        for
+          space  <- control.provision(pingSource).orDieWith(e => new RuntimeException(e.toString)).map(_.head)
+          faults <- control.faults.orDieWith(u => new RuntimeException(u.toString))
+          ruleId <- faults
+                      .inject(space, RequestMatch(path = PathMatch.Exact("/boom")), FaultKind.ConnectionReset)
+                      .orDieWith(e => new RuntimeException(e.toString))
+          stubs <- fake.spaceStubs.get // "$port/$flowId $body" per POST .../spaces/:flow/stubs
+          faultIx =
+            stubs.indexWhere(s => s.contains("_rift") && s.contains("CONNECTION_RESET_BY_PEER") && s.contains("/boom"))
+          // the rebuild re-registers the space's /ping rule AFTER the fault → fault wins first-match
+          rulePast = stubs.zipWithIndex.exists((s, i) => i > faultIx && s.contains("/ping"))
+          rmE     <- control.removeRule(space, ruleId).either // tracked in cs.faults → removable, not RuleNotFound
+        yield assertTrue(
+          ruleId.value.nonEmpty,
+          faultIx >= 0,
+          rulePast,
+          rmE.isRight
         )
       }
     },

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
@@ -21,13 +21,44 @@ object RiftProtocolSpec extends ZIOSpecDefault:
   )
 
   def spec = suite("RiftProtocol (canonical <-> Mountebank)")(
-    test("imposter carries port, http protocol, recordRequests, and one stub per rule") {
+    test("statefulStub carries the scenario FSM fields; stay omits newScenarioState (#131)") {
+      val invRule = (path: String, body: String) =>
+        MockRule(RequestMatch(path = PathMatch.Exact(path)), ResponseDef(status = 200, body = Body.Text(body)))
+      val advance = RiftProtocol.statefulStub(
+        "invoice",
+        ScenarioState("Started"),
+        Some(ScenarioState("Paid")),
+        invRule("/inv", "created")
+      )
+      val stay = RiftProtocol.statefulStub("invoice", ScenarioState("Paid"), None, invRule("/inv", "paid"))
+      assertTrue(
+        advance / "scenarioName" == Json.Str("invoice"),
+        advance / "requiredScenarioState" == Json.Str("Started"),
+        advance / "newScenarioState" == Json.Str("Paid"),
+        arr(advance / "responses").head / "is" / "body" == Json.Str("created"),
+        stay / "requiredScenarioState" == Json.Str("Paid"),
+        stay / "newScenarioState" == Json.Null // stay -> no transition field
+      )
+    },
+    test("parseScenarioState reads a scenario's state from the admin view; None when absent (#131)") {
+      val view =
+        """{"flowId":"4545","scenarios":[{"name":"invoice","state":"Paid"},{"name":"other","state":"Started"}]}"""
+      assertTrue(
+        RiftProtocol.parseScenarioState(view, "invoice") == Right(Some("Paid")),
+        RiftProtocol.parseScenarioState(view, "missing") == Right(None),
+        RiftProtocol.parseScenarioState("not json", "invoice").isLeft // malformed -> Left (becomes CommunicationError)
+      )
+    },
+    test("imposter carries port, http protocol, recordRequests, a stub per rule, and a flow store (#131)") {
       val j = RiftProtocol.imposter(4545, "ping", List(pingRule))
       assertTrue(
         j / "port" == Json.Num(4545),
         j / "protocol" == Json.Str("http"),
         j / "recordRequests" == Json.Bool(true),
-        arr(j / "stubs").size == 1
+        arr(j / "stubs").size == 1,
+        // an in-memory flow store keyed by port, so scenario stubs added later actually advance
+        j / "_rift" / "flowState" / "backend" == Json.Str("inmemory"),
+        j / "_rift" / "flowState" / "mountebankStateMapping" / "flowIdSource" == Json.Str("imposter_port")
       )
     },
     test("an exact path + method rule becomes equals predicates and an `is` response") {

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
@@ -76,6 +76,37 @@ object RiftProtocolSpec extends ZIOSpecDefault:
         withDelay / "_behaviors" / "wait" == Json.Num(50)
       )
     },
+    test("a connection FaultKind becomes a stub response with _rift.fault.tcp and a 200 carrier `is`") {
+      def tcp(fault: FaultKind): Json = RiftProtocol.faultResponse(fault) / "_rift" / "fault" / "tcp"
+      assertTrue(
+        tcp(FaultKind.ConnectionReset) == Json.Str("CONNECTION_RESET_BY_PEER"),
+        tcp(FaultKind.EmptyResponse) == Json.Str("EMPTY_RESPONSE"),
+        tcp(FaultKind.MalformedChunk) == Json.Str("MALFORMED_RESPONSE_CHUNK"),
+        tcp(FaultKind.RandomThenClose) == Json.Str("RANDOM_DATA_THEN_CLOSE"),
+        RiftProtocol.faultResponse(FaultKind.ConnectionReset) / "is" / "statusCode" == Json.Num(200)
+      )
+    },
+    test("a LatencySpike becomes _rift.fault.latency with probability 1 and ms; no tcp") {
+      import zio.*
+      val resp    = RiftProtocol.faultResponse(FaultKind.LatencySpike(1.second))
+      val latency = resp / "_rift" / "fault" / "latency"
+      assertTrue(
+        latency / "ms" == Json.Num(1000),
+        latency / "probability" == Json.Num(1),
+        field(resp / "_rift" / "fault", "tcp").isEmpty,
+        resp / "is" / "statusCode" == Json.Num(200)
+      )
+    },
+    test("faultStub carries the request predicates and the fault response under the given id") {
+      val m     = RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/boom"))
+      val stub  = RiftProtocol.faultStub(m, FaultKind.ConnectionReset, RuleId("f1"))
+      val preds = arr(stub / "predicates")
+      assertTrue(
+        stub / "id" == Json.Str("f1"),
+        preds.exists(p => p / "equals" / "path" == Json.Str("/boom")),
+        arr(stub / "responses").head / "_rift" / "fault" / "tcp" == Json.Str("CONNECTION_RESET_BY_PEER")
+      )
+    },
     test("PathMatch.Any emits no path predicate") {
       val stub = RiftProtocol.stub(pingRule.copy(`match` = RequestMatch(method = Some(Method.Post))))
       val keys =

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
@@ -138,6 +138,60 @@ object RiftProtocolSpec extends ZIOSpecDefault:
         arr(stub / "responses").head / "_rift" / "fault" / "tcp" == Json.Str("CONNECTION_RESET_BY_PEER")
       )
     },
+    test("scriptStub carries predicates and a _rift.script response (engine + code) (#132)") {
+      val m = RequestMatch(path = PathMatch.Exact("/s"))
+      val stub =
+        RiftProtocol.scriptStub(m, Script(ScriptEngine.Rhai, "fn should_inject(r,f){#{inject:false}}"), RuleId("s1"))
+      val resp = arr(stub / "responses").head
+      assertTrue(
+        stub / "id" == Json.Str("s1"),
+        arr(stub / "predicates").exists(p => p / "equals" / "path" == Json.Str("/s")),
+        resp / "_rift" / "script" / "engine" == Json.Str("rhai"),
+        resp / "_rift" / "script" / "code" == Json.Str("fn should_inject(r,f){#{inject:false}}")
+      )
+    },
+    test("script engine tokens map to rhai/lua/javascript (#132)") {
+      assertTrue(
+        RiftProtocol.scriptEngineName(ScriptEngine.Rhai) == "rhai",
+        RiftProtocol.scriptEngineName(ScriptEngine.Lua) == "lua",
+        RiftProtocol.scriptEngineName(ScriptEngine.JavaScript) == "javascript"
+      )
+    },
+    test(
+      "proxyStub emits a proxy response to the upstream in proxyOnce mode with method+path predicate generators (#132)"
+    ) {
+      val stub = RiftProtocol.proxyStub(RequestMatch(path = PathMatch.Exact("/p")), "http://up:8080", RuleId("p1"))
+      val resp = arr(stub / "responses").head
+      val gen  = arr(resp / "proxy" / "predicateGenerators").head
+      assertTrue(
+        stub / "id" == Json.Str("p1"),
+        resp / "proxy" / "to" == Json.Str("http://up:8080"),
+        resp / "proxy" / "mode" == Json.Str("proxyOnce"),
+        gen / "matches" / "method" == Json.Bool(true),
+        gen / "matches" / "path" == Json.Bool(true)
+      )
+    },
+    test("templateStub emits an `is` body plus a _behaviors.copy per capture; path/body sources map (#132)") {
+      val template = ResponseTemplate(
+        body = "Hello ${NAME} ${WHO}",
+        captures = List(
+          TemplateCapture("${NAME}", TemplateSource.Path, "[^/]+$"),
+          TemplateCapture("${WHO}", TemplateSource.Body, "\\w+")
+        )
+      )
+      val stub     = RiftProtocol.templateStub(RequestMatch(path = PathMatch.Exact("/greet")), template, RuleId("t1"))
+      val resp     = arr(stub / "responses").head
+      val copies   = arr(resp / "_behaviors" / "copy")
+      val pathCopy = copies.find(_ / "into" == Json.Str("${NAME}")).getOrElse(Json.Null)
+      val bodyCopy = copies.find(_ / "into" == Json.Str("${WHO}")).getOrElse(Json.Null)
+      assertTrue(
+        resp / "is" / "body" == Json.Str("Hello ${NAME} ${WHO}"),
+        pathCopy / "from" == Json.Str("path"),
+        pathCopy / "using" / "method" == Json.Str("regex"),
+        pathCopy / "using" / "selector" == Json.Str("[^/]+$"),
+        bodyCopy / "from" == Json.Str("body") // TemplateSource.Body -> "body"
+      )
+    },
     test("PathMatch.Any emits no path predicate") {
       val stub = RiftProtocol.stub(pingRule.copy(`match` = RequestMatch(method = Some(Method.Post))))
       val keys =

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
@@ -31,10 +31,10 @@ private[wiremock] final case class WireMockControl(
   ids: Ref[Int]
 ) extends MockControl:
 
-  import WireMockControl.SpaceState
+  import WireMockControl.{ScenarioRecord, SpaceState}
 
   def backendName: String           = "wiremock"
-  def capabilities: Set[Capability] = Set.empty
+  def capabilities: Set[Capability] = Set(Capability.StatefulScenarios, Capability.StateInspection)
 
   override def isolation: Isolation = mode match
     case WireMock.Mode.Correlated(_) => Isolation.Correlated
@@ -68,16 +68,18 @@ private[wiremock] final case class WireMockControl(
           stub     <- ZIO.attempt(StubMapping.buildFrom(stubMappingJson)).mapError(e => MockError.InvalidDefinition(msg(e)))
           server   <- WireMockControl.startServer.mapError(e => MockError.ProvisionFailed(msg(e)))
           rulesRef <- Ref.make(Vector.empty[(RuleId, StubMapping)])
+          scenRef  <- Ref.make(Map.empty[String, ScenarioRecord])
           ruleId   <- freshRuleId
           // Stop the server we just started if registration/tracking fails or is
           // interrupted before it lands in `spaces` — otherwise it leaks.
-          space <- (ZIO
-                     .attempt(server.addStubMapping(stub))
-                     .zipRight(rulesRef.set(Vector(ruleId -> stub)))
-                     .mapError(e => MockError.CommunicationError(msg(e)))
-                     .zipRight(spaces.update(_.updated(id, SpaceState(server, ownsServer = true, None, rulesRef))))
-                     .as(MockSpace(server.baseUrl(), identity, id)))
-                     .onError(_ => stop(server))
+          space <-
+            (ZIO
+              .attempt(server.addStubMapping(stub))
+              .zipRight(rulesRef.set(Vector(ruleId -> stub)))
+              .mapError(e => MockError.CommunicationError(msg(e)))
+              .zipRight(spaces.update(_.updated(id, SpaceState(server, ownsServer = true, None, rulesRef, scenRef))))
+              .as(MockSpace(server.baseUrl(), identity, id)))
+              .onError(_ => stop(server))
         yield List(space)
       case NativeSpec.Rift(_) =>
         ZIO.fail(MockError.InvalidDefinition("the WireMock adapter cannot provision a Rift native spec"))
@@ -110,7 +112,8 @@ private[wiremock] final case class WireMockControl(
     withSpace(space) { st =>
       for
         current <- st.rules.get
-        _       <- removeStubs(st.server, current.map(_._2))
+        scen    <- st.scenarios.get
+        _       <- removeStubs(st.server, current.map(_._2) ++ scen.values.flatMap(_.stubs))
         _       <- ZIO.when(st.ownsServer)(stop(st.server))
         _       <- spaces.update(_ - space.id)
       yield ()
@@ -140,11 +143,83 @@ private[wiremock] final case class WireMockControl(
     }
 
   def faults: IO[Unsupported, Faults]                   = unsupported(Capability.Faults)
-  def scenarios: IO[Unsupported, StatefulScenarios]     = unsupported(Capability.StatefulScenarios)
-  def stateInspection: IO[Unsupported, StateInspection] = unsupported(Capability.StateInspection)
+  def scenarios: IO[Unsupported, StatefulScenarios]     = ZIO.succeed(statefulScenarios)
+  def stateInspection: IO[Unsupported, StateInspection] = ZIO.succeed(stateInspector)
   def scripting: IO[Unsupported, Scripting]             = unsupported(Capability.Scripting)
   def proxyRecord: IO[Unsupported, ProxyRecord]         = unsupported(Capability.ProxyRecord)
   def templating: IO[Unsupported, Templating]           = unsupported(Capability.Templating)
+
+  // Native scenarios on the shared server are namespaced by space so two spaces
+  // declaring the same scenario name keep independent FSM state (the correlation
+  // header alone would still share one WireMock scenario, hence one state token).
+  private def scenarioName(id: SpaceId, name: String): String = s"${id.value}::$name"
+
+  private val statefulScenarios: StatefulScenarios = new StatefulScenarios:
+    def define(space: MockSpace, scenarioDef: ScenarioDef): IO[MockError, Unit] =
+      withSpace(space) { st =>
+        val nsName = scenarioName(space.id, scenarioDef.name)
+        val stubs = scenarioDef.rules.zipWithIndex.map { (r, i) =>
+          WireMockTranslation.statefulStub(
+            space.id,
+            nsName,
+            r.whenState,
+            r.thenState,
+            MockRule(r.request, r.respond),
+            i + 1,
+            st.correlation
+          )
+        }
+        for
+          existing <- st.scenarios.get
+          // Register the new edges and set the initial state, rolling back exactly the stubs we
+          // added if any step fails or is interrupted — a partial define must never orphan stubs
+          // on the shared server. The previous scenario (on re-define) is left intact until this
+          // succeeds, so a failed redefine never destroys known-good state.
+          _ <- (ZIO.attempt(stubs.foreach(st.server.addStubMapping)) *>
+                 // A scenario only exists once a stub references it, so only pin the initial
+                 // state when there are rules (an empty ScenarioDef installs nothing).
+                 ZIO.when(stubs.nonEmpty)(ZIO.attempt(st.server.setScenarioState(nsName, scenarioDef.initial.value))))
+                 .mapError(e => MockError.CommunicationError(msg(e)))
+                 .onError(_ => removeStubs(st.server, stubs.toVector).ignore)
+          _ <- existing.get(scenarioDef.name).fold(ZIO.unit)(rec => removeStubs(st.server, rec.stubs))
+          _ <- st.scenarios.update(_ + (scenarioDef.name -> ScenarioRecord(scenarioDef.initial, stubs.toVector)))
+        yield ()
+      }
+
+    def reset(space: MockSpace, name: String): IO[MockError, Unit] =
+      withSpace(space) { st =>
+        st.scenarios.get.flatMap(_.get(name) match
+          case Some(rec) =>
+            ZIO
+              .attempt(st.server.setScenarioState(scenarioName(space.id, name), rec.initial.value))
+              .mapError(e => MockError.CommunicationError(msg(e)))
+          case None => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${space.id.value}"))
+        )
+      }
+
+  private val stateInspector: StateInspection = new StateInspection:
+    def currentState(space: MockSpace, name: String): IO[MockError, ScenarioState] =
+      withSpace(space) { st =>
+        val nsName = scenarioName(space.id, name)
+        ZIO
+          .attempt(st.server.getAllScenarios.getScenarios.asScala.find(_.getName == nsName).map(_.getState))
+          .mapError(e => MockError.CommunicationError(msg(e)))
+          .flatMap {
+            case Some(s) => ZIO.succeed(ScenarioState(s))
+            case None    => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${space.id.value}"))
+          }
+      }
+
+    def setState(space: MockSpace, name: String, to: ScenarioState): IO[MockError, Unit] =
+      withSpace(space) { st =>
+        st.scenarios.get.flatMap(_.get(name) match
+          case Some(_) =>
+            ZIO
+              .attempt(st.server.setScenarioState(scenarioName(space.id, name), to.value))
+              .mapError(e => MockError.CommunicationError(msg(e)))
+          case None => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${space.id.value}"))
+        )
+      }
 
   // Stop every server this adapter still owns — the layer's scope finalizer.
   private[wiremock] def stopAll: UIO[Unit] =
@@ -161,9 +236,10 @@ private[wiremock] final case class WireMockControl(
       rules    <- rulesOf(src)
       id       <- freshSpaceId(src.name)
       rulesRef <- Ref.make(Vector.empty[(RuleId, StubMapping)])
+      scenRef  <- Ref.make(Map.empty[String, ScenarioRecord])
       corr      = correlationOf
       server   <- serverFor(id)
-      st        = SpaceState(server, ownsServer = corr.isEmpty, corr, rulesRef)
+      st        = SpaceState(server, ownsServer = corr.isEmpty, corr, rulesRef, scenRef)
       // If a rule fails mid-batch the space is never tracked, so destroy can
       // never reach it: undo its stubs (and stop its own server) here, or they
       // orphan on the shared server.
@@ -248,8 +324,13 @@ private[wiremock] object WireMockControl:
     server: WireMockServer,
     ownsServer: Boolean,
     correlation: Option[Correlation],
-    rules: Ref[Vector[(RuleId, StubMapping)]]
+    rules: Ref[Vector[(RuleId, StubMapping)]],
+    scenarios: Ref[Map[String, ScenarioRecord]]
   )
+
+  // A defined scenario's initial state (for `reset`) plus the stubs it installed
+  // (so `destroy` removes them from the shared server — they are not in `rules`).
+  final case class ScenarioRecord(initial: ScenarioState, stubs: Vector[StubMapping])
 
   /**
    * Build the adapter for `mode`, starting the shared server in Correlated mode

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockControl.scala
@@ -33,8 +33,9 @@ private[wiremock] final case class WireMockControl(
 
   import WireMockControl.{ScenarioRecord, SpaceState}
 
-  def backendName: String           = "wiremock"
-  def capabilities: Set[Capability] = Set(Capability.StatefulScenarios, Capability.StateInspection)
+  def backendName: String = "wiremock"
+  def capabilities: Set[Capability] =
+    Set(Capability.Faults, Capability.StatefulScenarios, Capability.StateInspection)
 
   override def isolation: Isolation = mode match
     case WireMock.Mode.Correlated(_) => Isolation.Correlated
@@ -145,7 +146,7 @@ private[wiremock] final case class WireMockControl(
         })
     }
 
-  def faults: IO[Unsupported, Faults]                   = unsupported(Capability.Faults)
+  def faults: IO[Unsupported, Faults]                   = ZIO.succeed(wmFaults)
   def scenarios: IO[Unsupported, StatefulScenarios]     = ZIO.succeed(statefulScenarios)
   def stateInspection: IO[Unsupported, StateInspection] = ZIO.succeed(stateInspector)
   def scripting: IO[Unsupported, Scripting]             = unsupported(Capability.Scripting)
@@ -222,6 +223,20 @@ private[wiremock] final case class WireMockControl(
               .mapError(e => MockError.CommunicationError(msg(e)))
           case None => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${space.id.value}"))
         )
+      }
+
+  // Faults (#128): a fault stub is a first-match (Overlay) stub carrying WireMock's
+  // native `Fault` (or a fixed delay), tracked in `st.rules` like any other — so
+  // correlation filtering, `removeRule` and `destroy` all apply to it unchanged.
+  private val wmFaults: Faults = new Faults:
+    def inject(space: MockSpace, m: RequestMatch, fault: FaultKind): IO[MockError, RuleId] =
+      withSpace(space) { st =>
+        for
+          ruleId <- freshRuleId
+          stub    = WireMockTranslation.faultStub(space.id, m, fault, Priority.Overlay, st.correlation)
+          _      <- ZIO.attempt(st.server.addStubMapping(stub)).mapError(e => MockError.CommunicationError(msg(e)))
+          _      <- st.rules.update((ruleId, stub) +: _)
+        yield ruleId
       }
 
   // Stop every server this adapter still owns — the layer's scope finalizer.

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockTranslation.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockTranslation.scala
@@ -3,6 +3,7 @@ package zio.bdd.mock.wiremock
 import zio.bdd.mock.*
 
 import com.github.tomakehurst.wiremock.client.{MappingBuilder, ResponseDefinitionBuilder, WireMock as WM}
+import com.github.tomakehurst.wiremock.http.Fault
 import com.github.tomakehurst.wiremock.matching.StringValuePattern
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 
@@ -20,13 +21,45 @@ private[wiremock] object WireMockTranslation:
    * `None` (the space owns its server outright).
    */
   def stub(id: SpaceId, rule: MockRule, priority: Priority, correlation: Option[Correlation]): StubMapping =
-    val base = requestBuilder(id, rule.`match`, correlation)
+    matcher(id, rule.`match`, priority, correlation).willReturn(response(rule.respond)).build()
+
+  /**
+   * Build a fault stub for space `id` matching `m` (#128): same request matcher
+   * as [[stub]] (so correlation/priority behave identically), but the response
+   * injects `fault` via WireMock's native `Fault` enum (connection kinds) or a
+   * fixed delay ([[FaultKind.LatencySpike]]).
+   */
+  def faultStub(
+    id: SpaceId,
+    m: RequestMatch,
+    fault: FaultKind,
+    priority: Priority,
+    correlation: Option[Correlation]
+  ): StubMapping =
+    matcher(id, m, priority, correlation).willReturn(faultResponse(fault)).build()
+
+  // Shared matcher builder for normal and fault stubs: the request matcher
+  // (requestBuilder) plus the Priority-enum precedence and a fresh id.
+  private def matcher(
+    id: SpaceId,
+    m: RequestMatch,
+    priority: Priority,
+    correlation: Option[Correlation]
+  ): MappingBuilder =
+    val base = requestBuilder(id, m, correlation)
     base.atPriority(priority match
       case Priority.Overlay => 1
       case Priority.Base    => 10
     )
     base.withId(UUID.randomUUID())
-    base.willReturn(response(rule.respond)).build()
+    base
+
+  private def faultResponse(fault: FaultKind): ResponseDefinitionBuilder = fault match
+    case FaultKind.ConnectionReset => WM.aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)
+    case FaultKind.EmptyResponse   => WM.aResponse().withFault(Fault.EMPTY_RESPONSE)
+    case FaultKind.MalformedChunk  => WM.aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)
+    case FaultKind.RandomThenClose => WM.aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE)
+    case FaultKind.LatencySpike(d) => WM.aResponse().withStatus(200).withFixedDelay(d.toMillis.toInt)
 
   /**
    * Build one edge of a scenario FSM (#130): the request matcher (plus the

--- a/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockTranslation.scala
+++ b/wiremock/src/main/scala/zio/bdd/mock/wiremock/WireMockTranslation.scala
@@ -20,17 +20,47 @@ private[wiremock] object WireMockTranslation:
    * `None` (the space owns its server outright).
    */
   def stub(id: SpaceId, rule: MockRule, priority: Priority, correlation: Option[Correlation]): StubMapping =
-    val base = methodAndUrl(rule.`match`)
-    rule.`match`.headers.foreach((k, v) => base.withHeader(k, valuePattern(v)))
-    rule.`match`.query.foreach((k, v) => base.withQueryParam(k, valuePattern(v)))
-    rule.`match`.body.foreach(b => base.withRequestBody(bodyPattern(b)))
-    correlation.foreach(c => base.withHeader(c.header, c.matcher(id)))
+    val base = requestBuilder(id, rule.`match`, correlation)
     base.atPriority(priority match
       case Priority.Overlay => 1
       case Priority.Base    => 10
     )
     base.withId(UUID.randomUUID())
     base.willReturn(response(rule.respond)).build()
+
+  /**
+   * Build one edge of a scenario FSM (#130): the request matcher (plus the
+   * space's correlation header) gated by
+   * `inScenario(name).whenScenarioStateIs`, optionally transitioning via
+   * `willSetStateTo` (`None` = stay). `priority` comes from the rule's
+   * declaration index so that among rules eligible in the same state, the
+   * first-declared wins — WireMock otherwise breaks an equal-priority tie in
+   * favour of the most-recently-added stub.
+   */
+  def statefulStub(
+    id: SpaceId,
+    scenarioName: String,
+    whenState: ScenarioState,
+    thenState: Option[ScenarioState],
+    rule: MockRule,
+    priority: Int,
+    correlation: Option[Correlation]
+  ): StubMapping =
+    val sc = requestBuilder(id, rule.`match`, correlation)
+      .inScenario(scenarioName)
+      .whenScenarioStateIs(whenState.value)
+    thenState.foreach(s => sc.willSetStateTo(s.value))
+    sc.atPriority(priority)
+    sc.withId(UUID.randomUUID())
+    sc.willReturn(response(rule.respond)).build()
+
+  private def requestBuilder(id: SpaceId, m: RequestMatch, correlation: Option[Correlation]): MappingBuilder =
+    val base = methodAndUrl(m)
+    m.headers.foreach((k, v) => base.withHeader(k, valuePattern(v)))
+    m.query.foreach((k, v) => base.withQueryParam(k, valuePattern(v)))
+    m.body.foreach(b => base.withRequestBody(bodyPattern(b)))
+    correlation.foreach(c => base.withHeader(c.header, c.matcher(id)))
+    base
 
   private def methodAndUrl(m: RequestMatch): MappingBuilder =
     val url = m.path match

--- a/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
+++ b/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
@@ -148,6 +148,50 @@ object WireMockControlSpec extends ZIOSpecDefault:
           elapsed <- Clock.nanoTime.map(_ - start)
         yield assertTrue(resp.status == 200, elapsed >= 250.millis.toNanos) // ~300ms fixed delay
       } @@ TestAspect.withLiveClock,
+      test("advertises Faults; its accessor succeeds and an unadvertised accessor fails fast") {
+        for
+          control    <- ZIO.service[MockControl]
+          faultsE    <- control.faults.either
+          scriptingE <- control.scripting.either
+        yield assertTrue(
+          control.capabilities.contains(Capability.Faults),
+          faultsE.isRight,
+          scriptingE == Left(Unsupported(Capability.Scripting, "wiremock"))
+        )
+      },
+      test("faults.inject ConnectionReset makes the SUT client observe a transport failure") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          faults  <- control.faults.orDieWith(u => new RuntimeException(u.toString))
+          _       <- die(faults.inject(a, RequestMatch(path = PathMatch.Exact("/boom")), FaultKind.ConnectionReset))
+          ping    <- SutClient.make(a).send(Method.Get, "/ping").exit // the normal rule still serves
+          boom    <- SutClient.make(a).send(Method.Get, "/boom").exit
+        yield assertTrue(ping.isSuccess, boom.isFailure)
+      },
+      test("faults.inject LatencySpike delays an otherwise-normal 200 response") {
+        for
+          control <- ZIO.service[MockControl]
+          a       <- die(control.provision(pingSource)).map(_.head)
+          faults  <- control.faults.orDieWith(u => new RuntimeException(u.toString))
+          _       <- die(faults.inject(a, RequestMatch(path = PathMatch.Exact("/slow")), FaultKind.LatencySpike(700.millis)))
+          start   <- Clock.nanoTime
+          resp    <- SutClient.make(a).send(Method.Get, "/slow").orDie
+          elapsed <- Clock.nanoTime.map(_ - start)
+        yield assertTrue(resp.status == 200, elapsed >= 400.millis.toNanos)
+      } @@ TestAspect.withLiveClock,
+      test("a fault overrides a normal rule on the same path (precedence) and removeRule restores it") {
+        for
+          control  <- ZIO.service[MockControl]
+          a        <- die(control.provision(pingSource)).map(_.head)   // /ping -> 200 pong
+          ok       <- SutClient.make(a).send(Method.Get, "/ping").exit
+          faults   <- control.faults.orDieWith(u => new RuntimeException(u.toString))
+          rid      <- die(faults.inject(a, RequestMatch(path = PathMatch.Exact("/ping")), FaultKind.ConnectionReset))
+          broken   <- SutClient.make(a).send(Method.Get, "/ping").exit // the fault wins over the rule
+          _        <- die(control.removeRule(a, rid))                  // the fault is tracked → removable
+          restored <- SutClient.make(a).send(Method.Get, "/ping").orDie
+        yield assertTrue(ok.isSuccess, broken.isFailure, restored.status == 200, restored.body == "pong")
+      },
       test("provisionNative(WireMock) serves a raw stub on its own server; a Rift spec is rejected") {
         for
           control <- ZIO.service[MockControl]
@@ -260,6 +304,21 @@ object WireMockControlSpec extends ZIOSpecDefault:
         aGone.isLeft      // A's server was stopped — connection refused
       )
     }.provide(perInstance),
+    test("WireMockTranslation.faultStub maps each kind to the WireMock Fault enum / fixed delay") {
+      import com.github.tomakehurst.wiremock.http.Fault
+      def respOf(kind: FaultKind) =
+        WireMockTranslation
+          .faultStub(SpaceId("s"), RequestMatch(path = PathMatch.Exact("/x")), kind, Priority.Overlay, None)
+          .getResponse
+      assertTrue(
+        respOf(FaultKind.ConnectionReset).getFault == Fault.CONNECTION_RESET_BY_PEER,
+        respOf(FaultKind.EmptyResponse).getFault == Fault.EMPTY_RESPONSE,
+        respOf(FaultKind.MalformedChunk).getFault == Fault.MALFORMED_RESPONSE_CHUNK,
+        respOf(FaultKind.RandomThenClose).getFault == Fault.RANDOM_DATA_THEN_CLOSE,
+        respOf(FaultKind.LatencySpike(1.second)).getFixedDelayMilliseconds.intValue == 1000,
+        respOf(FaultKind.LatencySpike(1.second)).getStatus == 200
+      )
+    },
     suite("traceparent correlation")(
       test("inject stamps a traceparent; a foreign trace-id does not reach the space") {
         for

--- a/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
+++ b/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
@@ -148,15 +148,22 @@ object WireMockControlSpec extends ZIOSpecDefault:
           elapsed <- Clock.nanoTime.map(_ - start)
         yield assertTrue(resp.status == 200, elapsed >= 250.millis.toNanos) // ~300ms fixed delay
       } @@ TestAspect.withLiveClock,
-      test("advertises Faults; its accessor succeeds and an unadvertised accessor fails fast") {
+      test("advertises Faults but none of the optional Rift-only capabilities (#132); their accessors fail fast") {
         for
           control    <- ZIO.service[MockControl]
           faultsE    <- control.faults.either
           scriptingE <- control.scripting.either
+          proxyE     <- control.proxyRecord.either
+          templateE  <- control.templating.either
         yield assertTrue(
           control.capabilities.contains(Capability.Faults),
+          !control.capabilities.contains(Capability.Scripting),
+          !control.capabilities.contains(Capability.ProxyRecord),
+          !control.capabilities.contains(Capability.Templating),
           faultsE.isRight,
-          scriptingE == Left(Unsupported(Capability.Scripting, "wiremock"))
+          scriptingE == Left(Unsupported(Capability.Scripting, "wiremock")),
+          proxyE == Left(Unsupported(Capability.ProxyRecord, "wiremock")),
+          templateE == Left(Unsupported(Capability.Templating, "wiremock"))
         )
       },
       test("faults.inject ConnectionReset makes the SUT client observe a transport failure") {

--- a/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
+++ b/wiremock/src/test/scala/zio/bdd/mock/wiremock/WireMockControlSpec.scala
@@ -2,6 +2,7 @@ package zio.bdd.mock.wiremock
 
 import zio.*
 import zio.bdd.mock.*
+import zio.bdd.mock.dsl.*
 import zio.test.*
 
 import java.net.{URI, http as jhttp}
@@ -46,7 +47,10 @@ object WireMockControlSpec extends ZIOSpecDefault:
   private val perInstance = PortAllocator.layer >>> Provisioning.layer >>> WireMock.perInstance
   private val traceparent = PortAllocator.layer >>> Provisioning.layer >>> WireMock.correlated(Correlation.traceparent)
 
-  private def die[A](z: IO[MockError, A]): UIO[A] = z.orDieWith(e => new RuntimeException(e.toString))
+  private def die[A](z: IO[MockError, A]): UIO[A]    = z.orDieWith(e => new RuntimeException(e.toString))
+  private def dieU[A](z: IO[Unsupported, A]): UIO[A] = z.orDieWith(u => new RuntimeException(u.toString))
+
+  private val emptySource = MockSource.Dsl(MockSpec(Nil))
 
   // Send straight to a base URI with no inject (and an optional raw header), to
   // model a SUT that did NOT carry the space tag.
@@ -167,7 +171,75 @@ object WireMockControlSpec extends ZIOSpecDefault:
           ra      <- die(control.received(a))
           rb      <- die(control.received(b))
         yield assertTrue(ra.size == 1, rb.size == 2) // received filters by space header on the shared server
-      }
+      },
+      // --- stateful scenarios (#130): edges the portable cap-stateful catalog can't express ---
+      suite("stateful scenarios")(
+        test("define replaces an existing scenario of the same name (replacing any existing)") {
+          for
+            control <- ZIO.service[MockControl]
+            ss      <- dieU(control.scenarios)
+            a       <- die(control.provision(emptySource)).map(_.head)
+            _       <- die(ss.define(a, scenario("sc").when("Started", get("/x")).respond(ok.text("v1")).stay.build))
+            r1      <- SutClient.make(a).send(Method.Get, "/x").orDie
+            _       <- die(ss.define(a, scenario("sc").when("Started", get("/x")).respond(ok.text("v2")).stay.build))
+            r2      <- SutClient.make(a).send(Method.Get, "/x").orDie
+          yield assertTrue(r1.body == "v1", r2.body == "v2") // the old edge is gone, not shadowed
+        },
+        test("a non-Started initial state is honoured by define and restored by reset") {
+          val oc =
+            scenario("oc")
+              .startingAt("Open")
+              .when("Open", get("/o"))
+              .respond(ok.text("open"))
+              .goTo("Closed")
+              .when("Closed", get("/o"))
+              .respond(ok.text("closed"))
+              .stay
+              .build
+          for
+            control <- ZIO.service[MockControl]
+            ss      <- dieU(control.scenarios)
+            si      <- dieU(control.stateInspection)
+            a       <- die(control.provision(emptySource)).map(_.head)
+            _       <- die(ss.define(a, oc))
+            s0      <- die(si.currentState(a, "oc"))
+            r1      <- SutClient.make(a).send(Method.Get, "/o").orDie // Open -> "open", -> Closed
+            r2      <- SutClient.make(a).send(Method.Get, "/o").orDie // Closed -> "closed"
+            _       <- die(ss.reset(a, "oc"))
+            s1      <- die(si.currentState(a, "oc"))
+            r3      <- SutClient.make(a).send(Method.Get, "/o").orDie // back in Open -> "open"
+          yield assertTrue(
+            s0 == ScenarioState("Open"),
+            r1.body == "open",
+            r2.body == "closed",
+            s1 == ScenarioState("Open"),
+            r3.body == "open"
+          )
+        },
+        test("reset / currentState / setState of an unknown scenario fail with InvalidDefinition") {
+          for
+            control <- ZIO.service[MockControl]
+            ss      <- dieU(control.scenarios)
+            si      <- dieU(control.stateInspection)
+            a       <- die(control.provision(emptySource)).map(_.head)
+            e1      <- ss.reset(a, "ghost").either
+            e2      <- si.currentState(a, "ghost").either
+            e3      <- si.setState(a, "ghost", ScenarioState("X")).either
+            expected = MockError.InvalidDefinition(s"no scenario 'ghost' on space ${a.id.value}")
+          yield assertTrue(e1 == Left(expected), e2 == Left(expected), e3 == Left(expected))
+        },
+        test("destroy removes the scenario's stubs from the shared server") {
+          for
+            control <- ZIO.service[MockControl]
+            ss      <- dieU(control.scenarios)
+            a       <- die(control.provision(emptySource)).map(_.head)
+            _       <- die(ss.define(a, scenario("sc").when("Started", get("/x")).respond(ok.text("v1")).stay.build))
+            before  <- SutClient.make(a).send(Method.Get, "/x").orDie
+            _       <- die(control.destroy(a))
+            after   <- SutClient.make(a).send(Method.Get, "/x").orDie
+          yield assertTrue(before.status == 200, before.body == "v1", after.status == 404)
+        }
+      )
     ).provide(correlated),
     test("the PerInstance-mode adapter reports PerInstance isolation") {
       ZIO.serviceWith[MockControl](c => assertTrue(c.isolation == Isolation.PerInstance))


### PR DESCRIPTION
M3 (stateful capabilities) milestone acceptance gate — merges the epic to master.

Brings the MockControl SPI's optional capabilities to the adapters:
- **StatefulScenarios + StateInspection** (single-token FSM): portable SPI + fluent DSL, with both the WireMock (native scenario API) and Rift (`_rift` declarative scenarios) adapters.
- **Faults** (connection-level + latency): Rift via `_rift.fault` (rift#239), WireMock via its native `Fault` enum / fixed delay.
- **Scripting / ProxyRecord / Templating** (Rift-only): `_rift.script`, a Mountebank `proxyOnce` proxy with record→replay, and a `copy` templating behavior. WireMock advertises none, so those `cap-*` features SKIP there.

Every capability is verified end-to-end against a real rift v0.6.0 container (the `RIFT_IT` CI job) and in-process WireMock, via the cross-adapter conformance matrix.

Closes #128
Closes #129
Closes #130
Closes #131
Closes #132

Milestone: M3