### PR TITLE
SutClient/MockSteps default to HTTP/2 and EOF against HTTP/1.1 mock servers (201 responses)

### DIFF
--- a/core/src/main/scala/zio/bdd/mock/steps/MockSteps.scala
+++ b/core/src/main/scala/zio/bdd/mock/steps/MockSteps.scala
@@ -6,7 +6,7 @@ import zio.bdd.core.step.{Stage, ZIOSteps}
 import zio.bdd.mock.*
 
 import java.net.URI
-import java.net.http.{HttpClient, HttpRequest as JHttpRequest, HttpResponse as JHttpResponse}
+import java.net.http.{HttpRequest as JHttpRequest, HttpResponse as JHttpResponse}
 import scala.jdk.CollectionConverters.*
 
 /**
@@ -168,8 +168,10 @@ trait MockSteps[R, S] { self: ZIOSteps[R & MockControl, S] =>
         val publisher = injected.body match
           case Some(body) => JHttpRequest.BodyPublishers.ofString(body)
           case None       => JHttpRequest.BodyPublishers.noBody()
-        val request  = builder.method(injected.method.toString.toUpperCase, publisher).build()
-        val response = HttpClient.newHttpClient().send(request, JHttpResponse.BodyHandlers.ofString())
+        val request = builder.method(injected.method.toString.toUpperCase, publisher).build()
+        // Pinned to HTTP/1.1 for the same reason as SutClient (#183): mock servers are cleartext
+        // HTTP/1.1 and the default HTTP/2 h2c path intermittently EOFs a 201.
+        val response = SutClient.http1Client.send(request, JHttpResponse.BodyHandlers.ofString())
         val headers = response.headers().map().asScala.foldLeft(Headers.empty) { case (h, (k, vs)) =>
           vs.asScala.foldLeft(h)((acc, v) => acc.add(k, v))
         }

--- a/core/src/test/scala/zio/bdd/mock/steps/MockStepsSpec.scala
+++ b/core/src/test/scala/zio/bdd/mock/steps/MockStepsSpec.scala
@@ -219,6 +219,16 @@ object MockStepsSpec extends ZIOSpecDefault:
         )
       ).map(r => assertTrue(!r.isPassed, r.error.isDefined))
     },
+    test("a 201-with-body response round-trips through sendThrough (the case that EOFs under HTTP/2) (#183)") {
+      run(
+        List(
+          step(G, """a mock space returning 201 "created" at "/thing""""),
+          step(W, """a "POST" "/thing" is sent through the space"""),
+          step(T, "the space response status is 201"),
+          step(T, """the space response body contains "created"""")
+        )
+      ).map(r => assertTrue(r.isPassed))
+    },
     test("a send to an unstubbed path returns 404 through the space") {
       run(
         List(

--- a/mock/src/main/scala/zio/bdd/mock/SutClient.scala
+++ b/mock/src/main/scala/zio/bdd/mock/SutClient.scala
@@ -44,6 +44,12 @@ trait SutClient:
 object SutClient:
   def make(space: MockSpace): SutClient = Live(space)
 
+  // Mock servers speak cleartext HTTP/1.1; the JDK client defaults to HTTP/2, whose h2c upgrade
+  // path intermittently EOFs on a 201 response under the test runtime (#183). Pin HTTP/1.1 — there
+  // is no reason to negotiate HTTP/2 against a mock. Shared with MockSteps.sendThrough.
+  private[mock] def http1Client: HttpClient =
+    HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build()
+
   /** Per-scenario layer: bind the SUT's dependency client to `space`. */
   def layer(space: MockSpace): ULayer[SutClient] = ZLayer.succeed(make(space))
 
@@ -66,7 +72,7 @@ object SutClient:
           case Some(content) => JHttpRequest.BodyPublishers.ofString(content)
           case None          => JHttpRequest.BodyPublishers.noBody()
         val request  = builder.method(injected.method.toString.toUpperCase, publisher).build()
-        val response = HttpClient.newHttpClient().send(request, JHttpResponse.BodyHandlers.ofString())
+        val response = http1Client.send(request, JHttpResponse.BodyHandlers.ofString())
         // Preserve every value per response header key (Headers canonicalises keys to lower-case).
         val respHeaders = response.headers().map().asScala.foldLeft(Headers.empty) { case (h, (k, vs)) =>
           vs.asScala.foldLeft(h)((acc, v) => acc.add(k, v))

--- a/mock/src/test/scala/zio/bdd/mock/SutClientSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/SutClientSpec.scala
@@ -53,10 +53,13 @@ object SutClientSpec extends ZIOSpecDefault:
                     val seg = full.stripPrefix("/").split("/", 2)
                     (seg(0), "/" + (if seg.length > 1 then seg(1) else ""))
                 recordings.computeIfAbsent(key, _ => new CopyOnWriteArrayList[(String, String)]()).add((method, path))
-                // Echo the request body back, stamp a header, and fail /down — so a
-                // test can pin SutResponse status/body/header decoding and the
-                // non-2xx-is-a-value contract.
-                val status    = if path.endsWith("/down") then 503 else 200
+                // Echo the request body back, stamp a header, fail /down, and 201 on /created — so a
+                // test can pin SutResponse status/body/header decoding, the non-2xx-is-a-value
+                // contract, and the 201-with-body round-trip (#183).
+                val status =
+                  if path.endsWith("/down") then 503
+                  else if path.endsWith("/created") then 201
+                  else 200
                 val respBytes = reqBody.getBytes
                 exchange.getResponseHeaders.set("X-Served-By", "dep")
                 exchange.sendResponseHeaders(status, if respBytes.isEmpty then -1 else respBytes.length.toLong)
@@ -167,6 +170,20 @@ object SutClientSpec extends ZIOSpecDefault:
             _   <- SutClient.make(rewriting).send(Method.Get, "/orig")
             rec <- dep.received("Z")
           yield assertTrue(rec == List(("GET", "/orig-rewritten"))) // the inject's URI rewrite was honoured
+        }
+      }
+    },
+    test(
+      "the SUT-facing client is pinned to HTTP/1.1 (mock servers are cleartext HTTP/1.1; HTTP/2 h2c EOFs a 201) (#183)"
+    ) {
+      assertTrue(SutClient.http1Client.version == HttpClient.Version.HTTP_1_1)
+    },
+    test("a 201-with-body response round-trips through SutClient (the case that EOFs under HTTP/2) (#183)") {
+      ZIO.scoped {
+        dependency.flatMap { dep =>
+          val client = SutClient.make(dep.perInstanceSpace("C"))
+          for created <- client.send(Method.Post, "/created", body = Some("new-resource"))
+          yield assertTrue(created.status == 201, created.body == "new-resource")
         }
       }
     },


### PR DESCRIPTION
## Summary

`SutClient.Live.send` and `MockSteps.sendThrough` built the JDK `HttpClient` with the default `Version.HTTP_2`. Against a cleartext HTTP/1.1 mock server (WireMock/Jetty), the client's h2c upgrade path intermittently throws `EOFException: EOF reached while reading` — reproducibly on **HTTP 201** responses under the ZIOBDD test runtime. Any user mocking a dependency that returns `201 Created` and asserting the round trip through `SutClient`/`MockSteps` hits it.

## Fix

Pin `HttpClient.Version.HTTP_1_1` via a single shared `private[mock] SutClient.http1Client`, used by both call sites. Mock servers are HTTP/1.1; there's no reason to negotiate HTTP/2.

## Tests

- Deterministic guard: `SutClient.http1Client.version == HTTP_1_1`.
- The previously-missing 201-with-body round-trip, driven end-to-end through **both** seams — `SutClient.send` (SutClientSpec) and `MockSteps.sendThrough` (MockStepsSpec) — against the in-process `com.sun` HTTP/1.1 server.

Verified: `scalafmtCheckAll`, mock + core suites green (SutClientSpec 10/10, MockStepsSpec 9/9).

Closes #183