### PR TITLE
string extractor is greedy and over-captures with multiple quoted args on one step

### DIFF
--- a/core/src/main/scala/zio/bdd/core/step/TypedExtractors.scala
+++ b/core/src/main/scala/zio/bdd/core/step/TypedExtractors.scala
@@ -32,21 +32,44 @@ object TypedExtractor {
 trait DefaultTypedExtractor {
 
   /**
-   * Matches any text, optionally double-quoted. Quotes are stripped from the
-   * captured value.
+   * Matches any text, optionally double-quoted (standard Cucumber `{string}`
+   * semantics). The quoted branch is escape-aware and non-spanning — it stops
+   * at its own unescaped closing quote (`\"`/`\\` stay inside the token)
+   * instead of the old greedy `".*"` running to the last quote on the line —
+   * and the captured value is unquoted and unescaped (`\"`→`"`, `\\`→`\`). The
+   * unquoted `.*` fallback is unchanged. (#184)
    */
-  val string: TypedExtractor[String] = TypedExtractor.make[String]("(\".*\"|.*)") { (_, groups, groupIndex) =>
-    groups
-      .lift(groupIndex)
-      .map { s =>
-        val trimmed = s.trim
-        val unquoted =
-          if (trimmed.startsWith("\"") && trimmed.endsWith("\""))
-            trimmed.substring(1, trimmed.length - 1)
-          else trimmed
-        (unquoted, groupIndex + 1)
+  val string: TypedExtractor[String] =
+    TypedExtractor.make[String]("""("(?:\\.|[^"\\])*"|.*)""") { (_, groups, groupIndex) =>
+      groups
+        .lift(groupIndex)
+        .map { s =>
+          val trimmed = s.trim
+          val unquoted =
+            if (trimmed.length >= 2 && trimmed.startsWith("\"") && trimmed.endsWith("\""))
+              unescapeQuoted(trimmed.substring(1, trimmed.length - 1))
+            else trimmed
+          (unquoted, groupIndex + 1)
+        }
+        .toRight(s"Expected string at group $groupIndex")
+    }
+
+  // Cucumber unescaping of a quoted token's contents: only `\"` and `\\` are escapes (→ `"` / `\`);
+  // any other backslash sequence is left verbatim.
+  private def unescapeQuoted(s: String): String = {
+    val sb = new StringBuilder(s.length)
+    var i  = 0
+    while (i < s.length) {
+      val c = s.charAt(i)
+      if (c == '\\' && i + 1 < s.length && { val n = s.charAt(i + 1); n == '"' || n == '\\' }) {
+        sb.append(s.charAt(i + 1))
+        i += 2
+      } else {
+        sb.append(c)
+        i += 1
       }
-      .toRight(s"Expected string at group $groupIndex")
+    }
+    sb.toString
   }
 
   /** Matches a single word (no whitespace). */

--- a/core/src/test/scala/zio/bdd/core/step/TypedExtractorSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/step/TypedExtractorSpec.scala
@@ -44,6 +44,51 @@ object TypedExtractorSpec extends ZIOSpecDefault with DefaultTypedExtractor {
     },
     test("fails when group index is out of bounds") {
       assert(string.extract(input(), List(), 0))(isLeft(containsString("Expected string")))
+    },
+    // End-to-end through StepExpression: the composed regex must give each quoted arg its own
+    // group instead of the first {string} spanning the whole line (#184).
+    test("two adjacent quoted args on one step do not span (#184)") {
+      val expr = StepExpression[(String, String, String)](
+        List(
+          Literal("the client sends "),
+          Extractor(string),
+          Literal(" "),
+          Extractor(string),
+          Literal(" with body "),
+          Extractor(string)
+        )
+      )
+      assert(expr.extract(input("the client sends \"POST\" \"/echo\" with body \"ping\"")))(
+        isSome(equalTo(("POST", "/echo", "ping")))
+      )
+    },
+    test("a quoted token with escaped quotes is captured whole and unescaped (#184)") {
+      val expr = StepExpression[Tuple1[String]](List(Literal("send "), Extractor(string)))
+      assert(expr.extract(input("send \"{\\\"id\\\":1}\"")))(isSome(equalTo(Tuple1("{\"id\":1}"))))
+    },
+    test("a quoted token unescapes an escaped backslash (#184)") {
+      val expr = StepExpression[Tuple1[String]](List(Literal("send "), Extractor(string)))
+      assert(expr.extract(input("send \"a\\\\b\"")))(isSome(equalTo(Tuple1("a\\b"))))
+    },
+    // A lone `"` reaches the handler only via the `.*` fallback; the length >= 2 guard returns it
+    // verbatim instead of throwing on substring(1, 0) (the old code's latent crash) (#184).
+    test("a lone quote is returned verbatim, not crashed on (#184)") {
+      assert(string.extract(input(), List("\""), 0))(isRight(equalTo(("\"", 1))))
+    },
+    // Only \" and \\ are escapes; any other backslash sequence in a quoted token stays verbatim (#184).
+    test("a non-escape backslash sequence inside a quoted token is left verbatim (#184)") {
+      assert(string.extract(input(), List("\"a\\nb\""), 0))(isRight(equalTo(("a\\nb", 1))))
+    },
+    // Unescaping is gated on the value being quoted: an unquoted backslash is not touched (#184).
+    test("an unquoted value containing a backslash is not unescaped (#184)") {
+      assert(string.extract(input(), List("a\\b"), 0))(isRight(equalTo(("a\\b", 1))))
+    },
+    // Composed: escape-aware boundary + unescape together across two args (#184).
+    test("a multi-arg step with an escaped quote in one value splits and unescapes correctly (#184)") {
+      val expr = StepExpression[(String, String)](
+        List(Literal("send "), Extractor(string), Literal(" to "), Extractor(string))
+      )
+      assert(expr.extract(input("send \"a\\\"b\" to \"c\"")))(isSome(equalTo(("a\"b", "c"))))
     }
   )
 


### PR DESCRIPTION
## Summary

The built-in `string` typed extractor (`{string}` / `_ / string`) used a greedy quoted branch `(".*"|.*)` that matches from the first `"` to the **last** `"` on the line, so a step with more than one quoted argument had its first `{string}` over-capture across them. The captured value was also never unescaped.

## Fix

Change the quoted branch to the standard Cucumber `{string}` pattern `("(?:\\.|[^"\\])*"|.*)` — escape-aware and non-spanning, so a quoted token stops at its own unescaped closing quote — and unescape `\"`→`"`, `\\`→`\` in the captured value (only those two are escapes; any other backslash is left verbatim). A `length >= 2` guard on the quote-strip closes a latent `substring(1, 0)` crash on a lone `"`. The unquoted `.*` fallback is unchanged.

- `"POST"` `"/echo"` → `POST`, `/echo` (no spanning).
- `"{\"id\":1}"` → `{"id":1}` (captured whole and unescaped to valid JSON).

## Tests

Seven cases added to `TypedExtractorSpec` (end-to-end through `StepExpression` and direct): escaped-quote and escaped-backslash unescape (the red→green gates), a composed multi-arg escaped-quote split, the lone-quote crash guard, non-escape backslash left verbatim, and unquoted-not-unescaped. `TypedExtractorSpec` 58/58; full `core` suite and `example` feature tests green.

Note: for balanced anchored steps the escape-aware regex yields the same captures as the old greedy one (Java `matches()` backtracking already resolved the literal repro); the observable behavioral change is the unescaping.

Closes #184