### PR TITLE
Shorter step definition silently shadows a longer overlapping one (fewest-extractors + greedy string fallback)

### DIFF
--- a/core/src/main/scala/zio/bdd/core/step/StepRegistry.scala
+++ b/core/src/main/scala/zio/bdd/core/step/StepRegistry.scala
@@ -147,18 +147,26 @@ final case class StepRegistryLive[R, S](steps: List[StepDef[R, S]]) extends Step
     }
   }
 
-  // The definition with the fewest extractor placeholders is the most specific (most
-  // literal) one. This lets a literal step like `the response body is not empty` win
-  // over a wildcard `the response body is {string}`. Only a tie at the most-specific
-  // level is a genuine ambiguity. Shared by both literal-text and template lookup —
-  // both prefer the same specificity ordering.
-  private def extractorCount(sd: StepDef[R, S]): Int = sd match {
-    case StepDefImpl(_, expr, _) => expr.parts.count { case _: Extractor[?] => true; case _ => false }
+  // Specificity ranking used to break ties when several definitions match the same step
+  // text. The more *literal* (fixed, non-extractor) characters a definition pins down, the
+  // more specific it is: this lets a longer, more-qualified variant like
+  // `a stub GET {string} requiring query {string} ... returns text {string}` win over a
+  // shorter `a stub GET {string} returns text {string}`, whose trailing `{string}` `.*`
+  // fallback would otherwise greedily swallow the middle and silently shadow it (#186).
+  // Literal length is the primary key; extractor count (fewer = more specific) breaks a
+  // literal-length tie, preserving the long-standing preference of a fully-literal step
+  // (e.g. `the response body is not empty`) over a `{string}` wildcard. Only a tie on both
+  // keys is a genuine ambiguity. Shared by both literal-text and template lookup.
+  private def specificity(sd: StepDef[R, S]): (Int, Int) = sd match {
+    case StepDefImpl(_, expr, _) =>
+      val literalLen     = expr.parts.collect { case Literal(s) => s.length }.sum
+      val extractorCount = expr.parts.count { case _: Extractor[?] => true; case _ => false }
+      (literalLen, -extractorCount)
   }
 
-  private def fewestExtractorsWinner[A](matches: List[(StepDef[R, S], A)]): Either[List[String], A] = {
-    val fewest  = matches.map { case (sd, _) => extractorCount(sd) }.min
-    val winners = matches.filter { case (sd, _) => extractorCount(sd) == fewest }
+  private def mostSpecificWinner[A](matches: List[(StepDef[R, S], A)]): Either[List[String], A] = {
+    val best    = matches.map { case (sd, _) => specificity(sd) }.max
+    val winners = matches.filter { case (sd, _) => specificity(sd) == best }
     winners match {
       case (_, a) :: Nil => Right(a)
       case _             => Left(winners.map { case (StepDefImpl(_, expr, _), _) => expr.toString })
@@ -170,7 +178,7 @@ final case class StepRegistryLive[R, S](steps: List[StepDef[R, S]]) extends Step
       case Nil                => ZIO.fail(NoMatchingStep(stepType, input, generateSnippet(stepType, input)))
       case (_, effect) :: Nil => ZIO.succeed(effect)
       case multiple =>
-        ZIO.fromEither(fewestExtractorsWinner(multiple).left.map(patterns => AmbiguousStep(stepType, input, patterns)))
+        ZIO.fromEither(mostSpecificWinner(multiple).left.map(patterns => AmbiguousStep(stepType, input, patterns)))
     }
 
   override def allDefinitions: UIO[List[StepMetadata]] =
@@ -211,7 +219,7 @@ final case class StepRegistryLive[R, S](steps: List[StepDef[R, S]]) extends Step
         case (_, cols) :: Nil => ZIO.succeed(cols)
         case multiple =>
           ZIO.fromEither(
-            fewestExtractorsWinner(multiple).left.map(patterns => AmbiguousTemplate(stepType, template, patterns))
+            mostSpecificWinner(multiple).left.map(patterns => AmbiguousTemplate(stepType, template, patterns))
           )
       }
     resolved.flatMap(cols => validateColumnTypes(stepType, template, cols))

--- a/core/src/test/scala/zio/bdd/core/step/StepRegistrySpec.scala
+++ b/core/src/test/scala/zio/bdd/core/step/StepRegistrySpec.scala
@@ -3,7 +3,7 @@ package zio.bdd.core.step
 import zio.bdd.gherkin.StepType
 import zio.test.*
 import zio.test.Assertion.*
-import zio.{Scope, UIO, ZIO, ZLayer}
+import zio.{Ref, Scope, UIO, ZIO, ZLayer}
 
 object StepRegistrySpec extends ZIOSpecDefault with DefaultTypedExtractor {
 
@@ -164,10 +164,124 @@ object StepRegistrySpec extends ZIOSpecDefault with DefaultTypedExtractor {
     }
   )
 
+  // ── Specificity: overlapping prefixes (#186) ────────────────────────────────
+
+  // The 2-arg step from the issue: its first `{string}` `.*` fallback can greedily swallow
+  // the middle of a line meant for the 6-arg step (up to the final ` returns text `), so
+  // both full-match. The more specific (more literal) definition must win, not the one with
+  // fewest extractors.
+  private def stubShort(winner: Ref[String]) = makeStep(
+    StepType.GivenStep,
+    StepExpression[(String, String)](
+      List(Literal("a stub GET "), Extractor(string), Literal(" returns text "), Extractor(string))
+    ),
+    (_: (String, String)) => winner.set("short")
+  )
+
+  private def stubLong(winner: Ref[String]) = makeStep(
+    StepType.GivenStep,
+    StepExpression[(String, String, String, String, String, String)](
+      List(
+        Literal("a stub GET "),
+        Extractor(string),
+        Literal(" requiring query "),
+        Extractor(string),
+        Literal(" = "),
+        Extractor(string),
+        Literal(" and query "),
+        Extractor(string),
+        Literal(" = "),
+        Extractor(string),
+        Literal(" returns text "),
+        Extractor(string)
+      )
+    ),
+    (_: (String, String, String, String, String, String)) => winner.set("long")
+  )
+
+  private val longLine =
+    "a stub GET \"/q\" requiring query \"a\" = \"1\" and query \"b\" = \"2\" returns text \"matched\""
+
+  // Wires `steps` into a registry, runs the definition matched for `input`, and returns
+  // which one fired — each step writes its label to the shared `winner` Ref when executed.
+  private def winnerAfter(steps: Ref[String] => List[StepDef[Any, Unit]], stepType: StepType, input: String) =
+    for {
+      winner <- Ref.make("none")
+      effect <- registry(steps(winner)).findStep(stepType, si(input))
+      _      <- effect.provide(stateLayer ++ Scope.default)
+      who    <- winner.get
+    } yield who
+
+  private val specificity = suite("Specificity (overlapping prefixes)")(
+    test("longer more specific overlapping step wins over shorter one (#186)") {
+      winnerAfter(w => List(stubShort(w), stubLong(w)), StepType.GivenStep, longLine)
+        .map(who => assertTrue(who == "long"))
+    },
+    test("winner is independent of registration order (#186)") {
+      winnerAfter(w => List(stubLong(w), stubShort(w)), StepType.GivenStep, longLine)
+        .map(who => assertTrue(who == "long"))
+    },
+    test("fully-literal step still wins over a wildcard string variant (#186)") {
+      def steps(w: Ref[String]) = List(
+        makeStep(
+          StepType.ThenStep,
+          StepExpression[Tuple1[String]](List(Literal("the response body is "), Extractor(string))),
+          (_: Tuple1[String]) => w.set("wildcard")
+        ),
+        makeStep(
+          StepType.ThenStep,
+          StepExpression[EmptyTuple](List(Literal("the response body is not empty"))),
+          (_: EmptyTuple) => w.set("literal")
+        )
+      )
+      winnerAfter(steps, StepType.ThenStep, "the response body is not empty")
+        .map(who => assertTrue(who == "literal"))
+    },
+    // Guards the secondary tie-break key: when two matches pin the same number of literal
+    // characters, the one with fewer extractors must still win. Here both have literalLen 3;
+    // the wildcard's `{string}` matches the empty tail, so only `-extractorCount` separates
+    // them. Without the secondary key this would be a false ambiguity.
+    test("on a literal-length tie, fewer extractors still wins (#186)") {
+      def steps(w: Ref[String]) = List(
+        makeStep(
+          StepType.GivenStep,
+          StepExpression[Tuple1[String]](List(Literal("abc"), Extractor(string))),
+          (_: Tuple1[String]) => w.set("wildcard")
+        ),
+        makeStep(
+          StepType.GivenStep,
+          StepExpression[EmptyTuple](List(Literal("abc"))),
+          (_: EmptyTuple) => w.set("literal")
+        )
+      )
+      winnerAfter(steps, StepType.GivenStep, "abc").map(who => assertTrue(who == "literal"))
+    },
+    // Two structurally different patterns that tie on both keys (each: 1 literal char,
+    // 1 extractor) and both full-match must still be reported as ambiguous, not silently
+    // resolved by registration order.
+    test("structurally different steps that tie on specificity are ambiguous (#186)") {
+      val prefix = makeStep(
+        StepType.GivenStep,
+        StepExpression[Tuple1[String]](List(Literal("a"), Extractor(string))),
+        (_: Tuple1[String]) => ZIO.unit
+      )
+      val suffix = makeStep(
+        StepType.GivenStep,
+        StepExpression[Tuple1[String]](List(Extractor(string), Literal("b"))),
+        (_: Tuple1[String]) => ZIO.unit
+      )
+      val reg = registry(List(prefix, suffix))
+      assertZIO(reg.findStep(StepType.GivenStep, si("ab")).either)(
+        isLeft(isSubtype[AmbiguousStep](anything))
+      )
+    }
+  )
+
   def spec: Spec[TestEnvironment & Scope, Any] = suite("StepRegistry")(
     lookup,
     noMatch,
     ambiguity,
-    crossKeyword
+    crossKeyword,
+    specificity
   )
 }


### PR DESCRIPTION
When multiple registered step definitions full-match the same Gherkin step text, the tie-break now prefers the most *specific* definition — ranked by literal-character length (primary) then fewest extractors (secondary) — instead of fewest extractors alone. This stops a shorter step from silently shadowing a longer, more-qualified overlapping variant whose middle the greedy `{string}` `.*` fallback would otherwise swallow.

Backward compatible: a fully-literal step still beats a `{string}` wildcard, and genuine equal-specificity ties still raise `AmbiguousStep`. Covered by a new "Specificity (overlapping prefixes)" test suite.

Closes #186

Milestone: none (core step-matching fix, outside the M1–M4 SPI roadmap)