### PR TITLE
build: bump rift to v0.9.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ import java.security.MessageDigest
 // preview API on JDK 21, so the embedded code stays JDK-21-gated; see embeddedNativeSettings.)
 // NOTE: build.sbt is compiled with the Scala 2.12 dialect — keep these blocks 2.12-compatible.
 
-val riftNativesVersion = "0.7.0"
+val riftNativesVersion = "0.9.0"
 
 // The (os, arch, ext) cdylibs bundled into the natives jar — linux/macOS × x86_64/aarch64 (#134).
 val riftNativeTriples: Seq[(String, String, String)] = Seq(

--- a/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
@@ -52,13 +52,13 @@ object RiftMode:
  */
 object Rift:
 
-  // Pinned to v0.8.0. Floor is v0.8.0: the adapter emits the flat
+  // Pinned to v0.9.0. Floor is v0.8.0: the adapter emits the flat
   // `_rift.flowState.flowIdSource` shape (EtaCassiopeia/rift#266, #268), which
   // Rift only reads from v0.8.0 on — earlier images expect the dropped
   // `mountebankStateMapping` wrapper and return 404/empty on the correlated
   // path. v0.8.0 also carries the v0.4.0 correlated-isolation endpoints (#223)
   // and the v0.2.0 keep-alive teardown fix (#207).
-  val DefaultImage: String     = "zainalpour/rift-proxy:v0.8.0"
+  val DefaultImage: String     = "zainalpour/rift-proxy:v0.9.0"
   val DefaultAdminPort: Int    = 2525
   val DefaultImposterBase: Int = 4545
   val DefaultPoolSize: Int     = 16


### PR DESCRIPTION
Bump both Rift version knobs to v0.9.0:

- `DefaultImage` (testcontainers) → `zainalpour/rift-proxy:v0.9.0`
- `riftNativesVersion` (embedded FFI natives) `0.7.0` → `0.9.0`

The wire-format floor stays v0.8.0 (flat `flowIdSource` shape); the pin comment keeps that rationale and now records the pin as v0.9.0.

Verified locally: `sbt compile` (JDK 21, embedded included) and `scalafmtCheckAll` green; all four v0.9.0 native cdylibs download + SHA-256 verify; image tag `v0.9.0` published.