### PR TITLE
feat: native lib packaging/loading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,12 @@ jobs:
       # be dlopen'd without it present — matches the Rift project's own FFI CI.
       - name: Install LuaJIT
         run: sudo apt-get update && sudo apt-get install -y libluajit-5.1-dev
-      # downloadRiftFfi fetches + checksum-verifies the per-host-triple native library; the forked
-      # test JVMs run with --enable-preview + --enable-native-access (set in embeddedNativeSettings).
+      # The librift_ffi cdylibs are bundled by the zio-bdd-rift-embedded-natives jar (a test dep of
+      # the embedded suites), downloaded + checksum-verified by its resourceGenerator; the loader
+      # extracts + loads the host's lib from the classpath out-of-the-box — no -Drift.ffi.lib. The
+      # forked test JVMs run with --enable-preview + --enable-native-access (embeddedNativeSettings).
       - name: Embedded smoke + portable conformance against MockControl.embedded
         run: >-
-          sbt rift/downloadRiftFfi conformance/downloadRiftFfi
-          "rift/testOnly zio.bdd.mock.rift.embedded.EmbeddedRiftFfiSpec"
+          sbt
+          "rift/testOnly zio.bdd.mock.rift.embedded.EmbeddedRiftFfiSpec zio.bdd.mock.rift.embedded.NativeLibrarySpec"
           "conformance/testOnly zio.bdd.mock.conformance.EmbeddedConformanceSpec"

--- a/build.sbt
+++ b/build.sbt
@@ -6,36 +6,56 @@ import java.net.URI
 import java.nio.file.{Files => JFiles, StandardCopyOption}
 import java.security.MessageDigest
 
-// ---- librift_ffi native library provisioning (embedded adapter, #133) ----------------------
-// The embedded MockControl drives Rift in-process over the librift_ffi C-ABI via Panama FFM. The
-// prebuilt shared library ships per host triple on the Rift GitHub release; the conformance gate
-// downloads + checksum-verifies it and passes its path to the forked test JVM. FFM is a preview
-// API on JDK 21, so those JVMs run with --enable-preview + --enable-native-access.
+// ---- librift_ffi native library packaging (#134) -------------------------------------------
+// The embedded adapter loads librift_ffi from the classpath: the zio-bdd-rift-embedded-natives jar
+// bundles the per-platform cdylibs as resources (native/<os>-<arch>/librift_ffi.<ext>), downloaded
+// + checksum-verified from the Rift release at build time. The runtime loader extracts the host's
+// lib to a temp file and loads it via Panama — no manual install, no system property. (FFM is a
+// preview API on JDK 21, so the embedded code stays JDK-21-gated; see embeddedNativeSettings.)
+// NOTE: build.sbt is compiled with the Scala 2.12 dialect — keep these blocks 2.12-compatible.
 
-lazy val riftFfiVersion  = settingKey[String]("Rift release tag providing librift_ffi")
-lazy val riftFfiLibFile  = settingKey[File]("Host-resolved path to the downloaded librift_ffi library")
-lazy val downloadRiftFfi = taskKey[File]("Download + checksum-verify librift_ffi for the host triple")
+val riftNativesVersion = "0.7.0"
 
-// The release asset name for the host OS/arch, or None on an unsupported platform (tests then skip).
-// NOTE: build.sbt is compiled with the Scala 2.12 dialect — keep this block 2.12-compatible.
-def riftFfiAssetName: Option[String] = {
-  val os = sys.props.getOrElse("os.name", "").toLowerCase
-  val arch = sys.props.getOrElse("os.arch", "").toLowerCase match {
-    case "aarch64" | "arm64" => "aarch64"
-    case "x86_64" | "amd64"  => "x86_64"
-    case other               => other
-  }
-  if (os.contains("mac") || os.contains("darwin")) Some(s"librift_ffi-darwin-$arch.dylib")
-  else if (os.contains("linux")) Some(s"librift_ffi-linux-$arch.so")
-  else if (os.contains("win")) Some(s"librift_ffi-windows-$arch.dll")
-  else None
-}
-
-def riftFfiLibTarget(targetDir: File): File =
-  targetDir / "native" / riftFfiAssetName.getOrElse("librift_ffi.unavailable")
+// The (os, arch, ext) cdylibs bundled into the natives jar — linux/macOS × x86_64/aarch64 (#134).
+val riftNativeTriples: Seq[(String, String, String)] = Seq(
+  ("linux", "x86_64", "so"),
+  ("linux", "aarch64", "so"),
+  ("darwin", "x86_64", "dylib"),
+  ("darwin", "aarch64", "dylib")
+)
 
 def sha256Hex(f: File): String =
   MessageDigest.getInstance("SHA-256").digest(JFiles.readAllBytes(f.toPath)).map(b => f"$b%02x").mkString
+
+// Download `asset` from the Rift release to `out`, verifying it against the sibling .sha256.
+// Idempotent: skips the download when `out` already matches the expected checksum. Returns `out`.
+def downloadRiftAsset(version: String, asset: String, out: File, log: sbt.util.Logger): File = {
+  val base = s"https://github.com/EtaCassiopeia/rift/releases/download/v$version"
+  val expected = {
+    val in = URI.create(s"$base/$asset.sha256").toURL.openStream()
+    try new String(in.readAllBytes(), "UTF-8").trim.split("\\s+").head
+    finally in.close()
+  }
+  if (out.exists() && sha256Hex(out) == expected) {
+    log.info(s"[rift-ffi] cached $asset")
+  } else {
+    JFiles.createDirectories(out.toPath.getParent)
+    log.info(s"[rift-ffi] downloading $asset (v$version) ...")
+    // Download to a sibling temp file and atomically move into place only after the checksum passes,
+    // so `out` never exists in a corrupt/partial state (the idempotency guard above trusts it).
+    val tmp = new File(out.getParentFile, s".${out.getName}.part")
+    try {
+      val in = URI.create(s"$base/$asset").toURL.openStream()
+      try JFiles.copy(in, tmp.toPath, StandardCopyOption.REPLACE_EXISTING)
+      finally in.close()
+      val got = sha256Hex(tmp)
+      if (got != expected) sys.error(s"[rift-ffi] checksum mismatch for $asset: got $got, expected $expected")
+      JFiles.move(tmp.toPath, out.toPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+      log.info(s"[rift-ffi] downloaded + verified $asset")
+    } finally if (tmp.exists()) tmp.delete()
+  }
+  out
+}
 
 // The major version of the JDK building this project. FFM (java.lang.foreign) is a preview API on
 // 21 and absent before it, so the embedded adapter's sources only compile on 21+. The project's
@@ -59,51 +79,36 @@ lazy val embeddedNativeSettings: Seq[Def.Setting[_]] =
       Test / unmanagedSourceDirectories += (Test / sourceDirectory).value / "jdk21",
       // The Java FFM bridge uses the preview Foreign Function & Memory API.
       javacOptions ++= Seq("--release", "21", "--enable-preview"),
-      riftFfiVersion := "0.7.0",
-      riftFfiLibFile := riftFfiLibTarget(target.value),
-  downloadRiftFfi := {
-    val log     = streams.value.log
-    val version = riftFfiVersion.value
-    val out     = riftFfiLibFile.value
-    riftFfiAssetName match {
-      case None =>
-        log.warn(
-          s"[rift-ffi] no prebuilt librift_ffi for ${sys.props.getOrElse("os.name", "?")}/" +
-            s"${sys.props.getOrElse("os.arch", "?")}; embedded tests will be skipped"
-        )
-        out
-      case Some(asset) =>
-        val base = s"https://github.com/EtaCassiopeia/rift/releases/download/v$version"
-        val expected = {
-          val in = URI.create(s"$base/$asset.sha256").toURL.openStream()
-          try new String(in.readAllBytes(), "UTF-8").trim.split("\\s+").head
-          finally in.close()
-        }
-        if (out.exists() && sha256Hex(out) == expected) {
-          log.info(s"[rift-ffi] using cached $asset")
-          out
-        } else {
-          JFiles.createDirectories(out.toPath.getParent)
-          log.info(s"[rift-ffi] downloading $asset (v$version) ...")
-          val in = URI.create(s"$base/$asset").toURL.openStream()
-          try JFiles.copy(in, out.toPath, StandardCopyOption.REPLACE_EXISTING)
-          finally in.close()
-          val got = sha256Hex(out)
-          if (got != expected) sys.error(s"[rift-ffi] checksum mismatch for $asset: got $got, expected $expected")
-          log.info(s"[rift-ffi] downloaded + verified $asset")
-          out
-        }
-    }
-  },
-  Test / fork := true,
-  Test / javaOptions ++= Seq(
-    "--enable-preview",
-    "--enable-native-access=ALL-UNNAMED",
-    s"-Drift.ffi.lib=${riftFfiLibFile.value.getAbsolutePath}"
-  ),
-  // Ensure the native library is present (and verified) before the forked test JVM starts.
-  (Test / test) := (Test / test).dependsOn(downloadRiftFfi).value
-)
+      Test / fork := true,
+      // FFM is preview on JDK 21; the native library is on the test classpath via the
+      // embeddedNatives test dependency (the loader extracts + loads it — no -Drift.ffi.lib needed).
+      Test / javaOptions ++= Seq("--enable-preview", "--enable-native-access=ALL-UNNAMED")
+    )
+
+// The bundled per-platform natives (#134): a pure-resources jar that packages the librift_ffi
+// cdylibs (downloaded + checksum-verified at build time) so MockControl.embedded loads them from
+// the classpath out-of-the-box. No Scala/Java code; a test dependency of the embedded suites, not
+// aggregated into the JDK-11 unit build. The download is gated on a 21+ JDK (where embedded is
+// actually built/used), so the JDK-11 build never pulls the ~60MB native artifacts; a publish that
+// ships them therefore runs on a 21+ JDK (the same one that builds the embedded code).
+lazy val embeddedNatives = (project in file("embedded-natives"))
+  .settings(
+    name             := "zio-bdd-rift-embedded-natives",
+    crossPaths       := false,
+    autoScalaLibrary := false,
+    Compile / resourceGenerators ++= (
+      if (!ffmEnabled) Nil
+      else
+        Seq(Def.task {
+          val log = streams.value.log
+          val dir = (Compile / resourceManaged).value
+          riftNativeTriples.map { case (os, arch, ext) =>
+            downloadRiftAsset(riftNativesVersion, s"librift_ffi-$os-$arch.$ext", dir / "native" / s"$os-$arch" / s"librift_ffi.$ext", log)
+          }
+        }.taskValue)
+    ),
+    mimaPreviousArtifacts := Set.empty
+  )
 
 inThisBuild(
   List(
@@ -243,24 +248,31 @@ lazy val mock = (project in file("mock"))
 // (Mountebank-compatible) backend. Drives the admin API via zio-http and can
 // stand up the published image via testcontainers. Depends on `mock`, never the
 // reverse.
-lazy val rift = (project in file("rift"))
-  .dependsOn(mock)
-  .settings(
-    name := "zio-bdd-rift",
-    libraryDependencies ++= commonDependencies,
-    libraryDependencies ++= Seq(
-      "dev.zio"      %% "zio-http"                   % "3.2.0",
-      "dev.zio"      %% "zio-json"                   % "0.7.3",
-      "com.dimafeng" %% "testcontainers-scala-core"  % "0.41.4"
-    ),
-    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
-    // The embedded adapter (#133) lives in JDK-21-only source dirs (src/{main,test}/jdk21) and is
-    // compiled with --release 21 --enable-preview — added by embeddedNativeSettings only on a 21+ JDK,
-    // so on the JDK-11 baseline the rift module builds (and publishes) without the FFM bridge.
-    embeddedNativeSettings,
-    // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
-    mimaPreviousArtifacts := Set.empty
-  )
+lazy val rift = {
+  // Explicit Project(id, base): inside this block the `project` macro would otherwise infer the id
+  // from the local `base` val (colliding with conformance), so pin it.
+  val base = Project("rift", file("rift"))
+    .dependsOn(mock)
+    .settings(
+      name := "zio-bdd-rift",
+      libraryDependencies ++= commonDependencies,
+      libraryDependencies ++= Seq(
+        "dev.zio"      %% "zio-http"                   % "3.2.0",
+        "dev.zio"      %% "zio-json"                   % "0.7.3",
+        "com.dimafeng" %% "testcontainers-scala-core"  % "0.41.4"
+      ),
+      testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+      // The embedded adapter (#133) lives in JDK-21-only source dirs (src/{main,test}/jdk21) and is
+      // compiled with --release 21 --enable-preview — added by embeddedNativeSettings only on a 21+ JDK,
+      // so on the JDK-11 baseline the rift module builds (and publishes) without the FFM bridge.
+      embeddedNativeSettings,
+      // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
+      mimaPreviousArtifacts := Set.empty
+    )
+  // The embedded smoke suite (JDK 21) loads librift_ffi from the bundled natives jar on its test
+  // classpath (#134); gated so the JDK-11 build never pulls the ~60MB native artifacts.
+  if (ffmEnabled) base.dependsOn(embeddedNatives % Test) else base
+}
 
 // WireMock adapter (#122): the in-process, pure-JVM, zero-Docker provider with
 // Correlated isolation by default. Implements the portable MockControl SPI over
@@ -281,18 +293,21 @@ lazy val wiremock = (project in file("wiremock"))
 // Conformance harness + matrix runner (#124): the executable definition of
 // "implements MockControl". The only module that depends on BOTH adapters, so it
 // can run one feature set across Rift + WireMock and emit the pass/skip/fail matrix.
-lazy val conformance = (project in file("conformance"))
-  .dependsOn(core, rift, wiremock)
-  .settings(
-    name := "zio-bdd-conformance",
-    libraryDependencies ++= commonDependencies,
-    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
-    // The conformance matrix runs the portable scenarios against MockControl.embedded (#133), which
-    // drives Rift in-process via FFM — so the forked test JVM needs the native library + preview.
-    embeddedNativeSettings,
-    publish / skip        := true, // a test harness, not a published artifact
-    mimaPreviousArtifacts := Set.empty
-  )
+lazy val conformance = {
+  val base = Project("conformance", file("conformance"))
+    .dependsOn(core, rift, wiremock)
+    .settings(
+      name := "zio-bdd-conformance",
+      libraryDependencies ++= commonDependencies,
+      testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+      // The portable conformance suites run against MockControl.embedded (#133/#134) on JDK 21,
+      // loading librift_ffi from the bundled natives jar on the test classpath.
+      embeddedNativeSettings,
+      publish / skip        := true, // a test harness, not a published artifact
+      mimaPreviousArtifacts := Set.empty
+    )
+  if (ffmEnabled) base.dependsOn(embeddedNatives % Test) else base
+}
 
 lazy val example = (project in file("example"))
   .dependsOn(core)

--- a/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
+++ b/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
@@ -3,7 +3,7 @@ package zio.bdd.mock.rift.embedded
 import zio.*
 import zio.bdd.mock.{MockControl, MockError, Provisioning}
 
-import java.nio.file.{Files, Paths}
+import java.nio.file.{Files, Path, StandardCopyOption}
 
 /**
  * Entry point for `MockControl.embedded` (#133): the opt-in, no-Docker,
@@ -11,10 +11,12 @@ import java.nio.file.{Files, Paths}
  * FFM behind the portable [[MockControl]] interface — a pure backend swap for
  * the container adapter.
  *
- * The native library is located via the `rift.ffi.lib` system property (falling
- * back to the `RIFT_FFI_LIB` environment variable). [[available]] reports
- * whether that path resolves to a real file, so a harness can park the backend
- * (rather than fail) on a platform where the library has not been provisioned.
+ * The native library loads out-of-the-box (#134): [[NativeLibrary]] resolves it
+ * from an explicit `-Drift.ffi.lib` override or the per-platform cdylib bundled
+ * in the `zio-bdd-rift-embedded-natives` jar; a bundled resource is extracted
+ * to a temp file and loaded. [[available]] reports whether a library resolves
+ * for the host, so a harness can park the backend (rather than fail) on an
+ * unsupported platform.
  *
  * Requires Project Panama FFM, a preview API on JDK 21: the host JVM must run
  * with `--enable-preview` (and `--enable-native-access` to silence the
@@ -23,47 +25,45 @@ import java.nio.file.{Files, Paths}
 object EmbeddedRift:
 
   /**
-   * System property naming the absolute path to the `librift_ffi` shared
-   * library.
+   * True iff a `librift_ffi` resolves for the host (a bundled native resource,
+   * or an override path).
    */
-  val LibPathProperty = "rift.ffi.lib"
-
-  /**
-   * Environment variable naming the `librift_ffi` shared library (fallback for
-   * the property).
-   */
-  val LibPathEnv = "RIFT_FFI_LIB"
-
-  /**
-   * The configured native-library path, if set (property takes precedence over
-   * the env var).
-   */
-  def libPath: Option[String] =
-    sys.props.get(LibPathProperty).orElse(sys.env.get(LibPathEnv)).map(_.trim).filter(_.nonEmpty)
-
-  /**
-   * True iff the native library path is configured and points to an existing
-   * regular file.
-   */
-  def available: Boolean =
-    libPath.exists(p => Files.isRegularFile(Paths.get(p)))
+  def available: Boolean = NativeLibrary.available
 
   /**
    * A scoped [[MockControl]] backed by the in-process Rift engine: `rift_start`
    * on layer construction, `rift_stop` on close. Fails with
-   * [[MockError.ProvisionFailed]] if the native library path is not configured
-   * or cannot be loaded.
+   * [[MockError.ProvisionFailed]] when no native library resolves for the host,
+   * or it cannot be loaded.
    */
   def layer: ZLayer[Provisioning, MockError, MockControl] =
     ZLayer.scoped {
       for
-        prov <- ZIO.service[Provisioning]
-        path <- ZIO
-                  .fromOption(libPath)
-                  .orElseFail(
-                    MockError.ProvisionFailed(s"native library path not set; set -D$LibPathProperty or $LibPathEnv")
-                  )
-        engine  <- RiftFfi.start(path)
+        prov    <- ZIO.service[Provisioning]
+        source  <- ZIO.fromEither(NativeLibrary.resolveSource)
+        path    <- loadablePath(source)
+        engine  <- RiftFfi.start(path.toString)
         control <- EmbeddedRiftMockControl.make(engine, prov)
       yield control
     }
+
+  // An override is already a real path; a bundled resource is extracted to a temp file (removed when
+  // the JVM exits — the engine keeps the loaded library mapped, so the file is no longer needed).
+  private def loadablePath(source: LibSource): IO[MockError, Path] =
+    source match
+      case LibSource.Override(p) => ZIO.succeed(p)
+      case LibSource.Bundled(resource) =>
+        ZIO.attemptBlocking {
+          val in = getClass.getClassLoader.getResourceAsStream(resource)
+          if in == null then throw new IllegalStateException(s"bundled native resource not found: $resource")
+          try
+            val suffix = resource.substring(resource.lastIndexOf('.'))
+            val tmp    = Files.createTempFile("librift_ffi-", suffix)
+            tmp.toFile.deleteOnExit()
+            Files.copy(in, tmp, StandardCopyOption.REPLACE_EXISTING)
+            tmp
+          finally in.close()
+        }.mapError { t =>
+          val msg = Option(t.getMessage).filter(_.nonEmpty).fold("")(m => s": $m")
+          MockError.ProvisionFailed(s"extracting bundled native '$resource': ${t.getClass.getSimpleName}$msg")
+        }

--- a/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/NativeLibrary.scala
+++ b/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/NativeLibrary.scala
@@ -1,0 +1,156 @@
+package zio.bdd.mock.rift.embedded
+
+import zio.bdd.mock.MockError
+
+import java.nio.file.{Files, Path, Paths}
+
+/**
+ * Where a `librift_ffi` to load comes from: an explicit override path, or a
+ * bundled classpath resource.
+ */
+private[embedded] enum LibSource:
+  case Override(path: Path)
+  case Bundled(resource: String)
+
+/**
+ * Locates the `librift_ffi` native library for the host platform (#134),
+ * resolved in order:
+ *
+ *   1. an explicit `-Drift.ffi.lib` system property (or `RIFT_FFI_LIB` env var)
+ *      pointing at a file — the escape hatch for a custom/local build; 2. the
+ *      per-platform cdylib bundled as a classpath resource
+ *      (`native/<os>-<arch>/librift_ffi.<ext>`) by the
+ *      `zio-bdd-rift-embedded-natives` jar.
+ *
+ * When neither resolves — an unsupported host, or the natives jar absent from
+ * the classpath — it returns a clear [[MockError.ProvisionFailed]] rather than
+ * failing obscurely at `dlopen`.
+ *
+ * [[resolveSourceFor]] is the pure, host-parameterised core (so resolution +
+ * bundled-resource presence are unit-testable without depending on the live
+ * host); extraction of a bundled resource to a temp file is an effect owned by
+ * [[EmbeddedRift]].
+ */
+private[embedded] object NativeLibrary:
+
+  /**
+   * System property naming an explicit path to a `librift_ffi` shared library
+   * (overrides bundling).
+   */
+  val LibPathProperty = "rift.ffi.lib"
+
+  /**
+   * Environment variable naming an explicit `librift_ffi` path (fallback for
+   * the property).
+   */
+  val LibPathEnv = "RIFT_FFI_LIB"
+
+  /**
+   * The raw configured override (property over env var), or `None` if neither
+   * is set/non-empty.
+   */
+  def configuredOverride: Option[String] =
+    sys.props.get(LibPathProperty).orElse(sys.env.get(LibPathEnv)).map(_.trim).filter(_.nonEmpty)
+
+  /**
+   * The (os, arch) triples the `zio-bdd-rift-embedded-natives` jar actually
+   * ships (#134).
+   */
+  val shippedTriples: Set[(String, String)] =
+    Set(("linux", "x86_64"), ("linux", "aarch64"), ("darwin", "x86_64"), ("darwin", "aarch64"))
+
+  /**
+   * Canonical OS token for the bundled-resource path, or `None` if unsupported.
+   */
+  def osToken(raw: String): Option[String] =
+    val s = raw.toLowerCase
+    if s.contains("mac") || s.contains("darwin") then Some("darwin")
+    else if s.contains("linux") then Some("linux")
+    else if s.contains("win") then Some("windows")
+    else None
+
+  /**
+   * Canonical architecture token for the bundled-resource path, or `None` if
+   * unsupported.
+   */
+  def archToken(raw: String): Option[String] =
+    raw.toLowerCase match
+      case "aarch64" | "arm64" => Some("aarch64")
+      case "x86_64" | "amd64"  => Some("x86_64")
+      case _                   => None
+
+  /** The shared-library extension for an OS token. */
+  def libExtension(os: String): Option[String] =
+    os match
+      case "linux"   => Some("so")
+      case "darwin"  => Some("dylib")
+      case "windows" => Some("dll")
+      case _         => None
+
+  /**
+   * The bundled classpath resource path for a host triple (independent of
+   * whether it is present).
+   */
+  def resourceFor(os: String, arch: String): Option[String] =
+    libExtension(os).map(ext => s"native/$os-$arch/librift_ffi.$ext")
+
+  private def resourceExists(resource: String): Boolean =
+    getClass.getClassLoader.getResource(resource) != null
+
+  /**
+   * Resolve the library source for an explicit host OS/arch and raw configured
+   * override (the pure, testable core). An override takes precedence but must
+   * point at an existing file — a set-but-invalid override is a loud error,
+   * never a silent fall-through to bundling. Otherwise the bundled resource for
+   * the host is used; failing that, the message distinguishes a missing natives
+   * jar (a shipped triple) from a platform this project does not ship a native
+   * for.
+   */
+  def resolveSourceFor(osRaw: String, archRaw: String, ovr: Option[String]): Either[MockError, LibSource] =
+    ovr match
+      case Some(raw) =>
+        val p = Paths.get(raw)
+        if Files.isRegularFile(p) then Right(LibSource.Override(p))
+        else
+          Left(
+            MockError.ProvisionFailed(
+              s"-D$LibPathProperty is set to '$raw' but no regular file exists there; " +
+                s"fix the path or unset it to load the bundled library"
+            )
+          )
+      case None =>
+        (osToken(osRaw), archToken(archRaw)) match
+          case (Some(os), Some(arch)) =>
+            resourceFor(os, arch).filter(resourceExists) match
+              case Some(resource) => Right(LibSource.Bundled(resource))
+              case None if shippedTriples((os, arch)) =>
+                Left(
+                  MockError.ProvisionFailed(
+                    s"no bundled librift_ffi for host $os-$arch on the classpath; add the " +
+                      s"zio-bdd-rift-embedded-natives dependency, or set -D$LibPathProperty to a librift_ffi path"
+                  )
+                )
+              case None =>
+                Left(
+                  MockError.ProvisionFailed(
+                    s"embedded Rift ships no native library for host $os-$arch; " +
+                      s"set -D$LibPathProperty to a librift_ffi path"
+                  )
+                )
+          case _ =>
+            Left(
+              MockError.ProvisionFailed(
+                s"unsupported host platform '$osRaw'/'$archRaw' for embedded Rift; " +
+                  s"set -D$LibPathProperty to a librift_ffi path"
+              )
+            )
+
+  /** Resolve the library source for the live host. */
+  def resolveSource: Either[MockError, LibSource] =
+    resolveSourceFor(sys.props.getOrElse("os.name", ""), sys.props.getOrElse("os.arch", ""), configuredOverride)
+
+  /**
+   * True iff a library can be resolved for the host (an override, or a bundled
+   * resource).
+   */
+  def available: Boolean = resolveSource.isRight

--- a/rift/src/test/jdk21/zio/bdd/mock/rift/embedded/NativeLibrarySpec.scala
+++ b/rift/src/test/jdk21/zio/bdd/mock/rift/embedded/NativeLibrarySpec.scala
@@ -1,0 +1,64 @@
+package zio.bdd.mock.rift.embedded
+
+import zio.bdd.mock.MockError
+import zio.test.*
+
+import java.nio.file.Files
+
+/**
+ * Verifies the #134 native-library packaging + resolution: the bundled
+ * `zio-bdd-rift-embedded-natives` resources are present for every supported
+ * triple, a valid override takes precedence (and an invalid one is a loud
+ * error), and unsupported / unshipped hosts fail with a clear, host-specific
+ * error rather than an obscure `dlopen` failure.
+ */
+object NativeLibrarySpec extends ZIOSpecDefault:
+
+  // (os.name, os.arch, expected bundled resource) for each platform the natives jar must carry —
+  // including the `arm64` arch alias some JVMs report on Apple Silicon.
+  private val supportedTriples = List(
+    ("Linux", "amd64", "native/linux-x86_64/librift_ffi.so"),
+    ("Linux", "aarch64", "native/linux-aarch64/librift_ffi.so"),
+    ("Mac OS X", "x86_64", "native/darwin-x86_64/librift_ffi.dylib"),
+    ("Mac OS X", "aarch64", "native/darwin-aarch64/librift_ffi.dylib"),
+    ("Mac OS X", "arm64", "native/darwin-aarch64/librift_ffi.dylib")
+  )
+
+  def spec = suite("NativeLibrary")(
+    test("every supported triple resolves to its bundled resource (present on the classpath)") {
+      assertTrue(
+        supportedTriples.forall((os, arch, res) =>
+          NativeLibrary.resolveSourceFor(os, arch, None) == Right(LibSource.Bundled(res))
+        )
+      )
+    },
+    test("a valid override path takes precedence over bundling and is used verbatim") {
+      // Resolve strictly while the file exists, then clean up — assertTrue captures the expression and
+      // the runner evaluates it later, so a `finally`-delete would race the file-existence check.
+      val f      = Files.createTempFile("custom-librift_ffi-", ".so")
+      val result = NativeLibrary.resolveSourceFor("Linux", "amd64", Some(f.toString))
+      Files.deleteIfExists(f)
+      assertTrue(result == Right(LibSource.Override(f)))
+    },
+    test("a set-but-missing override path fails loudly (never a silent fall-through to bundling)") {
+      assertTrue(NativeLibrary.resolveSourceFor("Linux", "amd64", Some("/no/such/librift_ffi.so")) match
+        case Left(MockError.ProvisionFailed(m)) => m.contains("is set to '/no/such/librift_ffi.so'")
+        case _                                  => false
+      )
+    },
+    test("a recognized host this project ships no native for fails with a clear error (windows)") {
+      assertTrue(NativeLibrary.resolveSourceFor("Windows 11", "amd64", None) match
+        case Left(MockError.ProvisionFailed(m)) => m.contains("ships no native library for host windows-x86_64")
+        case _                                  => false
+      )
+    },
+    test("an unsupported host platform fails with a clear error") {
+      assertTrue(NativeLibrary.resolveSourceFor("Plan 9", "sparc", None) match
+        case Left(MockError.ProvisionFailed(m)) => m.contains("unsupported host platform")
+        case _                                  => false
+      )
+    },
+    test("the live host resolves out-of-the-box — no -Drift.ffi.lib override set, yet available") {
+      assertTrue(!sys.props.contains(NativeLibrary.LibPathProperty), EmbeddedRift.available)
+    }
+  )


### PR DESCRIPTION
Load the right `librift_ffi` per platform from a bundled resources jar at runtime, so `MockControl.embedded` works out-of-the-box on linux/macOS (x86_64 + aarch64) with no manual native-lib install and no `-Drift.ffi.lib`.

- New pure-resources module `zio-bdd-rift-embedded-natives` bundles the per-platform cdylibs as `native/<os>-<arch>/librift_ffi.<ext>` (downloaded + checksum-verified at build time).
- `NativeLibrary` resolves: explicit override (a loud, typed error if set-but-missing) → bundled classpath resource → clear `ProvisionFailed` when the host is unsupported/unshipped. The host's lib is extracted to a temp file and loaded via the existing Panama FFM bridge.
- JDK-21-gated throughout (FFM is preview on 21): the natives jar is a test dep of the embedded suites and its download is gated, so the JDK-11 baseline build never pulls the ~60MB artifacts.

The embedded smoke + portable conformance suites now load out-of-the-box (no `-Drift.ffi.lib`); `NativeLibrarySpec` proves all four triples are bundled and exercises the clear-error paths. Live load is verified on the CI host (linux-x86_64); the other three triples are bundle-verified.

Closes #134

Milestone: M4