### PR TITLE
fix: emit flat _rift.flowState.flowIdSource for Rift adapter (drop mountebankStateMapping wrapper)

### DIFF
--- a/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
@@ -52,12 +52,13 @@ object RiftMode:
  */
 object Rift:
 
-  // Pinned to v0.6.0. Floor is v0.4.0: Correlated isolation (#156) needs the
-  // space-scoped stub + per-space teardown endpoints (EtaCassiopeia/rift#223),
-  // first shipped in v0.4.0 — which also supersedes the older v0.2.0 floor (the
-  // rift#207 release where DELETE /imposters/:port tears down keep-alive
-  // connections so a destroyed imposter stops serving a pooled client).
-  val DefaultImage: String     = "zainalpour/rift-proxy:v0.6.0"
+  // Pinned to v0.8.0. Floor is v0.8.0: the adapter emits the flat
+  // `_rift.flowState.flowIdSource` shape (EtaCassiopeia/rift#266, #268), which
+  // Rift only reads from v0.8.0 on — earlier images expect the dropped
+  // `mountebankStateMapping` wrapper and return 404/empty on the correlated
+  // path. v0.8.0 also carries the v0.4.0 correlated-isolation endpoints (#223)
+  // and the v0.2.0 keep-alive teardown fix (#207).
+  val DefaultImage: String     = "zainalpour/rift-proxy:v0.8.0"
   val DefaultAdminPort: Int    = 2525
   val DefaultImposterBase: Int = 4545
   val DefaultPoolSize: Int     = 16

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -33,9 +33,9 @@ private[rift] object RiftProtocol:
   private def flowStateExt(flowIdSource: String): (String, Json) =
     "_rift" -> Json.Obj(
       "flowState" -> Json.Obj(
-        "backend"                -> Json.Str("inmemory"),
-        "ttlSeconds"             -> Json.Num(300),
-        "mountebankStateMapping" -> Json.Obj("flowIdSource" -> Json.Str(flowIdSource))
+        "backend"      -> Json.Str("inmemory"),
+        "ttlSeconds"   -> Json.Num(300),
+        "flowIdSource" -> Json.Str(flowIdSource)
       )
     )
 
@@ -59,8 +59,7 @@ private[rift] object RiftProtocol:
    * source of `header:<correlationHeader>`, so Rift resolves each request's
    * flow + gates stubs/recorded requests by that header natively (rift#223).
    * The flow-state config is a backend-native extension, so it lives under
-   * `_rift.flowState`
-   * (`imposter.config.rift.flowState.mountebankStateMapping.flowIdSource`).
+   * `_rift.flowState` (`imposter.config.rift.flowState.flowIdSource`).
    */
   def correlatedImposter(port: Int, name: String, correlationHeader: String): Json =
     Json.Obj(

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
@@ -58,7 +58,16 @@ object RiftProtocolSpec extends ZIOSpecDefault:
         arr(j / "stubs").size == 1,
         // an in-memory flow store keyed by port, so scenario stubs added later actually advance
         j / "_rift" / "flowState" / "backend" == Json.Str("inmemory"),
-        j / "_rift" / "flowState" / "mountebankStateMapping" / "flowIdSource" == Json.Str("imposter_port")
+        // flowIdSource sits directly under flowState; the mountebankStateMapping wrapper is gone (rift#266)
+        j / "_rift" / "flowState" / "flowIdSource" == Json.Str("imposter_port"),
+        field(j / "_rift" / "flowState", "mountebankStateMapping").isEmpty
+      )
+    },
+    test("correlatedImposter emits flowIdSource header:<h> directly under flowState; no wrapper (rift#266)") {
+      val j = RiftProtocol.correlatedImposter(4600, "correlated", "X-Mock-Space")
+      assertTrue(
+        j / "_rift" / "flowState" / "flowIdSource" == Json.Str("header:X-Mock-Space"),
+        field(j / "_rift" / "flowState", "mountebankStateMapping").isEmpty
       )
     },
     test("an exact path + method rule becomes equals predicates and an `is` response") {


### PR DESCRIPTION
Updates the Rift adapter to Rift's flat flow-state shape: `flowIdSource` now sits directly under `_rift.flowState` instead of the removed `mountebankStateMapping` wrapper (rift#266 / EtaCassiopeia/rift#268). The change lives in the single producer `flowStateExt`, so both the per-instance (`imposter_port`) and correlated (`header:<h>`) paths emit the flat shape. No backward-compat is needed — the correlated-isolation feature is unpublished and Rift dropped the legacy alias entirely.

Tests assert the flat path and that the wrapper key is gone, on both the imposter and correlatedImposter paths.

Closes #181

Ref: EtaCassiopeia/rift#266, EtaCassiopeia/rift#268