### PR TITLE
Embedded (FFI) Rift adapter advertises no capabilities; container advertises all six — transport parity gap

### DIFF
--- a/conformance/src/test/jdk21/zio/bdd/mock/conformance/EmbeddedConformanceSpec.scala
+++ b/conformance/src/test/jdk21/zio/bdd/mock/conformance/EmbeddedConformanceSpec.scala
@@ -18,19 +18,25 @@ import zio.test.*
  *
  * `Matrix.conformant(embedded)` is the full acceptance condition for a suite:
  * with the library present, the core scenarios (which require no capability)
- * must PASS and the capability scenarios SKIP-justified (embedded advertises
- * none); with it absent, the whole column is SKIPPED-unavailable (also
- * conformant). So one assertion gates each catalogue.
+ * must PASS, the stub-based capability scenarios (faults/scripting/templating,
+ * #185) must PASS against the live engine, and the stateful scenarios
+ * SKIP-justified (embedded advertises no StatefulScenarios/StateInspection —
+ * the C-ABI has no scenario-state endpoints); with the library absent, the
+ * whole column is SKIPPED-unavailable (also conformant). So one assertion gates
+ * each catalogue.
  */
 object EmbeddedConformanceSpec extends ZIOSpecDefault:
 
   private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
 
+  // The embedded adapter advertises the four stub-based capabilities (#185); StatefulScenarios
+  // and StateInspection stay out of scope (no scenario-state endpoints over the C-ABI). This must
+  // mirror EmbeddedRiftMockControl.capabilities so the harness runs the supported catalogues live.
   private val embedded =
     MockBackendUnderTest(
       "embedded",
       Provisioning.live >>> EmbeddedRift.layer.mapError(asT),
-      Set.empty,
+      Set(Capability.Faults, Capability.Scripting, Capability.ProxyRecord, Capability.Templating),
       Isolation.PerInstance,
       available = EmbeddedRift.available
     )

--- a/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
+++ b/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
@@ -22,9 +22,19 @@ import zio.json.ast.Json
  * whole-imposter `rift_replace_stubs` (first-match order: overlay prepends,
  * base appends). It is PerInstance only — one imposter per space on its own
  * OS-assigned localhost port (the host allocates a free port, the engine binds
- * it directly; no container port-mapping) — and advertises no optional
- * capabilities (the C-ABI exposes none of the scenario-state endpoints they
- * need), so capability scenarios negotiate a justified SKIP.
+ * it directly; no container port-mapping).
+ *
+ * The stub-based optional capabilities — [[Faults]], [[Scripting]],
+ * [[ProxyRecord]], [[Templating]] — need no transport beyond
+ * `rift_replace_stubs` (each is a special-response stub the engine serves
+ * natively), so they are wired the same way the container adapter wires them
+ * over the admin API: the capability stub is tracked in `imp.extras` and
+ * re-registered ahead of the space's rules on every rebuild, so it wins
+ * first-match and is removable via [[removeRule]]. [[StatefulScenarios]] and
+ * [[StateInspection]] stay unsupported: they require the scenario-state
+ * endpoints (pin/read/reset the initial state) the C-ABI does not expose. So
+ * the embedded capability set is deliberately those four; the two stateful
+ * capabilities negotiate a justified SKIP.
  */
 private[embedded] final case class EmbeddedRiftMockControl(
   engine: EmbeddedEngine,
@@ -35,8 +45,9 @@ private[embedded] final case class EmbeddedRiftMockControl(
 
   import EmbeddedRiftMockControl.Imposter
 
-  def backendName: String           = "embedded"
-  def capabilities: Set[Capability] = Set.empty
+  def backendName: String = "embedded"
+  def capabilities: Set[Capability] =
+    Set(Capability.Faults, Capability.Scripting, Capability.ProxyRecord, Capability.Templating)
 
   def provision(source: MockSource): IO[MockError, List[MockSpace]] =
     for
@@ -62,33 +73,42 @@ private[embedded] final case class EmbeddedRiftMockControl(
       for
         ruleId <- freshId
         cur    <- imp.rules.get
+        extras <- imp.extras.get
         // First match wins: an overlay sits on top (index 0), a base rule is appended.
         next = priority match
                  case Priority.Overlay => (ruleId, rule) +: cur
                  case Priority.Base    => cur :+ (ruleId, rule)
         // Server-first, commit tracking on success — so a failed downcall never leaves the Ref
         // claiming a rule the engine didn't accept.
-        _ <- rebuild(imp, next)
+        _ <- rebuild(imp, extras, next)
         _ <- imp.rules.set(next)
       yield ruleId
     }
 
   def removeRule(space: MockSpace, id: RuleId): IO[MockError, Unit] =
     withImposter(space) { imp =>
-      imp.rules.get.flatMap { cur =>
-        if !cur.exists(_._1 == id) then ZIO.fail(MockError.RuleNotFound(space.id, id))
-        else
-          val next = cur.filterNot(_._1 == id)
-          rebuild(imp, next) *> imp.rules.set(next)
-      }
+      for
+        rules  <- imp.rules.get
+        extras <- imp.extras.get
+        // commit tracking only on success; a removed id is a rule or a capability stub
+        _ <-
+          if rules.exists(_._1 == id) then
+            val next = rules.filterNot(_._1 == id)
+            rebuild(imp, extras, next) *> imp.rules.set(next)
+          else if extras.exists(_._1 == id) then
+            val nextE = extras.filterNot(_._1 == id)
+            rebuild(imp, nextE, rules) *> imp.extras.set(nextE)
+          else ZIO.fail(MockError.RuleNotFound(space.id, id))
+      yield ()
     }
 
   def replaceRules(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit] =
     withImposter(space) { imp =>
       for
-        next <- tagRules(rules)
-        _    <- rebuild(imp, next)
-        _    <- imp.rules.set(next)
+        next   <- tagRules(rules)
+        extras <- imp.extras.get
+        _      <- rebuild(imp, extras, next)
+        _      <- imp.rules.set(next)
       yield ()
     }
 
@@ -110,12 +130,51 @@ private[embedded] final case class EmbeddedRiftMockControl(
         )
     }
 
-  def faults: IO[Unsupported, Faults]                   = unsupported(Capability.Faults)
+  def faults: IO[Unsupported, Faults]           = ZIO.succeed(embeddedFaults)
+  def scripting: IO[Unsupported, Scripting]     = ZIO.succeed(embeddedScripting)
+  def proxyRecord: IO[Unsupported, ProxyRecord] = ZIO.succeed(embeddedProxyRecord)
+  def templating: IO[Unsupported, Templating]   = ZIO.succeed(embeddedTemplating)
+
+  // No scenario-state endpoints over the C-ABI (see the class doc), so these stay unsupported.
   def scenarios: IO[Unsupported, StatefulScenarios]     = unsupported(Capability.StatefulScenarios)
   def stateInspection: IO[Unsupported, StateInspection] = unsupported(Capability.StateInspection)
-  def scripting: IO[Unsupported, Scripting]             = unsupported(Capability.Scripting)
-  def proxyRecord: IO[Unsupported, ProxyRecord]         = unsupported(Capability.ProxyRecord)
-  def templating: IO[Unsupported, Templating]           = unsupported(Capability.Templating)
+
+  // ===== Stub-based capabilities (#132/#185) ======================================
+  // Each installs a special-response stub (`_rift.fault`, `_rift.script`, a Mountebank
+  // `proxy`, or an `is` + `_behaviors.copy`) tracked in `imp.extras` and re-registered
+  // ahead of the space's rules on every rebuild — so it wins first-match over a normal
+  // rule and is removable via `removeRule`.
+
+  private val embeddedFaults: Faults = new Faults:
+    def inject(space: MockSpace, m: RequestMatch, fault: FaultKind): IO[MockError, RuleId] =
+      injectExtra(space, rid => RiftProtocol.faultStub(m, fault, rid))
+
+  private val embeddedScripting: Scripting = new Scripting:
+    def inject(space: MockSpace, m: RequestMatch, script: Script): IO[MockError, RuleId] =
+      injectExtra(space, rid => RiftProtocol.scriptStub(m, script, rid))
+
+  private val embeddedProxyRecord: ProxyRecord = new ProxyRecord:
+    def proxy(space: MockSpace, m: RequestMatch, upstream: String): IO[MockError, RuleId] =
+      injectExtra(space, rid => RiftProtocol.proxyStub(m, upstream, rid))
+
+  private val embeddedTemplating: Templating = new Templating:
+    def inject(space: MockSpace, m: RequestMatch, template: ResponseTemplate): IO[MockError, RuleId] =
+      injectExtra(space, rid => RiftProtocol.templateStub(m, template, rid))
+
+  // Track a fresh capability stub and rebuild the imposter with it ahead of the rules.
+  // Server-first, commit tracking on success — so a failed downcall never leaves `imp.extras`
+  // claiming a stub the engine didn't accept (mirrors addRule).
+  private def injectExtra(space: MockSpace, buildStub: RuleId => Json): IO[MockError, RuleId] =
+    withImposter(space) { imp =>
+      for
+        ruleId <- freshId
+        rules  <- imp.rules.get
+        extras <- imp.extras.get
+        next    = (ruleId, buildStub(ruleId)) +: extras
+        _      <- rebuild(imp, next, rules)
+        _      <- imp.extras.set(next)
+      yield ruleId
+    }
 
   // ---------------------------------------------------------------------------
 
@@ -130,9 +189,10 @@ private[embedded] final case class EmbeddedRiftMockControl(
       _ <- ZIO.unless(bound == port)(
              ZIO.fail(MockError.ProvisionFailed(s"embedded Rift bound port $bound but $port was requested"))
            )
-      rules <- Ref.make(built.tagged)
-      id     = SpaceId(s"${src.name}-$port")
-      _     <- spaces.update(_.updated(id, Imposter(port, rules, built.nativeStubs)))
+      rules  <- Ref.make(built.tagged)
+      extras <- Ref.make(Vector.empty[(RuleId, Json)])
+      id      = SpaceId(s"${src.name}-$port")
+      _      <- spaces.update(_.updated(id, Imposter(port, rules, extras, built.nativeStubs)))
     yield MockSpace(s"http://localhost:$port", identity, id)
 
   private def withImposter[A](space: MockSpace)(f: Imposter => IO[MockError, A]): IO[MockError, A] =
@@ -174,10 +234,16 @@ private[embedded] final case class EmbeddedRiftMockControl(
   private def withIds(tagged: Vector[(RuleId, MockRule)]): List[MockRule] =
     tagged.map((rid, r) => r.copy(id = Some(rid))).toList
 
-  // Re-register a space's whole stub list via `rift_replace_stubs`: the tracked portable rules in
-  // first-match order, then the native base stubs (so an overlay rule shadows a native stub).
-  private def rebuild(imp: Imposter, tracked: Vector[(RuleId, MockRule)]): IO[MockError, Unit] =
-    engine.replaceStubs(imp.port, Json.Arr((withIds(tracked).map(RiftProtocol.stub) ++ imp.nativeStubs)*).toJson)
+  // Re-register a space's whole stub list via `rift_replace_stubs`: the tracked capability stubs
+  // (faults/script/proxy/template) first so they win first-match, then the tracked portable rules
+  // in first-match order, then the native base stubs (so an overlay rule shadows a native stub).
+  private def rebuild(
+    imp: Imposter,
+    extras: Vector[(RuleId, Json)],
+    tracked: Vector[(RuleId, MockRule)]
+  ): IO[MockError, Unit] =
+    val stubs = extras.map(_._2) ++ withIds(tracked).map(RiftProtocol.stub) ++ imp.nativeStubs
+    engine.replaceStubs(imp.port, Json.Arr(stubs*).toJson)
 
   private def freshId: UIO[RuleId]                  = ids.updateAndGet(_ + 1).map(n => RuleId(s"r$n"))
   private def freshIds(n: Int): UIO[Vector[RuleId]] = ZIO.foreach(0 until n)(_ => freshId).map(_.toVector)
@@ -188,11 +254,18 @@ private[embedded] object EmbeddedRiftMockControl:
 
   /**
    * A live imposter: its bound port, the ordered portable rules tracked for
-   * `rift_replace_stubs`, and the native base stubs (from a raw imposter
-   * document) re-registered beneath the tracked rules on every rebuild — empty
-   * for a DSL-provisioned space.
+   * `rift_replace_stubs`, the pre-built capability stubs (#132/#185: fault /
+   * script / proxy / template) re-registered ahead of the rules on every
+   * rebuild, and the native base stubs (from a raw imposter document)
+   * re-registered beneath the tracked rules — both empty for a plain
+   * DSL-provisioned space with no capability injected.
    */
-  final case class Imposter(port: Int, rules: Ref[Vector[(RuleId, MockRule)]], nativeStubs: Vector[Json])
+  final case class Imposter(
+    port: Int,
+    rules: Ref[Vector[(RuleId, MockRule)]],
+    extras: Ref[Vector[(RuleId, Json)]],
+    nativeStubs: Vector[Json]
+  )
 
   /**
    * The create-imposter body, the rules to track, and the native base stubs for

--- a/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/RiftFfi.scala
+++ b/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/RiftFfi.scala
@@ -4,47 +4,63 @@ import zio.*
 import zio.bdd.mock.MockError
 
 /**
- * The ZIO-facing wrapper over [[RiftFfiBridge]] — the Panama FFM bindings to
- * `librift_ffi`. Every downcall is a blocking call into the engine's own Tokio
- * threads, so each is wrapped in `ZIO.attemptBlocking`; the crate's sentinels
- * (port `0`, rc `-1`, null) become typed [[MockError]]s, and a genuine FFM
- * failure surfaces as a [[MockError.CommunicationError]].
+ * The ZIO-facing surface over the Rift engine's small C-ABI: create an
+ * imposter, replace all of its stubs, read its recorded requests. A trait (not
+ * just the live wrapper) so the adapter can be unit-tested against a recording
+ * double without the native library.
  */
-private[embedded] final class EmbeddedEngine(bridge: RiftFfiBridge):
+private[embedded] trait EmbeddedEngine:
 
   /**
    * Create an imposter from a full imposter JSON config; yields its bound port.
    */
-  def createImposter(configJson: String): IO[MockError, Int] =
-    blocking("rift_create_imposter")(bridge.createImposter(configJson)).flatMap { port =>
-      if port == 0 then
-        ZIO.fail(MockError.ProvisionFailed("rift_create_imposter returned 0 (bind failure or malformed config)"))
-      else ZIO.succeed(port)
-    }
+  def createImposter(configJson: String): IO[MockError, Int]
 
   /** Replace all stubs on `port` from a JSON array of Mountebank stubs. */
-  def replaceStubs(port: Int, stubsJson: String): IO[MockError, Unit] =
-    blocking("rift_replace_stubs")(bridge.replaceStubs(port, stubsJson)).flatMap { rc =>
-      if rc == 0 then ZIO.unit
-      else ZIO.fail(MockError.CommunicationError(s"rift_replace_stubs returned $rc for port $port"))
-    }
+  def replaceStubs(port: Int, stubsJson: String): IO[MockError, Unit]
 
   /**
    * The recorded requests for `port` as a JSON array string (`[]` when none).
    */
-  def recorded(port: Int): IO[MockError, String] =
-    blocking("rift_recorded")(bridge.recorded(port)).flatMap { json =>
-      if json == null then ZIO.fail(MockError.CommunicationError(s"rift_recorded returned null for port $port"))
-      else ZIO.succeed(json)
-    }
+  def recorded(port: Int): IO[MockError, String]
 
-  private def blocking[A](op: String)(thunk: => A): IO[MockError, A] =
-    ZIO
-      .attemptBlocking(thunk)
-      .mapError { t =>
-        val msg = Option(t.getMessage).filter(_.nonEmpty).fold("")(m => s": $m")
-        MockError.CommunicationError(s"$op via FFM failed (${t.getClass.getSimpleName}$msg)")
+private[embedded] object EmbeddedEngine:
+
+  /**
+   * The live engine over [[RiftFfiBridge]] — the Panama FFM bindings to
+   * `librift_ffi`. Every downcall is a blocking call into the engine's own
+   * Tokio threads, so each is wrapped in `ZIO.attemptBlocking`; the crate's
+   * sentinels (port `0`, rc `-1`, null) become typed [[MockError]]s, and a
+   * genuine FFM failure surfaces as a [[MockError.CommunicationError]].
+   */
+  final class Live(bridge: RiftFfiBridge) extends EmbeddedEngine:
+
+    def createImposter(configJson: String): IO[MockError, Int] =
+      blocking("rift_create_imposter")(bridge.createImposter(configJson)).flatMap { port =>
+        if port == 0 then
+          ZIO.fail(MockError.ProvisionFailed("rift_create_imposter returned 0 (bind failure or malformed config)"))
+        else ZIO.succeed(port)
       }
+
+    def replaceStubs(port: Int, stubsJson: String): IO[MockError, Unit] =
+      blocking("rift_replace_stubs")(bridge.replaceStubs(port, stubsJson)).flatMap { rc =>
+        if rc == 0 then ZIO.unit
+        else ZIO.fail(MockError.CommunicationError(s"rift_replace_stubs returned $rc for port $port"))
+      }
+
+    def recorded(port: Int): IO[MockError, String] =
+      blocking("rift_recorded")(bridge.recorded(port)).flatMap { json =>
+        if json == null then ZIO.fail(MockError.CommunicationError(s"rift_recorded returned null for port $port"))
+        else ZIO.succeed(json)
+      }
+
+    private def blocking[A](op: String)(thunk: => A): IO[MockError, A] =
+      ZIO
+        .attemptBlocking(thunk)
+        .mapError { t =>
+          val msg = Option(t.getMessage).filter(_.nonEmpty).fold("")(m => s": $m")
+          MockError.CommunicationError(s"$op via FFM failed (${t.getClass.getSimpleName}$msg)")
+        }
 
 private[embedded] object RiftFfi:
 
@@ -60,7 +76,7 @@ private[embedded] object RiftFfi:
           .attemptBlocking(RiftFfiBridge.start(libPath))
           .mapError(t => MockError.ProvisionFailed(s"loading librift_ffi from '$libPath': ${message(t)}"))
       )(bridge => ZIO.attemptBlocking(bridge.close()).orDie)
-      .map(EmbeddedEngine(_))
+      .map(EmbeddedEngine.Live(_))
 
   private def message(t: Throwable): String =
     Option(t.getMessage).getOrElse(t.getClass.getSimpleName)

--- a/rift/src/test/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
+++ b/rift/src/test/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
@@ -1,0 +1,182 @@
+package zio.bdd.mock.rift.embedded
+
+import zio.*
+import zio.bdd.mock.*
+import zio.json.*
+import zio.json.ast.Json
+import zio.test.*
+
+/**
+ * Unit gate for the embedded (FFI) adapter's optional-capability wiring (#185).
+ *
+ * The FFI surface is exactly create-imposter / replace-stubs / read-recorded,
+ * so every stub-based capability (faults, scripting, proxy/record, templating)
+ * is realised as a whole-imposter `rift_replace_stubs` with the capability stub
+ * registered ahead of the tracked rules (first-match). This spec drives the
+ * adapter against a recording [[EmbeddedEngine]] double — no native library —
+ * and asserts the emitted stub JSON, so it runs in a plain `sbt test`.
+ *
+ * StatefulScenarios + StateInspection stay unsupported: they need the
+ * scenario-state endpoints (pin/read/reset initial state) the C-ABI does not
+ * expose, so the embedded capability set is deliberately those four.
+ */
+object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
+
+  private val pingRule = MockRule(
+    RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/ping")),
+    ResponseDef(status = 200, body = Body.Text("pong"))
+  )
+  private val pingSource = MockSource.Dsl(MockSpec(List(pingRule)))
+
+  // A recording engine that echoes the requested port (parsed from the config, like the real
+  // engine) and keeps the latest replace-stubs JSON per port so the test can inspect the wire.
+  private final class RecordingEngine(replaced: Ref[Map[Int, String]]) extends EmbeddedEngine:
+    def createImposter(configJson: String): IO[MockError, Int] =
+      ZIO.succeed(portOf(configJson))
+    def replaceStubs(port: Int, stubsJson: String): IO[MockError, Unit] =
+      replaced.update(_.updated(port, stubsJson))
+    def recorded(port: Int): IO[MockError, String] = ZIO.succeed("[]")
+
+    private def portOf(cfg: String): Int =
+      cfg
+        .fromJson[Json]
+        .toOption
+        .collect { case o: Json.Obj => o }
+        .flatMap(_.fields.collectFirst { case ("port", Json.Num(n)) => n.intValue })
+        .getOrElse(0)
+
+  private def portFromUri(baseUri: String): Int = baseUri.substring(baseUri.lastIndexOf(':') + 1).toInt
+
+  private def withControl(
+    use: (MockControl, Ref[Map[Int, String]]) => IO[Any, TestResult]
+  ): ZIO[Provisioning, Any, TestResult] =
+    for
+      prov     <- ZIO.service[Provisioning]
+      replaced <- Ref.make(Map.empty[Int, String])
+      control  <- EmbeddedRiftMockControl.make(RecordingEngine(replaced), prov)
+      result   <- use(control, replaced)
+    yield result
+
+  def spec = suite("EmbeddedRiftCapabilities")(
+    test("advertises exactly the four stub-based capabilities and every accessor succeeds") {
+      withControl { (control, _) =>
+        for
+          faultsE   <- control.faults.either
+          scriptE   <- control.scripting.either
+          proxyE    <- control.proxyRecord.either
+          templateE <- control.templating.either
+        yield assertTrue(
+          control.capabilities == Set(
+            Capability.Faults,
+            Capability.Scripting,
+            Capability.ProxyRecord,
+            Capability.Templating
+          ),
+          faultsE.isRight,
+          scriptE.isRight,
+          proxyE.isRight,
+          templateE.isRight
+        )
+      }
+    },
+    test("faults.inject rebuilds the imposter with a first-match _rift.fault stub ahead of the rules") {
+      withControl { (control, replaced) =>
+        for
+          space  <- control.provision(pingSource).map(_.head)
+          port    = portFromUri(space.baseUri)
+          faults <- control.faults
+          _      <- faults.inject(space, RequestMatch(path = PathMatch.Exact("/boom")), FaultKind.ConnectionReset)
+          json   <- replaced.get.map(_.getOrElse(port, ""))
+        yield assertTrue(
+          json.contains("CONNECTION_RESET_BY_PEER"),
+          json.contains("/boom"),
+          json.contains("_rift"),
+          json.indexOf("/boom") < json.indexOf("/ping") // fault wins first-match over the normal rule
+        )
+      }
+    },
+    test("scripting/proxyRecord/templating each rebuild with a first-match capability stub ahead of the rules") {
+      withControl { (control, replaced) =>
+        for
+          space    <- control.provision(pingSource).map(_.head)
+          port      = portFromUri(space.baseUri)
+          script   <- control.scripting
+          proxy    <- control.proxyRecord
+          template <- control.templating
+          _        <- script.inject(space, RequestMatch(path = PathMatch.Exact("/s")), Script(ScriptEngine.Rhai, "code"))
+          _        <- proxy.proxy(space, RequestMatch(path = PathMatch.Exact("/p")), "http://up")
+          _ <- template.inject(
+                 space,
+                 RequestMatch(path = PathMatch.Exact("/t")),
+                 ResponseTemplate(body = "x${V}", captures = List(TemplateCapture("${V}", TemplateSource.Body, ".*")))
+               )
+          json <- replaced.get.map(_.getOrElse(port, ""))
+        yield assertTrue(
+          json.contains("rhai") && json.contains("/s"),
+          json.contains("proxyOnce") && json.contains("http://up") && json.contains("/p"),
+          json.contains("copy") && json.contains("${V}") && json.contains("/t"),
+          // each capability stub wins first-match — the `contains` guards above ensure these index
+          // comparisons aren't satisfied vacuously by a `-1` (absent) match.
+          json.indexOf("/s") < json.indexOf("/ping"),
+          json.indexOf("/p") < json.indexOf("/ping"),
+          json.indexOf("/t") < json.indexOf("/ping")
+        )
+      }
+    },
+    test("an injected capability rule is tracked and removable; the rebuild drops the stub, unknown ids fail") {
+      withControl { (control, replaced) =>
+        for
+          space  <- control.provision(pingSource).map(_.head)
+          port    = portFromUri(space.baseUri)
+          faults <- control.faults
+          ruleId <- faults.inject(space, RequestMatch(path = PathMatch.Exact("/boom")), FaultKind.ConnectionReset)
+          rmE    <- control.removeRule(space, ruleId).either
+          json   <- replaced.get.map(_.getOrElse(port, ""))
+          ghostE <- control.removeRule(space, RuleId("ghost")).either
+        yield assertTrue(
+          rmE.isRight,
+          !json.contains("CONNECTION_RESET_BY_PEER"), // the fault stub is gone after removal
+          !json.contains("/boom"),
+          json.contains("/ping"), // the normal rule survives
+          ghostE == Left(MockError.RuleNotFound(space.id, RuleId("ghost")))
+        )
+      }
+    },
+    test("an injected extra survives a later addRule/replaceRules and stays first-match ahead of the new rules") {
+      withControl { (control, replaced) =>
+        val addedRule = MockRule(RequestMatch(path = PathMatch.Exact("/added")), ResponseDef(status = 200))
+        val replRule  = MockRule(RequestMatch(path = PathMatch.Exact("/replaced")), ResponseDef(status = 200))
+        for
+          space     <- control.provision(pingSource).map(_.head)
+          port       = portFromUri(space.baseUri)
+          faults    <- control.faults
+          _         <- faults.inject(space, RequestMatch(path = PathMatch.Exact("/boom")), FaultKind.ConnectionReset)
+          _         <- control.addRule(space, addedRule, Priority.Base)
+          afterAdd  <- replaced.get.map(_.getOrElse(port, ""))
+          _         <- control.replaceRules(space, List(replRule))
+          afterRepl <- replaced.get.map(_.getOrElse(port, ""))
+        yield assertTrue(
+          // addRule keeps the fault stub, still ahead of the newly-added rule
+          afterAdd.contains("CONNECTION_RESET_BY_PEER") && afterAdd.contains("/added"),
+          afterAdd.indexOf("/boom") < afterAdd.indexOf("/added"),
+          // replaceRules swaps the ruleset but preserves the injected fault, still first-match
+          afterRepl.contains("CONNECTION_RESET_BY_PEER") && afterRepl.contains("/replaced"),
+          !afterRepl.contains("/added"),
+          afterRepl.indexOf("/boom") < afterRepl.indexOf("/replaced")
+        )
+      }
+    },
+    test("scenarios + stateInspection stay unsupported and are not advertised") {
+      withControl { (control, _) =>
+        for
+          scenE <- control.scenarios.either
+          siE   <- control.stateInspection.either
+        yield assertTrue(
+          scenE == Left(Unsupported(Capability.StatefulScenarios, "embedded")),
+          siE == Left(Unsupported(Capability.StateInspection, "embedded")),
+          !control.capabilities.contains(Capability.StatefulScenarios),
+          !control.capabilities.contains(Capability.StateInspection)
+        )
+      }
+    }
+  ).provide(Provisioning.live) @@ TestAspect.withLiveClock

--- a/rift/src/test/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRiftFfiSpec.scala
+++ b/rift/src/test/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRiftFfiSpec.scala
@@ -114,6 +114,38 @@ object EmbeddedRiftFfiSpec extends ZIOSpecDefault:
           reverted.status == 200 && reverted.body == "native!"   // native stub preserved across mutation
         )).provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
     },
+    test("proxyRecord: an injected proxy records the upstream response and replays it (#185)") {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
+      else
+        // A second embedded imposter is the upstream: the proxy on the target space forwards GET /u
+        // to it, records the first response, and replays it on the second call — proving the advertised
+        // ProxyRecord capability works end-to-end over the FFI, not just that the adapter emits the JSON.
+        val upstreamSource =
+          MockSource.Dsl(
+            MockSpec(
+              List(
+                MockRule(
+                  RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/u")),
+                  ResponseDef(status = 200, body = Body.Text("from-upstream"))
+                )
+              )
+            )
+          )
+        (for
+          control  <- ZIO.service[MockControl]
+          upstream <- control.provision(upstreamSource).mapError(asT).map(_.head)
+          target   <- control.provision(pingSource).mapError(asT).map(_.head)
+          proxy    <- control.proxyRecord.mapError(u => new RuntimeException(s"Unsupported: $u"))
+          _        <- proxy.proxy(target, RequestMatch(path = PathMatch.Exact("/u")), upstream.baseUri).mapError(asT)
+          first    <- SutClient.make(target).send(Method.Get, "/u")
+          replayed <- SutClient.make(target).send(Method.Get, "/u")
+          _        <- control.destroy(target).mapError(asT)
+          _        <- control.destroy(upstream).mapError(asT)
+        yield assertTrue(
+          first.status == 200 && first.body == "from-upstream",      // proxied + recorded
+          replayed.status == 200 && replayed.body == "from-upstream" // replayed from the recording
+        )).provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
+    },
     test("provisionNative: a WireMock spec is rejected with InvalidDefinition") {
       if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
       else


### PR DESCRIPTION
## Summary

The embedded (Panama FFM) Rift adapter advertised **no** optional capabilities while the container adapter advertised all six — so swapping the container backend for the in-process embedded backend silently lost faults/scripting/proxy/templating through the portable `MockControl` API.

This wires the four stub-based capabilities (**Faults, Scripting, ProxyRecord, Templating**) through the FFI: each capability stub is tracked in `imp.extras` and re-registered ahead of the space's rules on every whole-imposter `rift_replace_stubs` rebuild (first-match, removable via `removeRule`) — the same shape the container adapter uses over the admin API. **StatefulScenarios** and **StateInspection** stay `Unsupported` by design: the C-ABI exposes no scenario-state endpoints (pin/read/reset), so the embedded capability set is deliberately those four.

`EmbeddedEngine` is refactored into a trait + `Live` impl as a test seam, enabling a unit gate against a recording double (no native library). The embedded conformance fixture now advertises the four caps, so faults/scripting/templating catalogues run **live** against the engine (previously all SKIPPED), and a live proxy record/replay test proves ProxyRecord end-to-end.

## Verification
- `rift/test`: 72 tests pass (new unit gate + live proxy record/replay)
- Embedded conformance: 6/6 — faults×5 / scripting / templating PASS live; cap-stateful SKIP-justified
- scalafmtCheckAll + compile clean

Closes #185
Milestone: M4