### PR TITLE
feat: MockControl.embedded via Panama FFM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,32 @@ jobs:
         env:
           RIFT_IT: "1"
         run: sbt "rift/testOnly zio.bdd.mock.rift.RiftContainerSpec" "conformance/test"
+
+  # MockControl.embedded (#133) drives Rift in-process over librift_ffi via Panama FFM, a preview
+  # API that exists only on JDK 21+. The project baseline is JDK 11, so the embedded sources are
+  # gated to src/{main,test}/jdk21 (compiled only on a 21+ JDK) and exercised here on a dedicated
+  # JDK 21 runner. No Docker: the in-process engine binds localhost ports directly.
+  embedded:
+    name: Embedded FFM provider (JDK 21)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: sbt
+      - uses: sbt/setup-sbt@v1
+      # librift_ffi dynamically links LuaJIT (the Lua scripting engine), so the shared library can't
+      # be dlopen'd without it present — matches the Rift project's own FFI CI.
+      - name: Install LuaJIT
+        run: sudo apt-get update && sudo apt-get install -y libluajit-5.1-dev
+      # downloadRiftFfi fetches + checksum-verifies the per-host-triple native library; the forked
+      # test JVMs run with --enable-preview + --enable-native-access (set in embeddedNativeSettings).
+      - name: Embedded smoke + portable conformance against MockControl.embedded
+        run: >-
+          sbt rift/downloadRiftFfi conformance/downloadRiftFfi
+          "rift/testOnly zio.bdd.mock.rift.embedded.EmbeddedRiftFfiSpec"
+          "conformance/testOnly zio.bdd.mock.conformance.EmbeddedConformanceSpec"

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,109 @@ import xerial.sbt.Sonatype.sonatypeCentralHost
 import StepGeneratorPlugin.autoImport.*
 import com.typesafe.tools.mima.core.*
 
+import java.net.URI
+import java.nio.file.{Files => JFiles, StandardCopyOption}
+import java.security.MessageDigest
+
+// ---- librift_ffi native library provisioning (embedded adapter, #133) ----------------------
+// The embedded MockControl drives Rift in-process over the librift_ffi C-ABI via Panama FFM. The
+// prebuilt shared library ships per host triple on the Rift GitHub release; the conformance gate
+// downloads + checksum-verifies it and passes its path to the forked test JVM. FFM is a preview
+// API on JDK 21, so those JVMs run with --enable-preview + --enable-native-access.
+
+lazy val riftFfiVersion  = settingKey[String]("Rift release tag providing librift_ffi")
+lazy val riftFfiLibFile  = settingKey[File]("Host-resolved path to the downloaded librift_ffi library")
+lazy val downloadRiftFfi = taskKey[File]("Download + checksum-verify librift_ffi for the host triple")
+
+// The release asset name for the host OS/arch, or None on an unsupported platform (tests then skip).
+// NOTE: build.sbt is compiled with the Scala 2.12 dialect — keep this block 2.12-compatible.
+def riftFfiAssetName: Option[String] = {
+  val os = sys.props.getOrElse("os.name", "").toLowerCase
+  val arch = sys.props.getOrElse("os.arch", "").toLowerCase match {
+    case "aarch64" | "arm64" => "aarch64"
+    case "x86_64" | "amd64"  => "x86_64"
+    case other               => other
+  }
+  if (os.contains("mac") || os.contains("darwin")) Some(s"librift_ffi-darwin-$arch.dylib")
+  else if (os.contains("linux")) Some(s"librift_ffi-linux-$arch.so")
+  else if (os.contains("win")) Some(s"librift_ffi-windows-$arch.dll")
+  else None
+}
+
+def riftFfiLibTarget(targetDir: File): File =
+  targetDir / "native" / riftFfiAssetName.getOrElse("librift_ffi.unavailable")
+
+def sha256Hex(f: File): String =
+  MessageDigest.getInstance("SHA-256").digest(JFiles.readAllBytes(f.toPath)).map(b => f"$b%02x").mkString
+
+// The major version of the JDK building this project. FFM (java.lang.foreign) is a preview API on
+// 21 and absent before it, so the embedded adapter's sources only compile on 21+. The project's
+// baseline is JDK 11 (CI + release), so embedded is gated: on a < 21 JDK its source dirs are not
+// added (the rift/conformance modules build clean and the published artifacts stay JDK-11), and a
+// dedicated JDK-21 CI job exercises it.
+def jdkMajor: Int = {
+  val raw = sys.props.getOrElse("java.specification.version", "11")
+  val s   = if (raw.startsWith("1.")) raw.substring(2) else raw
+  s.takeWhile(_.isDigit) match { case "" => 11; case d => d.toInt }
+}
+lazy val ffmEnabled: Boolean = jdkMajor >= 21
+
+// JDK-21-only: provisions the native library + the embedded source dirs + the preview/native-access
+// test JVM. Empty on a < 21 JDK, so the embedded adapter is simply absent from that build.
+lazy val embeddedNativeSettings: Seq[Def.Setting[_]] =
+  if (!ffmEnabled) Nil
+  else
+    Seq(
+      Compile / unmanagedSourceDirectories += (Compile / sourceDirectory).value / "jdk21",
+      Test / unmanagedSourceDirectories += (Test / sourceDirectory).value / "jdk21",
+      // The Java FFM bridge uses the preview Foreign Function & Memory API.
+      javacOptions ++= Seq("--release", "21", "--enable-preview"),
+      riftFfiVersion := "0.7.0",
+      riftFfiLibFile := riftFfiLibTarget(target.value),
+  downloadRiftFfi := {
+    val log     = streams.value.log
+    val version = riftFfiVersion.value
+    val out     = riftFfiLibFile.value
+    riftFfiAssetName match {
+      case None =>
+        log.warn(
+          s"[rift-ffi] no prebuilt librift_ffi for ${sys.props.getOrElse("os.name", "?")}/" +
+            s"${sys.props.getOrElse("os.arch", "?")}; embedded tests will be skipped"
+        )
+        out
+      case Some(asset) =>
+        val base = s"https://github.com/EtaCassiopeia/rift/releases/download/v$version"
+        val expected = {
+          val in = URI.create(s"$base/$asset.sha256").toURL.openStream()
+          try new String(in.readAllBytes(), "UTF-8").trim.split("\\s+").head
+          finally in.close()
+        }
+        if (out.exists() && sha256Hex(out) == expected) {
+          log.info(s"[rift-ffi] using cached $asset")
+          out
+        } else {
+          JFiles.createDirectories(out.toPath.getParent)
+          log.info(s"[rift-ffi] downloading $asset (v$version) ...")
+          val in = URI.create(s"$base/$asset").toURL.openStream()
+          try JFiles.copy(in, out.toPath, StandardCopyOption.REPLACE_EXISTING)
+          finally in.close()
+          val got = sha256Hex(out)
+          if (got != expected) sys.error(s"[rift-ffi] checksum mismatch for $asset: got $got, expected $expected")
+          log.info(s"[rift-ffi] downloaded + verified $asset")
+          out
+        }
+    }
+  },
+  Test / fork := true,
+  Test / javaOptions ++= Seq(
+    "--enable-preview",
+    "--enable-native-access=ALL-UNNAMED",
+    s"-Drift.ffi.lib=${riftFfiLibFile.value.getAbsolutePath}"
+  ),
+  // Ensure the native library is present (and verified) before the forked test JVM starts.
+  (Test / test) := (Test / test).dependsOn(downloadRiftFfi).value
+)
+
 inThisBuild(
   List(
     organization := "io.github.etacassiopeia",
@@ -151,6 +254,10 @@ lazy val rift = (project in file("rift"))
       "com.dimafeng" %% "testcontainers-scala-core"  % "0.41.4"
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    // The embedded adapter (#133) lives in JDK-21-only source dirs (src/{main,test}/jdk21) and is
+    // compiled with --release 21 --enable-preview — added by embeddedNativeSettings only on a 21+ JDK,
+    // so on the JDK-11 baseline the rift module builds (and publishes) without the FFM bridge.
+    embeddedNativeSettings,
     // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
     mimaPreviousArtifacts := Set.empty
   )
@@ -180,6 +287,9 @@ lazy val conformance = (project in file("conformance"))
     name := "zio-bdd-conformance",
     libraryDependencies ++= commonDependencies,
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    // The conformance matrix runs the portable scenarios against MockControl.embedded (#133), which
+    // drives Rift in-process via FFM — so the forked test JVM needs the native library + preview.
+    embeddedNativeSettings,
     publish / skip        := true, // a test harness, not a published artifact
     mimaPreviousArtifacts := Set.empty
   )

--- a/conformance/src/test/jdk21/zio/bdd/mock/conformance/EmbeddedConformanceSpec.scala
+++ b/conformance/src/test/jdk21/zio/bdd/mock/conformance/EmbeddedConformanceSpec.scala
@@ -1,0 +1,61 @@
+package zio.bdd.mock.conformance
+
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.rift.embedded.EmbeddedRift
+import zio.test.*
+
+/**
+ * The portable conformance suites run against `MockControl.embedded` (#133) —
+ * the in-process Rift provider over `librift_ffi` (Panama FFM) — proving it is
+ * a pure backend swap: the exact same scenario catalogues used for
+ * WireMock/Rift, with no scenario changes.
+ *
+ * JDK-21-only (FFM is a preview API on 21), so this spec lives in
+ * `src/test/jdk21` and is compiled only on a 21+ JDK; it is gated on the native
+ * library being present ([[EmbeddedRift.available]]), mirroring how `RIFT_IT`
+ * gates the container backend.
+ *
+ * `Matrix.conformant(embedded)` is the full acceptance condition for a suite:
+ * with the library present, the core scenarios (which require no capability)
+ * must PASS and the capability scenarios SKIP-justified (embedded advertises
+ * none); with it absent, the whole column is SKIPPED-unavailable (also
+ * conformant). So one assertion gates each catalogue.
+ */
+object EmbeddedConformanceSpec extends ZIOSpecDefault:
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+
+  private val embedded =
+    MockBackendUnderTest(
+      "embedded",
+      Provisioning.live >>> EmbeddedRift.layer.mapError(asT),
+      Set.empty,
+      Isolation.PerInstance,
+      available = EmbeddedRift.available
+    )
+
+  private def conforms(label: String, scenarios: List[ConformanceScenario]) =
+    test(label) {
+      for
+        matrix <- ConformanceHarness.run(List(embedded), scenarios)
+        _      <- ZIO.logInfo(s"embedded $label:\n${matrix.render}")
+        fails =
+          scenarios.flatMap(s =>
+            matrix
+              .cell(s.name, "embedded")
+              .filter(_.outcome == Outcome.Fail)
+              .map(c => s"${c.scenario}: ${c.detail.getOrElse("")}")
+          )
+        _ <- ZIO.logInfo(s"embedded $label FAILs: $fails").when(fails.nonEmpty)
+      yield assertTrue(scenarios.nonEmpty, matrix.conformant(embedded))
+    }
+
+  def spec = suite("EmbeddedConformance")(
+    conforms("core (#125)", CoreConformanceScenarios.all),
+    conforms("negotiation/error (#127)", NegotiationErrorScenarios.all),
+    conforms("cap-stateful (#131)", CapStatefulScenarios.all),
+    conforms("faults (#128)", FaultScenarios.all),
+    conforms("scripting (#132)", ScriptingScenarios.all),
+    conforms("templating (#132)", TemplatingScenarios.all)
+  ) @@ TestAspect.withLiveClock

--- a/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
+++ b/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
@@ -1,0 +1,69 @@
+package zio.bdd.mock.rift.embedded
+
+import zio.*
+import zio.bdd.mock.{MockControl, MockError, Provisioning}
+
+import java.nio.file.{Files, Paths}
+
+/**
+ * Entry point for `MockControl.embedded` (#133): the opt-in, no-Docker,
+ * in-process Rift provider, driving the engine over `librift_ffi` via Panama
+ * FFM behind the portable [[MockControl]] interface — a pure backend swap for
+ * the container adapter.
+ *
+ * The native library is located via the `rift.ffi.lib` system property (falling
+ * back to the `RIFT_FFI_LIB` environment variable). [[available]] reports
+ * whether that path resolves to a real file, so a harness can park the backend
+ * (rather than fail) on a platform where the library has not been provisioned.
+ *
+ * Requires Project Panama FFM, a preview API on JDK 21: the host JVM must run
+ * with `--enable-preview` (and `--enable-native-access` to silence the
+ * restricted-method warning).
+ */
+object EmbeddedRift:
+
+  /**
+   * System property naming the absolute path to the `librift_ffi` shared
+   * library.
+   */
+  val LibPathProperty = "rift.ffi.lib"
+
+  /**
+   * Environment variable naming the `librift_ffi` shared library (fallback for
+   * the property).
+   */
+  val LibPathEnv = "RIFT_FFI_LIB"
+
+  /**
+   * The configured native-library path, if set (property takes precedence over
+   * the env var).
+   */
+  def libPath: Option[String] =
+    sys.props.get(LibPathProperty).orElse(sys.env.get(LibPathEnv)).map(_.trim).filter(_.nonEmpty)
+
+  /**
+   * True iff the native library path is configured and points to an existing
+   * regular file.
+   */
+  def available: Boolean =
+    libPath.exists(p => Files.isRegularFile(Paths.get(p)))
+
+  /**
+   * A scoped [[MockControl]] backed by the in-process Rift engine: `rift_start`
+   * on layer construction, `rift_stop` on close. Fails with
+   * [[MockError.ProvisionFailed]] if the native library path is not configured
+   * or cannot be loaded.
+   */
+  def layer: ZLayer[Provisioning, MockError, MockControl] =
+    ZLayer.scoped {
+      for
+        prov <- ZIO.service[Provisioning]
+        path <- ZIO
+                  .fromOption(libPath)
+                  .orElseFail(
+                    MockError.ProvisionFailed(s"native library path not set; set -D$LibPathProperty or $LibPathEnv")
+                  )
+        engine  <- RiftFfi.start(path)
+        control <- EmbeddedRiftMockControl.make(engine, prov)
+      yield control
+    }

--- a/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
+++ b/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
@@ -1,0 +1,207 @@
+package zio.bdd.mock.rift.embedded
+
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.rift.RiftProtocol
+import zio.json.*
+import zio.json.ast.Json
+
+/**
+ * The embedded Rift adapter (#133): implements the portable [[MockControl]]
+ * core port by driving the Rift engine in-process over the `librift_ffi` C-ABI
+ * (Panama FFM), with no Docker.
+ *
+ * It shares the Mountebank-compatible JSON codec ([[RiftProtocol]]) with the
+ * container adapter — the FFI consumes the same imposter/stub model the admin
+ * API does — so the wire fidelity is identical; only the transport differs (FFM
+ * downcalls instead of HTTP).
+ *
+ * The FFI surface is intentionally small: create an imposter, replace all of
+ * its stubs, read its recorded requests. So this adapter keeps each space's
+ * ordered rules in a [[Ref]] and realises every rule mutation as a
+ * whole-imposter `rift_replace_stubs` (first-match order: overlay prepends,
+ * base appends). It is PerInstance only — one imposter per space on its own
+ * OS-assigned localhost port (the host allocates a free port, the engine binds
+ * it directly; no container port-mapping) — and advertises no optional
+ * capabilities (the C-ABI exposes none of the scenario-state endpoints they
+ * need), so capability scenarios negotiate a justified SKIP.
+ */
+private[embedded] final case class EmbeddedRiftMockControl(
+  engine: EmbeddedEngine,
+  provisioning: Provisioning,
+  spaces: Ref[Map[SpaceId, EmbeddedRiftMockControl.Imposter]],
+  ids: Ref[Int]
+) extends MockControl:
+
+  import EmbeddedRiftMockControl.Imposter
+
+  def backendName: String           = "embedded"
+  def capabilities: Set[Capability] = Set.empty
+
+  def provision(source: MockSource): IO[MockError, List[MockSpace]] =
+    for
+      sources <- provisioning.normalize(source)
+      created <- Ref.make(List.empty[MockSpace])
+      // Provision atomically: if a later source fails, tear down the spaces already stood up so a
+      // partial provision doesn't leave them serving (their bound ports are reclaimed only when the
+      // engine stops). The original failure propagates; a cleanup failure is logged, never masks it.
+      spaces <- ZIO
+                  .foreach(sources)(src => serve(src).tap(s => created.update(s :: _)))
+                  .onError(_ => created.get.flatMap(ZIO.foreachDiscard(_)(s => destroy(s).ignoreLogged)))
+    yield spaces
+
+  def provisionNative[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]] =
+    spec match
+      case NativeSpec.Rift(imposterJson) =>
+        serve(NormalizedSource("native", SourcePayload.Raw(imposterJson), None)).map(List(_))
+      case NativeSpec.WireMock(_) =>
+        ZIO.fail(MockError.InvalidDefinition("the embedded Rift adapter cannot provision a WireMock native spec"))
+
+  def addRule(space: MockSpace, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
+    withImposter(space) { imp =>
+      for
+        ruleId <- freshId
+        cur    <- imp.rules.get
+        // First match wins: an overlay sits on top (index 0), a base rule is appended.
+        next = priority match
+                 case Priority.Overlay => (ruleId, rule) +: cur
+                 case Priority.Base    => cur :+ (ruleId, rule)
+        // Server-first, commit tracking on success — so a failed downcall never leaves the Ref
+        // claiming a rule the engine didn't accept.
+        _ <- rebuild(imp, next)
+        _ <- imp.rules.set(next)
+      yield ruleId
+    }
+
+  def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit] =
+    withImposter(space) { imp =>
+      imp.rules.get.flatMap { cur =>
+        if !cur.exists(_._1 == id) then ZIO.fail(MockError.RuleNotFound(space.id, id))
+        else
+          val next = cur.filterNot(_._1 == id)
+          rebuild(imp, next) *> imp.rules.set(next)
+      }
+    }
+
+  def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit] =
+    withImposter(space) { imp =>
+      for
+        next <- tagRules(rules)
+        _    <- rebuild(imp, next)
+        _    <- imp.rules.set(next)
+      yield ()
+    }
+
+  def destroy(space: MockSpace): IO[MockError, Unit] =
+    withImposter(space) { imp =>
+      // The C-ABI has no per-imposter delete (only `rift_delete_all`, which would tear down sibling
+      // spaces), so destroy empties the imposter's stubs (it then serves only the 404 default) and
+      // drops local tracking — after which every op on this space fails SpaceNotFound. The bound
+      // port lingers until the engine stops; that is reclaimed when the scoped layer closes.
+      engine.replaceStubs(imp.port, "[]") *> spaces.update(_ - space.id)
+    }
+
+  def received(space: MockSpace): IO[MockError, List[RecordedRequest]] =
+    withImposter(space) { imp =>
+      engine
+        .recorded(imp.port)
+        .flatMap(json =>
+          ZIO.fromEither(RiftProtocol.parseRequestsArray(json)).mapError(MockError.CommunicationError(_))
+        )
+    }
+
+  def faults: IO[Unsupported, Faults]                   = unsupported(Capability.Faults)
+  def scenarios: IO[Unsupported, StatefulScenarios]     = unsupported(Capability.StatefulScenarios)
+  def stateInspection: IO[Unsupported, StateInspection] = unsupported(Capability.StateInspection)
+  def scripting: IO[Unsupported, Scripting]             = unsupported(Capability.Scripting)
+  def proxyRecord: IO[Unsupported, ProxyRecord]         = unsupported(Capability.ProxyRecord)
+  def templating: IO[Unsupported, Templating]           = unsupported(Capability.Templating)
+
+  // ---------------------------------------------------------------------------
+
+  // Stand up one imposter for `src` on its own OS-assigned localhost port. The host allocates a
+  // free port (PortAllocator) and the engine binds it directly (`rift_create_imposter` echoes the
+  // requested port); a mismatch means the port was taken in the bind window — surfaced, not hidden.
+  private def serve(src: NormalizedSource): IO[MockError, MockSpace] =
+    for
+      port  <- provisioning.allocator.freePort
+      built <- buildImposter(port, src)
+      bound <- engine.createImposter(built.configJson)
+      _ <- ZIO.unless(bound == port)(
+             ZIO.fail(MockError.ProvisionFailed(s"embedded Rift bound port $bound but $port was requested"))
+           )
+      rules <- Ref.make(built.tagged)
+      id     = SpaceId(s"${src.name}-$port")
+      _     <- spaces.update(_.updated(id, Imposter(port, rules, built.nativeStubs)))
+    yield MockSpace(s"http://localhost:$port", identity, id)
+
+  private def withImposter[A](space: MockSpace)(f: Imposter => IO[MockError, A]): IO[MockError, A] =
+    spaces.get.flatMap(_.get(space.id) match
+      case Some(imp) => f(imp)
+      case None      => ZIO.fail(MockError.SpaceNotFound(space.id))
+    )
+
+  // Build the create-imposter body for `src`, the portable rules to track, and the native base
+  // stubs to preserve. A DSL source's rules are each tagged with a fresh id and tracked; a raw
+  // imposter document's own stubs aren't portable rules, so they are kept verbatim as a base layer
+  // that every later `rift_replace_stubs` rebuild re-registers beneath the tracked rules — so a
+  // mutation (e.g. an overlay) on a natively-provisioned space doesn't drop its native stubs.
+  private def buildImposter(port: Int, src: NormalizedSource): IO[MockError, EmbeddedRiftMockControl.Built] =
+    src.payload match
+      case SourcePayload.Rules(rules) =>
+        tagRules(rules).map(tagged =>
+          EmbeddedRiftMockControl.Built(
+            RiftProtocol.imposter(port, src.name, withIds(tagged)).toJson,
+            tagged,
+            Vector.empty
+          )
+        )
+      case SourcePayload.Raw(text) =>
+        ZIO
+          .fromEither(RiftProtocol.imposterFromRaw(port, src.name, text))
+          .mapError(MockError.InvalidDefinition(_))
+          .map((doc, _) => EmbeddedRiftMockControl.Built(doc.toJson, Vector.empty, stubsOf(doc)))
+
+  // The `stubs` array of an imposter document, or empty if absent/malformed-shaped.
+  private def stubsOf(imposterDoc: Json): Vector[Json] =
+    imposterDoc match
+      case o: Json.Obj => o.fields.collectFirst { case ("stubs", Json.Arr(es)) => es.toVector }.getOrElse(Vector.empty)
+      case _           => Vector.empty
+
+  private def tagRules(rules: List[MockRule]): UIO[Vector[(RuleId, MockRule)]] =
+    freshIds(rules.size).map(ids => rules.zip(ids).map((r, rid) => (rid, r)).toVector)
+
+  private def withIds(tagged: Vector[(RuleId, MockRule)]): List[MockRule] =
+    tagged.map((rid, r) => r.copy(id = Some(rid))).toList
+
+  // Re-register a space's whole stub list via `rift_replace_stubs`: the tracked portable rules in
+  // first-match order, then the native base stubs (so an overlay rule shadows a native stub).
+  private def rebuild(imp: Imposter, tracked: Vector[(RuleId, MockRule)]): IO[MockError, Unit] =
+    engine.replaceStubs(imp.port, Json.Arr((withIds(tracked).map(RiftProtocol.stub) ++ imp.nativeStubs)*).toJson)
+
+  private def freshId: UIO[RuleId]                  = ids.updateAndGet(_ + 1).map(n => RuleId(s"r$n"))
+  private def freshIds(n: Int): UIO[Vector[RuleId]] = ZIO.foreach(0 until n)(_ => freshId).map(_.toVector)
+
+  private def unsupported[A](c: Capability): IO[Unsupported, A] = ZIO.fail(Unsupported(c, backendName))
+
+private[embedded] object EmbeddedRiftMockControl:
+
+  /**
+   * A live imposter: its bound port, the ordered portable rules tracked for
+   * `rift_replace_stubs`, and the native base stubs (from a raw imposter
+   * document) re-registered beneath the tracked rules on every rebuild — empty
+   * for a DSL-provisioned space.
+   */
+  final case class Imposter(port: Int, rules: Ref[Vector[(RuleId, MockRule)]], nativeStubs: Vector[Json])
+
+  /**
+   * The create-imposter body, the rules to track, and the native base stubs for
+   * one space.
+   */
+  final case class Built(configJson: String, tagged: Vector[(RuleId, MockRule)], nativeStubs: Vector[Json])
+
+  def make(engine: EmbeddedEngine, provisioning: Provisioning): UIO[MockControl] =
+    for
+      spaces <- Ref.make(Map.empty[SpaceId, Imposter])
+      ids    <- Ref.make(0)
+    yield EmbeddedRiftMockControl(engine, provisioning, spaces, ids)

--- a/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/RiftFfi.scala
+++ b/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/RiftFfi.scala
@@ -1,0 +1,66 @@
+package zio.bdd.mock.rift.embedded
+
+import zio.*
+import zio.bdd.mock.MockError
+
+/**
+ * The ZIO-facing wrapper over [[RiftFfiBridge]] — the Panama FFM bindings to
+ * `librift_ffi`. Every downcall is a blocking call into the engine's own Tokio
+ * threads, so each is wrapped in `ZIO.attemptBlocking`; the crate's sentinels
+ * (port `0`, rc `-1`, null) become typed [[MockError]]s, and a genuine FFM
+ * failure surfaces as a [[MockError.CommunicationError]].
+ */
+private[embedded] final class EmbeddedEngine(bridge: RiftFfiBridge):
+
+  /**
+   * Create an imposter from a full imposter JSON config; yields its bound port.
+   */
+  def createImposter(configJson: String): IO[MockError, Int] =
+    blocking("rift_create_imposter")(bridge.createImposter(configJson)).flatMap { port =>
+      if port == 0 then
+        ZIO.fail(MockError.ProvisionFailed("rift_create_imposter returned 0 (bind failure or malformed config)"))
+      else ZIO.succeed(port)
+    }
+
+  /** Replace all stubs on `port` from a JSON array of Mountebank stubs. */
+  def replaceStubs(port: Int, stubsJson: String): IO[MockError, Unit] =
+    blocking("rift_replace_stubs")(bridge.replaceStubs(port, stubsJson)).flatMap { rc =>
+      if rc == 0 then ZIO.unit
+      else ZIO.fail(MockError.CommunicationError(s"rift_replace_stubs returned $rc for port $port"))
+    }
+
+  /**
+   * The recorded requests for `port` as a JSON array string (`[]` when none).
+   */
+  def recorded(port: Int): IO[MockError, String] =
+    blocking("rift_recorded")(bridge.recorded(port)).flatMap { json =>
+      if json == null then ZIO.fail(MockError.CommunicationError(s"rift_recorded returned null for port $port"))
+      else ZIO.succeed(json)
+    }
+
+  private def blocking[A](op: String)(thunk: => A): IO[MockError, A] =
+    ZIO
+      .attemptBlocking(thunk)
+      .mapError { t =>
+        val msg = Option(t.getMessage).filter(_.nonEmpty).fold("")(m => s": $m")
+        MockError.CommunicationError(s"$op via FFM failed (${t.getClass.getSimpleName}$msg)")
+      }
+
+private[embedded] object RiftFfi:
+
+  /**
+   * Start the embedded engine from the native library at `libPath`, scoped:
+   * `rift_start` on acquire, `rift_stop` (and native-library release) on the
+   * scope's close.
+   */
+  def start(libPath: String): ZIO[Scope, MockError, EmbeddedEngine] =
+    ZIO
+      .acquireRelease(
+        ZIO
+          .attemptBlocking(RiftFfiBridge.start(libPath))
+          .mapError(t => MockError.ProvisionFailed(s"loading librift_ffi from '$libPath': ${message(t)}"))
+      )(bridge => ZIO.attemptBlocking(bridge.close()).orDie)
+      .map(EmbeddedEngine(_))
+
+  private def message(t: Throwable): String =
+    Option(t.getMessage).getOrElse(t.getClass.getSimpleName)

--- a/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/RiftFfiBridge.java
+++ b/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/RiftFfiBridge.java
@@ -1,0 +1,154 @@
+package zio.bdd.mock.rift.embedded;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.nio.file.Path;
+
+/**
+ * Project Panama (FFM) bindings to the {@code librift_ffi} C-ABI (rift#204): an opaque handle +
+ * JSON in / JSON out over the Rift engine, so {@code MockControl.embedded} can drive Rift
+ * in-process with no Docker. Authored in Java because FFM is a preview API in JDK 21 and the
+ * downcall {@link MethodHandle#invoke} is signature-polymorphic — both are handled natively by
+ * javac (the {@code --enable-preview} class bit and the per-call-site descriptor), avoiding the
+ * cross-language pitfalls of calling these from Scala.
+ *
+ * <p>Boundary discipline mirrors the crate: memory is created and freed on the same side
+ * ({@link #recorded} hands the {@code *mut c_char} straight back to {@code rift_free}); the handle
+ * owns a Tokio runtime on its own threads, so the blocking downcalls are wrapped in
+ * {@code ZIO.attemptBlocking} by the Scala caller. One bridge is safe to share across threads —
+ * the engine is {@code Sync} and every input string is marshalled in a per-call confined arena.
+ *
+ * <p>Errors are returned as the crate's sentinels (port {@code 0}, rc {@code -1}, null pointer),
+ * never exceptions; a genuine FFM/link failure surfaces as a {@link RuntimeException} the caller
+ * turns into a {@code MockError}.
+ */
+public final class RiftFfiBridge implements AutoCloseable {
+
+  private static final Linker LINKER = Linker.nativeLinker();
+
+  private final Arena arena;
+  private final MemorySegment handle;
+  private final MethodHandle createImposter;
+  private final MethodHandle replaceStubs;
+  private final MethodHandle recorded;
+  private final MethodHandle free;
+  private final MethodHandle stop;
+
+  // rift_delete_all is intentionally not bound: it is a global reset that would tear down sibling
+  // imposters, so the adapter destroys a single space via rift_replace_stubs([]) instead.
+  private RiftFfiBridge(Arena arena, SymbolLookup lookup, MemorySegment handle) {
+    this.arena = arena;
+    this.handle = handle;
+    this.createImposter = downcall(lookup, "rift_create_imposter",
+        FunctionDescriptor.of(ValueLayout.JAVA_SHORT, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+    this.replaceStubs = downcall(lookup, "rift_replace_stubs",
+        FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_SHORT, ValueLayout.ADDRESS));
+    this.recorded = downcall(lookup, "rift_recorded",
+        FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_SHORT));
+    this.free = downcall(lookup, "rift_free", FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+    this.stop = downcall(lookup, "rift_stop", FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+  }
+
+  /**
+   * Load the native library, link the symbols, and start the engine ({@code rift_start}). Throws
+   * if the library cannot be loaded/linked or the engine's runtime could not be created.
+   */
+  public static RiftFfiBridge start(String libPath) throws Throwable {
+    Arena arena = Arena.ofShared();
+    try {
+      SymbolLookup lookup = SymbolLookup.libraryLookup(Path.of(libPath), arena);
+      MethodHandle startH = downcall(lookup, "rift_start", FunctionDescriptor.of(ValueLayout.ADDRESS));
+      MemorySegment handle = (MemorySegment) startH.invoke();
+      if (handle.address() == 0L) {
+        throw new IllegalStateException("rift_start returned null (engine runtime could not be created)");
+      }
+      return new RiftFfiBridge(arena, lookup, handle);
+    } catch (Throwable t) {
+      arena.close();
+      throw t;
+    }
+  }
+
+  private static MethodHandle downcall(SymbolLookup lookup, String name, FunctionDescriptor descriptor) {
+    MemorySegment symbol = lookup.find(name)
+        .orElseThrow(() -> new IllegalStateException("librift_ffi missing symbol: " + name));
+    return LINKER.downcallHandle(symbol, descriptor);
+  }
+
+  /** Create an imposter from a JSON config. Returns its bound port, or {@code 0} on any error. */
+  public int createImposter(String configJson) {
+    try (Arena call = Arena.ofConfined()) {
+      short port = (short) createImposter.invoke(handle, call.allocateUtf8String(configJson));
+      return port & 0xFFFF;
+    } catch (Throwable t) {
+      throw new RuntimeException("rift_create_imposter downcall failed", t);
+    }
+  }
+
+  /** Replace all stubs on {@code port} from a JSON array. Returns {@code 0} on success, {@code -1} on error. */
+  public int replaceStubs(int port, String stubsJson) {
+    try (Arena call = Arena.ofConfined()) {
+      return (int) replaceStubs.invoke(handle, (short) port, call.allocateUtf8String(stubsJson));
+    } catch (Throwable t) {
+      throw new RuntimeException("rift_replace_stubs downcall failed", t);
+    }
+  }
+
+  /**
+   * The recorded requests for {@code port} as a JSON array string, or {@code null} on any error
+   * (unknown port, encode failure). The native buffer is freed via {@code rift_free} before return.
+   */
+  public String recorded(int port) {
+    try {
+      MemorySegment result = (MemorySegment) recorded.invoke(handle, (short) port);
+      if (result.address() == 0L) {
+        return null;
+      }
+      Throwable primary = null;
+      try {
+        return result.reinterpret(Long.MAX_VALUE).getUtf8String(0);
+      } catch (Throwable t) {
+        primary = t;
+        throw t;
+      } finally {
+        // Free the buffer either way, but never let a free failure mask the read failure.
+        try {
+          free.invoke(result);
+        } catch (Throwable t) {
+          if (primary != null) primary.addSuppressed(t);
+          else throw t;
+        }
+      }
+    } catch (Throwable t) {
+      throw new RuntimeException("rift_recorded downcall failed", t);
+    }
+  }
+
+  /**
+   * Stop the engine ({@code rift_stop}) and release the native library. Not idempotent — call
+   * exactly once; the scoped layer guarantees a single release.
+   */
+  @Override
+  public void close() {
+    Throwable primary = null;
+    try {
+      stop.invoke(handle);
+    } catch (Throwable t) {
+      primary = new RuntimeException("rift_stop downcall failed", t);
+      throw (RuntimeException) primary;
+    } finally {
+      // Always unload the library; a close failure must not mask a rift_stop failure.
+      try {
+        arena.close();
+      } catch (Throwable t) {
+        if (primary != null) primary.addSuppressed(t);
+        else throw t;
+      }
+    }
+  }
+}

--- a/rift/src/test/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRiftFfiSpec.scala
+++ b/rift/src/test/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRiftFfiSpec.scala
@@ -1,0 +1,140 @@
+package zio.bdd.mock.rift.embedded
+
+import zio.*
+import zio.bdd.mock.*
+import zio.test.*
+
+import java.nio.file.{Files, Path}
+
+/**
+ * Exercises the full core port of [[EmbeddedRift]] over the live `librift_ffi`
+ * C-ABI: start the engine, provision an imposter on an OS-assigned port, serve
+ * + record a real HTTP round-trip, mutate rules (overlay / replace), and tear
+ * the space down. It is gated on [[EmbeddedRift.available]] — when the native
+ * library is not provisioned (no `-Drift.ffi.lib`), the case is skipped rather
+ * than failed, exactly like the Docker-gated container suite.
+ */
+object EmbeddedRiftFfiSpec extends ZIOSpecDefault:
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+
+  private val pingSource =
+    MockSource.Dsl(
+      MockSpec(
+        List(
+          MockRule(
+            RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+            ResponseDef(status = 200, body = Body.Text("pong"))
+          )
+        )
+      )
+    )
+
+  private def v2Rule =
+    MockRule(RequestMatch(path = PathMatch.Exact("/v2")), ResponseDef(status = 200, body = Body.Text("v2")))
+
+  // A valid raw Rift imposter document (no port — the adapter forces an OS-assigned one).
+  private val goodRaw =
+    """{"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/a"}}],"responses":[{"is":{"statusCode":200,"body":"a"}}]}]}"""
+
+  // A raw native imposter serving GET /native — used to verify native stubs survive rule mutation.
+  private val nativeRaw =
+    """{"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/native"}}],"responses":[{"is":{"statusCode":200,"body":"native!"}}]}]}"""
+
+  // A temp directory with one valid and one malformed imposter file; sorted, the good one provisions
+  // first, then the bad one fails — exercising the multi-source rollback. Cleaned up with the scope.
+  private def tempDirWithGoodAndBad: ZIO[Scope, Throwable, Path] =
+    ZIO.acquireRelease(
+      ZIO.attemptBlocking {
+        val dir = Files.createTempDirectory("embedded-rollback")
+        Files.writeString(dir.resolve("a-good.json"), goodRaw)
+        Files.writeString(dir.resolve("b-bad.json"), "this is not json")
+        dir
+      }
+    )(dir =>
+      ZIO.attemptBlocking {
+        Files.deleteIfExists(dir.resolve("a-good.json"))
+        Files.deleteIfExists(dir.resolve("b-bad.json"))
+        Files.deleteIfExists(dir)
+      }.ignore
+    )
+
+  def spec = suite("EmbeddedRiftFfi")(
+    test("core lifecycle over FFM: provision → serve → record → mutate → destroy") {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes) // skipped: no native library
+      else
+        (for
+          control <- ZIO.service[MockControl]
+          spaces  <- control.provision(pingSource).mapError(asT)
+          space    = spaces.head
+          resp    <- SutClient.make(space).send(Method.Get, "/ping")
+          recv    <- control.received(space).mapError(asT)
+          // overlay then replace: both realised as a whole-imposter rift_replace_stubs
+          _    <- control.addRule(space, v2Rule, Priority.Overlay).mapError(asT)
+          v2   <- SutClient.make(space).send(Method.Get, "/v2")
+          _    <- control.replaceRules(space, List(v2Rule)).mapError(asT)
+          oldR <- SutClient.make(space).send(Method.Get, "/ping")
+          newR <- SutClient.make(space).send(Method.Get, "/v2")
+          _    <- control.destroy(space).mapError(asT)
+          gone <- control.received(space).either
+        yield assertTrue(
+          resp.status == 200,
+          resp.body == "pong",
+          recv.exists(_.uri == "/ping"),
+          v2.status == 200 && v2.body == "v2",
+          oldR.status == 404, // replaceRules dropped the /ping rule
+          newR.status == 200 && newR.body == "v2",
+          gone == Left(MockError.SpaceNotFound(space.id)) // ops on a destroyed space fail SpaceNotFound
+        )).provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
+    },
+    test("provisionNative: a raw Rift imposter serves, and an overlay reverts to its native stub") {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
+      else
+        (for
+          control <- ZIO.service[MockControl]
+          a       <- control.provisionNative(NativeSpec.Rift(nativeRaw)).mapError(asT).map(_.head)
+          served  <- SutClient.make(a).send(Method.Get, "/native")
+          ovId <- control
+                    .addRule(
+                      a,
+                      MockRule(
+                        RequestMatch(path = PathMatch.Exact("/native")),
+                        ResponseDef(status = 200, body = Body.Text("overlaid"))
+                      ),
+                      Priority.Overlay
+                    )
+                    .mapError(asT)
+          overlaid <- SutClient.make(a).send(Method.Get, "/native")
+          _        <- control.removeRule(a, ovId).mapError(asT)
+          reverted <- SutClient.make(a).send(Method.Get, "/native")
+          _        <- control.destroy(a).mapError(asT)
+        yield assertTrue(
+          served.status == 200 && served.body == "native!",
+          overlaid.status == 200 && overlaid.body == "overlaid", // overlay shadows the native stub
+          reverted.status == 200 && reverted.body == "native!"   // native stub preserved across mutation
+        )).provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
+    },
+    test("provisionNative: a WireMock spec is rejected with InvalidDefinition") {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
+      else
+        (for
+          control  <- ZIO.service[MockControl]
+          rejected <- control.provisionNative(NativeSpec.WireMock("{}")).either
+        yield assertTrue(rejected match
+          case Left(_: MockError.InvalidDefinition) => true
+          case _                                    => false
+        )).provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
+    },
+    test("provision is atomic: a failed source in a multi-source Dir rolls back the served spaces") {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
+      else
+        ZIO
+          .scoped(for
+            dir     <- tempDirWithGoodAndBad
+            control <- ZIO.service[MockControl]
+            // a-good provisions, then b-bad fails → the whole provision fails and a-good is torn down.
+            result <- control.provision(MockSource.Dir(dir.toString)).either
+          yield assertTrue(result.isLeft))
+          .provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
+    }
+  ) @@ TestAspect.withLiveClock


### PR DESCRIPTION
`MockControl.embedded` — the opt-in, no-Docker, in-process Rift provider — driving the engine over the `librift_ffi` C-ABI via Project Panama FFM, behind the same `MockControl` interface. A pure backend swap for the container adapter: it shares the `RiftProtocol` JSON codec, binds imposters on OS-assigned localhost ports (no port mapping), and wraps the blocking downcalls in `ZIO.attemptBlocking` with a `Scoped` layer (`rift_start` on acquire, `rift_stop` on release).

The full M1 core conformance suite passes against `MockControl.embedded` with no test changes; it advertises no optional capabilities (the C-ABI exposes none of their endpoints), so capability scenarios negotiate a justified SKIP. The native library is downloaded + checksum-verified per host triple by the build and gated on presence. Requires JDK 21 (FFM preview).

Closes #133

Milestone: M4