### PR TITLE
feat(rift): FFM bridge v2 + full-capability embedded adapter (in-process admin plane)

### DIFF
--- a/conformance/src/test/jdk21/zio/bdd/mock/conformance/EmbeddedConformanceSpec.scala
+++ b/conformance/src/test/jdk21/zio/bdd/mock/conformance/EmbeddedConformanceSpec.scala
@@ -18,25 +18,31 @@ import zio.test.*
  *
  * `Matrix.conformant(embedded)` is the full acceptance condition for a suite:
  * with the library present, the core scenarios (which require no capability)
- * must PASS, the stub-based capability scenarios (faults/scripting/templating,
- * #185) must PASS against the live engine, and the stateful scenarios
- * SKIP-justified (embedded advertises no StatefulScenarios/StateInspection —
- * the C-ABI has no scenario-state endpoints); with the library absent, the
- * whole column is SKIPPED-unavailable (also conformant). So one assertion gates
- * each catalogue.
+ * must PASS, and every capability catalogue — the stub-based four
+ * (faults/scripting/templating, #185) and the stateful two (scenarios/state
+ * inspection, #193, over the v2 in-process admin plane) — must PASS against the
+ * live engine; with the library absent, the whole column is SKIPPED-unavailable
+ * (also conformant). So one assertion gates each catalogue.
  */
 object EmbeddedConformanceSpec extends ZIOSpecDefault:
 
   private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
 
-  // The embedded adapter advertises the four stub-based capabilities (#185); StatefulScenarios
-  // and StateInspection stay out of scope (no scenario-state endpoints over the C-ABI). This must
-  // mirror EmbeddedRiftMockControl.capabilities so the harness runs the supported catalogues live.
+  // The v2 embedded adapter is capability-complete (all six) — the in-process admin plane (rift#343)
+  // reaches the scenario-state endpoints the C-ABI could not before. This must mirror
+  // EmbeddedRiftMockControl.capabilities so the harness runs every catalogue live.
   private val embedded =
     MockBackendUnderTest(
       "embedded",
       Provisioning.live >>> EmbeddedRift.layer.mapError(asT),
-      Set(Capability.Faults, Capability.Scripting, Capability.ProxyRecord, Capability.Templating),
+      Set(
+        Capability.Faults,
+        Capability.Scripting,
+        Capability.ProxyRecord,
+        Capability.Templating,
+        Capability.StatefulScenarios,
+        Capability.StateInspection
+      ),
       Isolation.PerInstance,
       available = EmbeddedRift.available
     )

--- a/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
+++ b/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
@@ -2,6 +2,8 @@ package zio.bdd.mock.rift.embedded
 
 import zio.*
 import zio.bdd.mock.{MockControl, MockError, Provisioning}
+import zio.http.Client
+import zio.json.ast.Json
 
 import java.nio.file.{Files, Path, StandardCopyOption}
 
@@ -20,9 +22,13 @@ import java.nio.file.{Files, Path, StandardCopyOption}
  *
  * Requires Project Panama FFM, a preview API on JDK 21: the host JVM must run
  * with `--enable-preview` (and `--enable-native-access` to silence the
- * restricted-method warning).
+ * restricted-method warning). Requires the C-ABI v2 (rift#343, `librift_ffi` ≥
+ * v0.9.0) — a pre-v2 library fails fast at start with a missing-symbol error.
  */
 object EmbeddedRift:
+
+  // The engine binds the in-process admin API on loopback with an OS-assigned port (rift#343).
+  private val serveAdminOptions: String = Json.Obj("host" -> Json.Str("127.0.0.1"), "port" -> Json.Num(0)).toString
 
   /**
    * True iff a `librift_ffi` resolves for the host (a bundled native resource,
@@ -32,20 +38,44 @@ object EmbeddedRift:
 
   /**
    * A scoped [[MockControl]] backed by the in-process Rift engine: `rift_start`
-   * on layer construction, `rift_stop` on close. Fails with
-   * [[MockError.ProvisionFailed]] when no native library resolves for the host,
-   * or it cannot be loaded.
+   * plus `rift_serve_admin` (the in-process admin plane) on layer construction,
+   * `rift_stop` on close. Self-contained — it builds its own loopback HTTP
+   * client for the admin plane, so the public requirement stays just
+   * [[Provisioning]]. Fails with [[MockError.ProvisionFailed]] when no native
+   * library resolves for the host, or it cannot be loaded.
    */
   def layer: ZLayer[Provisioning, MockError, MockControl] =
     ZLayer.scoped {
       for
-        prov    <- ZIO.service[Provisioning]
-        source  <- ZIO.fromEither(NativeLibrary.resolveSource)
-        path    <- loadablePath(source)
-        engine  <- RiftFfi.start(path.toString)
-        control <- EmbeddedRiftMockControl.make(engine, prov)
+        prov   <- ZIO.service[Provisioning]
+        engine <- startEngine
+        // Standing up the admin plane is part of constructing the backend, so a failure here is a
+        // ProvisionFailed (matching this layer's contract), not the raw CommunicationError.
+        adminInfo <-
+          engine
+            .serveAdmin(serveAdminOptions)
+            .mapError(e => MockError.ProvisionFailed(s"starting the embedded Rift admin plane: $e"))
+        client  <- adminClient
+        control <- EmbeddedRiftMockControl.make(engine, prov, EmbeddedRiftMockControl.Admin(adminInfo.adminUrl, client))
       yield control
     }
+
+  // Resolve the native library and start the engine, scoped (rift_start on acquire, rift_stop on
+  // close). Shared by `layer` and the live FFI spec (which drives the engine's admin plane directly).
+  private[embedded] def startEngine: ZIO[Scope, MockError, EmbeddedEngine] =
+    for
+      source <- ZIO.fromEither(NativeLibrary.resolveSource)
+      path   <- loadablePath(source)
+      engine <- RiftFfi.start(path.toString)
+    yield engine
+
+  // The loopback HTTP client for the in-process admin plane, owned by the layer's scope so the
+  // embedded adapter needs nothing from the environment but Provisioning (mirrors the container
+  // adapter's Client, but self-provided).
+  private def adminClient: ZIO[Scope, MockError, Client] =
+    Client.default.build
+      .map(_.get[Client])
+      .mapError(t => MockError.ProvisionFailed(s"building embedded Rift admin HTTP client: ${message(t)}"))
 
   // An override is already a real path; a bundled resource is extracted to a temp file (removed when
   // the JVM exits — the engine keeps the loaded library mapped, so the file is no longer needed).
@@ -67,3 +97,6 @@ object EmbeddedRift:
           val msg = Option(t.getMessage).filter(_.nonEmpty).fold("")(m => s": $m")
           MockError.ProvisionFailed(s"extracting bundled native '$resource': ${t.getClass.getSimpleName}$msg")
         }
+
+  private def message(t: Throwable): String =
+    Option(t.getMessage).getOrElse(t.getClass.getSimpleName)

--- a/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
+++ b/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
@@ -2,7 +2,8 @@ package zio.bdd.mock.rift.embedded
 
 import zio.*
 import zio.bdd.mock.*
-import zio.bdd.mock.rift.RiftProtocol
+import zio.bdd.mock.rift.{RiftProtocol, RiftScenarioAdmin}
+import zio.http.Client
 import zio.json.*
 import zio.json.ast.Json
 
@@ -13,49 +14,58 @@ import zio.json.ast.Json
  *
  * It shares the Mountebank-compatible JSON codec ([[RiftProtocol]]) with the
  * container adapter — the FFI consumes the same imposter/stub model the admin
- * API does — so the wire fidelity is identical; only the transport differs (FFM
- * downcalls instead of HTTP).
+ * API does — so the wire fidelity is identical; only the transport differs.
  *
- * The FFI surface is intentionally small: create an imposter, replace all of
- * its stubs, read its recorded requests. So this adapter keeps each space's
- * ordered rules in a [[Ref]] and realises every rule mutation as a
- * whole-imposter `rift_replace_stubs` (first-match order: overlay prepends,
- * base appends). It is PerInstance only — one imposter per space on its own
- * OS-assigned localhost port (the host allocates a free port, the engine binds
- * it directly; no container port-mapping).
+ * Requires the C-ABI v2 (rift#343, `librift_ffi` ≥ v0.9.0): the engine starts
+ * the '''real''' admin API in-process on loopback
+ * ([[EmbeddedEngine.serveAdmin]]) over the same manager the FFI downcalls
+ * drive. So the adapter is "the container adapter minus Docker": the hot-path
+ * data plane stays FFI downcalls (`create_imposter`/`replace_stubs`/`recorded`,
+ * no HTTP hop), while the admin long tail — scenario pin/read/reset — routes
+ * over the loopback admin URL through the shared [[RiftScenarioAdmin]], exactly
+ * as the container adapter does. `destroy` frees the port via
+ * `rift_delete_imposter`. All six capabilities are advertised. (Older Rift is
+ * unsupported — a pre-v2 library fails fast at load, so there is no legacy
+ * tier.)
  *
- * The stub-based optional capabilities — [[Faults]], [[Scripting]],
- * [[ProxyRecord]], [[Templating]] — need no transport beyond
- * `rift_replace_stubs` (each is a special-response stub the engine serves
- * natively), so they are wired the same way the container adapter wires them
- * over the admin API: the capability stub is tracked in `imp.extras` and
- * re-registered ahead of the space's rules on every rebuild, so it wins
- * first-match and is removable via [[removeRule]]. [[StatefulScenarios]] and
- * [[StateInspection]] stay unsupported: they require the scenario-state
- * endpoints (pin/read/reset the initial state) the C-ABI does not expose. So
- * the embedded capability set is deliberately those four; the two stateful
- * capabilities negotiate a justified SKIP.
+ * The FFI surface for stubs is intentionally small: create an imposter, replace
+ * all of its stubs, read its recorded requests. So this adapter keeps each
+ * space's ordered rules in a [[Ref]] and realises every
+ * rule/scenario/capability mutation as a whole-imposter `rift_replace_stubs`
+ * (first-match order: capability stubs, then scenario stubs, then rules, then
+ * native base stubs). It is PerInstance only — one imposter per space on its
+ * own OS-assigned localhost port.
  */
 private[embedded] final case class EmbeddedRiftMockControl(
   engine: EmbeddedEngine,
   provisioning: Provisioning,
   spaces: Ref[Map[SpaceId, EmbeddedRiftMockControl.Imposter]],
-  ids: Ref[Int]
+  ids: Ref[Int],
+  admin: EmbeddedRiftMockControl.Admin
 ) extends MockControl:
 
   import EmbeddedRiftMockControl.Imposter
 
   def backendName: String = "embedded"
+
+  // The v2 in-process admin plane makes the embedded adapter capability-complete: all six.
   def capabilities: Set[Capability] =
-    Set(Capability.Faults, Capability.Scripting, Capability.ProxyRecord, Capability.Templating)
+    Set(
+      Capability.Faults,
+      Capability.Scripting,
+      Capability.ProxyRecord,
+      Capability.Templating,
+      Capability.StatefulScenarios,
+      Capability.StateInspection
+    )
 
   def provision(source: MockSource): IO[MockError, List[MockSpace]] =
     for
       sources <- provisioning.normalize(source)
       created <- Ref.make(List.empty[MockSpace])
       // Provision atomically: if a later source fails, tear down the spaces already stood up so a
-      // partial provision doesn't leave them serving (their bound ports are reclaimed only when the
-      // engine stops). The original failure propagates; a cleanup failure is logged, never masks it.
+      // partial provision doesn't leave them serving. The original failure propagates; a cleanup
+      // failure is logged, never masks it.
       spaces <- ZIO
                   .foreach(sources)(src => serve(src).tap(s => created.update(s :: _)))
                   .onError(_ => created.get.flatMap(ZIO.foreachDiscard(_)(s => destroy(s).ignoreLogged)))
@@ -80,7 +90,7 @@ private[embedded] final case class EmbeddedRiftMockControl(
                  case Priority.Base    => cur :+ (ruleId, rule)
         // Server-first, commit tracking on success — so a failed downcall never leaves the Ref
         // claiming a rule the engine didn't accept.
-        _ <- rebuild(imp, extras, next)
+        _ <- rebuildCurrent(imp, extras, next)
         _ <- imp.rules.set(next)
       yield ruleId
     }
@@ -94,10 +104,10 @@ private[embedded] final case class EmbeddedRiftMockControl(
         _ <-
           if rules.exists(_._1 == id) then
             val next = rules.filterNot(_._1 == id)
-            rebuild(imp, extras, next) *> imp.rules.set(next)
+            rebuildCurrent(imp, extras, next) *> imp.rules.set(next)
           else if extras.exists(_._1 == id) then
             val nextE = extras.filterNot(_._1 == id)
-            rebuild(imp, nextE, rules) *> imp.extras.set(nextE)
+            rebuildCurrent(imp, nextE, rules) *> imp.extras.set(nextE)
           else ZIO.fail(MockError.RuleNotFound(space.id, id))
       yield ()
     }
@@ -107,18 +117,16 @@ private[embedded] final case class EmbeddedRiftMockControl(
       for
         next   <- tagRules(rules)
         extras <- imp.extras.get
-        _      <- rebuild(imp, extras, next)
+        _      <- rebuildCurrent(imp, extras, next)
         _      <- imp.rules.set(next)
       yield ()
     }
 
   def destroy(space: MockSpace): IO[MockError, Unit] =
     withImposter(space) { imp =>
-      // The C-ABI has no per-imposter delete (only `rift_delete_all`, which would tear down sibling
-      // spaces), so destroy empties the imposter's stubs (it then serves only the 404 default) and
-      // drops local tracking — after which every op on this space fails SpaceNotFound. The bound
-      // port lingers until the engine stops; that is reclaimed when the scoped layer closes.
-      engine.replaceStubs(imp.port, "[]") *> spaces.update(_ - space.id)
+      // rift_delete_imposter frees the bound port immediately (an equal-port re-provision then
+      // succeeds); tracking is dropped so every later op on the space fails SpaceNotFound.
+      engine.deleteImposter(imp.port) *> spaces.update(_ - space.id)
     }
 
   def received(space: MockSpace): IO[MockError, List[RecordedRequest]] =
@@ -135,9 +143,9 @@ private[embedded] final case class EmbeddedRiftMockControl(
   def proxyRecord: IO[Unsupported, ProxyRecord] = ZIO.succeed(embeddedProxyRecord)
   def templating: IO[Unsupported, Templating]   = ZIO.succeed(embeddedTemplating)
 
-  // No scenario-state endpoints over the C-ABI (see the class doc), so these stay unsupported.
-  def scenarios: IO[Unsupported, StatefulScenarios]     = unsupported(Capability.StatefulScenarios)
-  def stateInspection: IO[Unsupported, StateInspection] = unsupported(Capability.StateInspection)
+  // Scenario/state route over the in-process admin plane (rift#343).
+  def scenarios: IO[Unsupported, StatefulScenarios]     = ZIO.succeed(embeddedScenarios)
+  def stateInspection: IO[Unsupported, StateInspection] = ZIO.succeed(embeddedStateInspection)
 
   // ===== Stub-based capabilities (#132/#185) ======================================
   // Each installs a special-response stub (`_rift.fault`, `_rift.script`, a Mountebank
@@ -171,10 +179,68 @@ private[embedded] final case class EmbeddedRiftMockControl(
         rules  <- imp.rules.get
         extras <- imp.extras.get
         next    = (ruleId, buildStub(ruleId)) +: extras
-        _      <- rebuild(imp, next, rules)
+        _      <- rebuildCurrent(imp, next, rules)
         _      <- imp.extras.set(next)
       yield ruleId
     }
+
+  // ===== StatefulScenarios + StateInspection (v2, #131/#193) ======================
+  // The v2 in-process admin plane runs over the same ImposterManager the FFI downcalls drive
+  // (rift#343), so a stateful stub registered via rift_replace_stubs is visible to the admin
+  // scenario endpoints, and pinning state over loopback HTTP affects the FFI-served imposter. The
+  // stateful stubs are tracked (imp.scenarioStubs) so a later rule/capability rebuild preserves
+  // them; the state pin/read reuses RiftScenarioAdmin (shared with the container adapter). flowId =
+  // the imposter port (PerInstance), matching how requests resolve their state slice.
+
+  private val embeddedScenarios: StatefulScenarios = new StatefulScenarios:
+    def define(space: MockSpace, sc: ScenarioDef): IO[MockError, Unit] =
+      withImposter(space) { imp =>
+        val newStubs =
+          sc.rules.map(r =>
+            RiftProtocol.statefulStub(sc.name, r.whenState, r.thenState, MockRule(r.request, r.respond))
+          )
+        for
+          cur    <- imp.scenarioStubs.get
+          extras <- imp.extras.get
+          rules  <- imp.rules.get
+          nextS   = cur ++ newStubs
+          // Ordering mirrors the container adapter's piDefine (server-first): register the stubs,
+          // commit the stub-tracking Ref (so a later rebuild preserves them), pin the initial state,
+          // then commit the scenarios map. Like the container, a re-define of an existing name appends
+          // rather than replaces — provision a fresh space per scenario (as the conformance does).
+          _ <- rebuildWith(imp, extras, nextS, rules)
+          _ <- imp.scenarioStubs.set(nextS)
+          _ <- putScenarioState(imp, sc.name, sc.initial)
+          _ <- imp.scenarios.update(_ + (sc.name -> sc.initial))
+        yield ()
+      }
+    def reset(space: MockSpace, name: String): IO[MockError, Unit] =
+      withImposter(space) { imp =>
+        imp.scenarios.get.flatMap(_.get(name) match
+          case Some(initial) => putScenarioState(imp, name, initial)
+          case None          => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${space.id.value}"))
+        )
+      }
+
+  private val embeddedStateInspection: StateInspection = new StateInspection:
+    def currentState(space: MockSpace, name: String): IO[MockError, ScenarioState] =
+      withImposter(space) { imp =>
+        RiftScenarioAdmin.readState(admin.client, admin.url, imp.port, imp.port.toString, name).flatMap {
+          case Some(s) => ZIO.succeed(ScenarioState(s))
+          case None    => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${space.id.value}"))
+        }
+      }
+    def setState(space: MockSpace, name: String, to: ScenarioState): IO[MockError, Unit] =
+      withImposter(space) { imp =>
+        imp.scenarios.get.flatMap(s =>
+          if s.contains(name) then putScenarioState(imp, name, to)
+          else ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${space.id.value}"))
+        )
+      }
+
+  // flowId = the imposter port (PerInstance): the slice a request resolves its scenario state to.
+  private def putScenarioState(imp: Imposter, name: String, state: ScenarioState): IO[MockError, Unit] =
+    RiftScenarioAdmin.putState(admin.client, admin.url, imp.port, imp.port.toString, name, state)
 
   // ---------------------------------------------------------------------------
 
@@ -189,10 +255,12 @@ private[embedded] final case class EmbeddedRiftMockControl(
       _ <- ZIO.unless(bound == port)(
              ZIO.fail(MockError.ProvisionFailed(s"embedded Rift bound port $bound but $port was requested"))
            )
-      rules  <- Ref.make(built.tagged)
-      extras <- Ref.make(Vector.empty[(RuleId, Json)])
-      id      = SpaceId(s"${src.name}-$port")
-      _      <- spaces.update(_.updated(id, Imposter(port, rules, extras, built.nativeStubs)))
+      rules     <- Ref.make(built.tagged)
+      extras    <- Ref.make(Vector.empty[(RuleId, Json)])
+      scenStubs <- Ref.make(Vector.empty[Json])
+      scenarios <- Ref.make(Map.empty[String, ScenarioState])
+      id         = SpaceId(s"${src.name}-$port")
+      _         <- spaces.update(_.updated(id, Imposter(port, rules, extras, scenStubs, scenarios, built.nativeStubs)))
     yield MockSpace(s"http://localhost:$port", identity, id)
 
   private def withImposter[A](space: MockSpace)(f: Imposter => IO[MockError, A]): IO[MockError, A] =
@@ -204,8 +272,7 @@ private[embedded] final case class EmbeddedRiftMockControl(
   // Build the create-imposter body for `src`, the portable rules to track, and the native base
   // stubs to preserve. A DSL source's rules are each tagged with a fresh id and tracked; a raw
   // imposter document's own stubs aren't portable rules, so they are kept verbatim as a base layer
-  // that every later `rift_replace_stubs` rebuild re-registers beneath the tracked rules — so a
-  // mutation (e.g. an overlay) on a natively-provisioned space doesn't drop its native stubs.
+  // that every later `rift_replace_stubs` rebuild re-registers beneath the tracked rules.
   private def buildImposter(port: Int, src: NormalizedSource): IO[MockError, EmbeddedRiftMockControl.Built] =
     src.payload match
       case SourcePayload.Rules(rules) =>
@@ -234,36 +301,51 @@ private[embedded] final case class EmbeddedRiftMockControl(
   private def withIds(tagged: Vector[(RuleId, MockRule)]): List[MockRule] =
     tagged.map((rid, r) => r.copy(id = Some(rid))).toList
 
-  // Re-register a space's whole stub list via `rift_replace_stubs`: the tracked capability stubs
-  // (faults/script/proxy/template) first so they win first-match, then the tracked portable rules
-  // in first-match order, then the native base stubs (so an overlay rule shadows a native stub).
-  private def rebuild(
+  // Re-register a space's whole stub list via `rift_replace_stubs`, first-match order: the tracked
+  // capability stubs (faults/script/proxy/template), then the scenario stubs, then the portable
+  // rules, then the native base stubs. `rebuildCurrent` reads the current scenario stubs; `rebuildWith`
+  // takes them explicitly so `define` can rebuild-then-commit server-first.
+  private def rebuildCurrent(
     imp: Imposter,
     extras: Vector[(RuleId, Json)],
     tracked: Vector[(RuleId, MockRule)]
   ): IO[MockError, Unit] =
-    val stubs = extras.map(_._2) ++ withIds(tracked).map(RiftProtocol.stub) ++ imp.nativeStubs
+    imp.scenarioStubs.get.flatMap(sc => rebuildWith(imp, extras, sc, tracked))
+
+  private def rebuildWith(
+    imp: Imposter,
+    extras: Vector[(RuleId, Json)],
+    scenarioStubs: Vector[Json],
+    tracked: Vector[(RuleId, MockRule)]
+  ): IO[MockError, Unit] =
+    val stubs = extras.map(_._2) ++ scenarioStubs ++ withIds(tracked).map(RiftProtocol.stub) ++ imp.nativeStubs
     engine.replaceStubs(imp.port, Json.Arr(stubs*).toJson)
 
   private def freshId: UIO[RuleId]                  = ids.updateAndGet(_ + 1).map(n => RuleId(s"r$n"))
   private def freshIds(n: Int): UIO[Vector[RuleId]] = ZIO.foreach(0 until n)(_ => freshId).map(_.toVector)
 
-  private def unsupported[A](c: Capability): IO[Unsupported, A] = ZIO.fail(Unsupported(c, backendName))
-
 private[embedded] object EmbeddedRiftMockControl:
 
   /**
+   * Where the v2 in-process admin plane is reachable, plus the HTTP client to
+   * reach it.
+   */
+  final case class Admin(url: String, client: Client)
+
+  /**
    * A live imposter: its bound port, the ordered portable rules tracked for
-   * `rift_replace_stubs`, the pre-built capability stubs (#132/#185: fault /
-   * script / proxy / template) re-registered ahead of the rules on every
-   * rebuild, and the native base stubs (from a raw imposter document)
-   * re-registered beneath the tracked rules — both empty for a plain
-   * DSL-provisioned space with no capability injected.
+   * `rift_replace_stubs`, the pre-built capability stubs (#132/#185) and
+   * scenario stubs (#193) re-registered ahead of the rules on every rebuild,
+   * the defined scenarios' initial states (for reset), and the native base
+   * stubs (from a raw imposter document) re-registered beneath the tracked
+   * rules.
    */
   final case class Imposter(
     port: Int,
     rules: Ref[Vector[(RuleId, MockRule)]],
     extras: Ref[Vector[(RuleId, Json)]],
+    scenarioStubs: Ref[Vector[Json]],
+    scenarios: Ref[Map[String, ScenarioState]],
     nativeStubs: Vector[Json]
   )
 
@@ -273,8 +355,8 @@ private[embedded] object EmbeddedRiftMockControl:
    */
   final case class Built(configJson: String, tagged: Vector[(RuleId, MockRule)], nativeStubs: Vector[Json])
 
-  def make(engine: EmbeddedEngine, provisioning: Provisioning): UIO[MockControl] =
+  def make(engine: EmbeddedEngine, provisioning: Provisioning, admin: Admin): UIO[MockControl] =
     for
       spaces <- Ref.make(Map.empty[SpaceId, Imposter])
       ids    <- Ref.make(0)
-    yield EmbeddedRiftMockControl(engine, provisioning, spaces, ids)
+    yield EmbeddedRiftMockControl(engine, provisioning, spaces, ids, admin)

--- a/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/RiftFfi.scala
+++ b/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/RiftFfi.scala
@@ -2,12 +2,18 @@ package zio.bdd.mock.rift.embedded
 
 import zio.*
 import zio.bdd.mock.MockError
+import zio.json.*
 
 /**
- * The ZIO-facing surface over the Rift engine's small C-ABI: create an
- * imposter, replace all of its stubs, read its recorded requests. A trait (not
- * just the live wrapper) so the adapter can be unit-tested against a recording
- * double without the native library.
+ * The ZIO-facing surface over the Rift engine's C-ABI v2 (rift#343,
+ * `librift_ffi` ≥ v0.9.0): the data plane (create an imposter, replace all of
+ * its stubs, read its recorded requests) plus the in-process admin plane
+ * ([[serveAdmin]]), per-imposter delete ([[deleteImposter]]), and build
+ * identity ([[buildInfo]]). A pre-v2 library fails fast at load
+ * ([[RiftFfiBridge.start]]), so this surface always assumes v2.
+ *
+ * A trait (not just the live wrapper) so the adapter can be unit-tested against
+ * a recording double without the native library.
  */
 private[embedded] trait EmbeddedEngine:
 
@@ -24,7 +30,41 @@ private[embedded] trait EmbeddedEngine:
    */
   def recorded(port: Int): IO[MockError, String]
 
+  /**
+   * Start the real admin API in-process on this engine's runtime, over this
+   * engine's manager (so FFI-created imposters are visible to it), and yield
+   * the loopback admin URL.
+   */
+  def serveAdmin(optionsJson: String): IO[MockError, EmbeddedEngine.AdminInfo]
+
+  /** Delete one imposter, freeing its bound port. */
+  def deleteImposter(port: Int): IO[MockError, Unit]
+
+  /** The engine's build identity (version/commit/features). */
+  def buildInfo: IO[MockError, EmbeddedEngine.BuildInfo]
+
 private[embedded] object EmbeddedEngine:
+
+  /**
+   * The result of [[EmbeddedEngine.serveAdmin]] — where the in-process admin
+   * API is reachable.
+   */
+  final case class AdminInfo(adminUrl: String, adminPort: Int)
+  object AdminInfo:
+    given JsonDecoder[AdminInfo] = DeriveJsonDecoder.gen[AdminInfo]
+
+  /**
+   * The engine's build identity from `rift_build_info`. `commit`/`builtAt` may
+   * be absent.
+   */
+  final case class BuildInfo(
+    version: String,
+    commit: Option[String] = None,
+    builtAt: Option[String] = None,
+    features: List[String] = Nil
+  )
+  object BuildInfo:
+    given JsonDecoder[BuildInfo] = DeriveJsonDecoder.gen[BuildInfo]
 
   /**
    * The live engine over [[RiftFfiBridge]] — the Panama FFM bindings to
@@ -35,23 +75,67 @@ private[embedded] object EmbeddedEngine:
    */
   final class Live(bridge: RiftFfiBridge) extends EmbeddedEngine:
 
+    // The data-plane calls return sentinels (port 0, rc -1, null) rather than throwing, so the
+    // engine's reason (rift_last_error) is read on the SAME blocking thread — inside the thunk —
+    // and folded into the message (the crate confines last_error to the failing thread). A success
+    // is Right; a sentinel is Left(message-with-reason), turned into the typed MockError below.
+
     def createImposter(configJson: String): IO[MockError, Int] =
-      blocking("rift_create_imposter")(bridge.createImposter(configJson)).flatMap { port =>
-        if port == 0 then
-          ZIO.fail(MockError.ProvisionFailed("rift_create_imposter returned 0 (bind failure or malformed config)"))
-        else ZIO.succeed(port)
+      blocking("rift_create_imposter") {
+        val port = bridge.createImposter(configJson)
+        if port == 0 then Left(withReason("rift_create_imposter returned 0 (bind failure or malformed config)"))
+        else Right(port)
+      }.flatMap {
+        case Right(port) => ZIO.succeed(port)
+        case Left(msg)   => ZIO.fail(MockError.ProvisionFailed(msg))
       }
 
     def replaceStubs(port: Int, stubsJson: String): IO[MockError, Unit] =
-      blocking("rift_replace_stubs")(bridge.replaceStubs(port, stubsJson)).flatMap { rc =>
-        if rc == 0 then ZIO.unit
-        else ZIO.fail(MockError.CommunicationError(s"rift_replace_stubs returned $rc for port $port"))
+      blocking("rift_replace_stubs") {
+        val rc = bridge.replaceStubs(port, stubsJson)
+        if rc == 0 then None else Some(withReason(s"rift_replace_stubs returned $rc for port $port"))
+      }.flatMap {
+        case None      => ZIO.unit
+        case Some(msg) => ZIO.fail(MockError.CommunicationError(msg))
       }
 
     def recorded(port: Int): IO[MockError, String] =
-      blocking("rift_recorded")(bridge.recorded(port)).flatMap { json =>
-        if json == null then ZIO.fail(MockError.CommunicationError(s"rift_recorded returned null for port $port"))
-        else ZIO.succeed(json)
+      blocking("rift_recorded") {
+        val json = bridge.recorded(port)
+        if json == null then Left(withReason(s"rift_recorded returned null for port $port")) else Right(json)
+      }.flatMap {
+        case Right(json) => ZIO.succeed(json)
+        case Left(msg)   => ZIO.fail(MockError.CommunicationError(msg))
+      }
+
+    // Append the engine's thread-local reason to a sentinel message. MUST be called on the same
+    // thread as the failing downcall (inside the `blocking` thunk) — see RiftFfiBridge.lastError.
+    private def withReason(base: String): String =
+      Option(bridge.lastError()).filter(_.nonEmpty).fold(base)(r => s"$base: $r")
+
+    def serveAdmin(optionsJson: String): IO[MockError, AdminInfo] =
+      blocking("rift_serve_admin")(bridge.serveAdmin(optionsJson)).flatMap { json =>
+        ZIO
+          .fromEither(json.fromJson[AdminInfo])
+          .mapError(e => MockError.CommunicationError(s"rift_serve_admin returned unparseable admin info: $e ($json)"))
+      }
+
+    def deleteImposter(port: Int): IO[MockError, Unit] =
+      blocking("rift_delete_imposter") {
+        val rc = bridge.deleteImposter(port)
+        if rc == 0 then None else Some(withReason(s"rift_delete_imposter returned $rc for port $port"))
+      }.flatMap {
+        case None      => ZIO.unit
+        case Some(msg) => ZIO.fail(MockError.CommunicationError(msg))
+      }
+
+    def buildInfo: IO[MockError, BuildInfo] =
+      blocking("rift_build_info")(bridge.buildInfo).flatMap { json =>
+        if json == null then ZIO.fail(MockError.CommunicationError("rift_build_info returned null"))
+        else
+          ZIO
+            .fromEither(json.fromJson[BuildInfo])
+            .mapError(e => MockError.CommunicationError(s"rift_build_info returned unparseable build info: $e ($json)"))
       }
 
     private def blocking[A](op: String)(thunk: => A): IO[MockError, A] =

--- a/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/RiftFfiBridge.java
+++ b/rift/src/main/jdk21/zio/bdd/mock/rift/embedded/RiftFfiBridge.java
@@ -10,22 +10,32 @@ import java.lang.invoke.MethodHandle;
 import java.nio.file.Path;
 
 /**
- * Project Panama (FFM) bindings to the {@code librift_ffi} C-ABI (rift#204): an opaque handle +
- * JSON in / JSON out over the Rift engine, so {@code MockControl.embedded} can drive Rift
- * in-process with no Docker. Authored in Java because FFM is a preview API in JDK 21 and the
- * downcall {@link MethodHandle#invoke} is signature-polymorphic — both are handled natively by
- * javac (the {@code --enable-preview} class bit and the per-call-site descriptor), avoiding the
- * cross-language pitfalls of calling these from Scala.
+ * Project Panama (FFM) bindings to the {@code librift_ffi} C-ABI: an opaque handle + JSON in / JSON
+ * out over the Rift engine, so {@code MockControl.embedded} can drive Rift in-process with no Docker.
+ * Authored in Java because FFM is a preview API in JDK 21 and the downcall {@link MethodHandle#invoke}
+ * is signature-polymorphic — both are handled natively by javac (the {@code --enable-preview} class
+ * bit and the per-call-site descriptor), avoiding the cross-language pitfalls of calling these from
+ * Scala.
  *
- * <p>Boundary discipline mirrors the crate: memory is created and freed on the same side
- * ({@link #recorded} hands the {@code *mut c_char} straight back to {@code rift_free}); the handle
- * owns a Tokio runtime on its own threads, so the blocking downcalls are wrapped in
- * {@code ZIO.attemptBlocking} by the Scala caller. One bridge is safe to share across threads —
- * the engine is {@code Sync} and every input string is marshalled in a per-call confined arena.
+ * <p>Requires the C-ABI v2 (rift#343, first shipped in {@code librift_ffi} v0.9.0): the data plane
+ * ({@code rift_start/stop/create_imposter/replace_stubs/recorded/free}) plus the in-process admin
+ * plane ({@code rift_serve_admin}), per-imposter delete ({@code rift_delete_imposter}), build
+ * identity ({@code rift_build_info}), and thread-local error text ({@code rift_last_error}). All
+ * symbols are bound at {@link #start}, so a pre-v2 library fails fast there with a missing-symbol
+ * error rather than degrading silently — zio-bdd pins the v2 natives and does not support older Rift.
+ *
+ * <p>Boundary discipline mirrors the crate: memory is created and freed on the same side (returned
+ * {@code *mut c_char} buffers are handed straight back to {@code rift_free}; {@code rift_build_info}
+ * is the one static string that must NOT be freed); the handle owns a Tokio runtime on its own
+ * threads, so the blocking downcalls are wrapped in {@code ZIO.attemptBlocking} by the Scala caller.
+ * One bridge is safe to share across threads — the engine is {@code Sync} and every input string is
+ * marshalled in a per-call confined arena.
  *
  * <p>Errors are returned as the crate's sentinels (port {@code 0}, rc {@code -1}, null pointer),
- * never exceptions; a genuine FFM/link failure surfaces as a {@link RuntimeException} the caller
- * turns into a {@code MockError}.
+ * never exceptions; the library also records a thread-local reason ({@code rift_last_error}) that a
+ * failed call folds into its {@link RuntimeException} so the caller's {@code MockError} carries the
+ * engine-side message instead of "see engine tracing". A genuine FFM/link failure surfaces as a
+ * {@link RuntimeException} the caller turns into a {@code MockError}.
  */
 public final class RiftFfiBridge implements AutoCloseable {
 
@@ -39,8 +49,12 @@ public final class RiftFfiBridge implements AutoCloseable {
   private final MethodHandle free;
   private final MethodHandle stop;
 
-  // rift_delete_all is intentionally not bound: it is a global reset that would tear down sibling
-  // imposters, so the adapter destroys a single space via rift_replace_stubs([]) instead.
+  // v2 (rift#343): the in-process admin plane, per-imposter delete, build identity, thread-local error.
+  private final MethodHandle serveAdmin;
+  private final MethodHandle deleteImposter;
+  private final MethodHandle buildInfo;
+  private final MethodHandle lastError;
+
   private RiftFfiBridge(Arena arena, SymbolLookup lookup, MemorySegment handle) {
     this.arena = arena;
     this.handle = handle;
@@ -52,6 +66,14 @@ public final class RiftFfiBridge implements AutoCloseable {
         FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_SHORT));
     this.free = downcall(lookup, "rift_free", FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
     this.stop = downcall(lookup, "rift_stop", FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+    // v2 symbols are mandatory: binding them here makes a pre-v2 library fail fast at start with a
+    // missing-symbol error (rift_build_info being the canonical v2 marker).
+    this.buildInfo = downcall(lookup, "rift_build_info", FunctionDescriptor.of(ValueLayout.ADDRESS));
+    this.serveAdmin = downcall(lookup, "rift_serve_admin",
+        FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+    this.deleteImposter = downcall(lookup, "rift_delete_imposter",
+        FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_SHORT));
+    this.lastError = downcall(lookup, "rift_last_error", FunctionDescriptor.of(ValueLayout.ADDRESS));
   }
 
   /**
@@ -86,7 +108,7 @@ public final class RiftFfiBridge implements AutoCloseable {
       short port = (short) createImposter.invoke(handle, call.allocateUtf8String(configJson));
       return port & 0xFFFF;
     } catch (Throwable t) {
-      throw new RuntimeException("rift_create_imposter downcall failed", t);
+      throw failure("rift_create_imposter", t);
     }
   }
 
@@ -95,7 +117,7 @@ public final class RiftFfiBridge implements AutoCloseable {
     try (Arena call = Arena.ofConfined()) {
       return (int) replaceStubs.invoke(handle, (short) port, call.allocateUtf8String(stubsJson));
     } catch (Throwable t) {
-      throw new RuntimeException("rift_replace_stubs downcall failed", t);
+      throw failure("rift_replace_stubs", t);
     }
   }
 
@@ -106,32 +128,68 @@ public final class RiftFfiBridge implements AutoCloseable {
   public String recorded(int port) {
     try {
       MemorySegment result = (MemorySegment) recorded.invoke(handle, (short) port);
+      return readAndFree(result);
+    } catch (Throwable t) {
+      throw failure("rift_recorded", t);
+    }
+  }
+
+  /**
+   * Start the in-process admin API from an options JSON ({@code {"host":..,"port":..}}); returns the
+   * admin-info JSON ({@code {"adminPort":N,"adminUrl":"http://..","metricsPort":..}}). Throws with the
+   * engine's {@code rift_last_error} message on a null sentinel (bad JSON, bind failure, or a plane
+   * already serving — one plane per handle).
+   */
+  public String serveAdmin(String optionsJson) {
+    MemorySegment result;
+    try (Arena call = Arena.ofConfined()) {
+      // The returned buffer is engine-owned, independent of `call`, so reading it after the arena
+      // closes is safe — only the input string lives in `call`.
+      result = (MemorySegment) serveAdmin.invoke(handle, call.allocateUtf8String(optionsJson));
+    } catch (Throwable t) {
+      throw failure("rift_serve_admin", t);
+    }
+    String json;
+    try {
+      json = readAndFree(result);
+    } catch (Throwable t) {
+      throw failure("rift_serve_admin", t);
+    }
+    if (json == null) {
+      throw new IllegalStateException("rift_serve_admin returned null" + lastErrorSuffix());
+    }
+    return json;
+  }
+
+  /** Delete one imposter, freeing its port. Returns {@code 0} on success, {@code -1} on error. */
+  public int deleteImposter(int port) {
+    try {
+      return (int) deleteImposter.invoke(handle, (short) port);
+    } catch (Throwable t) {
+      throw failure("rift_delete_imposter", t);
+    }
+  }
+
+  /**
+   * The engine's build identity JSON ({@code {"version":..,"commit":..,"builtAt":..,"features":[..]}}).
+   * The pointer is a STATIC string owned by the library — it is read but never freed.
+   */
+  public String buildInfo() {
+    try {
+      MemorySegment result = (MemorySegment) buildInfo.invoke();
       if (result.address() == 0L) {
         return null;
       }
-      Throwable primary = null;
-      try {
-        return result.reinterpret(Long.MAX_VALUE).getUtf8String(0);
-      } catch (Throwable t) {
-        primary = t;
-        throw t;
-      } finally {
-        // Free the buffer either way, but never let a free failure mask the read failure.
-        try {
-          free.invoke(result);
-        } catch (Throwable t) {
-          if (primary != null) primary.addSuppressed(t);
-          else throw t;
-        }
-      }
+      return result.reinterpret(Long.MAX_VALUE).getUtf8String(0);
     } catch (Throwable t) {
-      throw new RuntimeException("rift_recorded downcall failed", t);
+      throw failure("rift_build_info", t);
     }
   }
 
   /**
    * Stop the engine ({@code rift_stop}) and release the native library. Not idempotent — call
-   * exactly once; the scoped layer guarantees a single release.
+   * exactly once; the scoped layer guarantees a single release. In v2 mode {@code rift_stop} also
+   * shuts the admin/metrics listeners down before the manager.
    */
   @Override
   public void close() {
@@ -150,5 +208,58 @@ public final class RiftFfiBridge implements AutoCloseable {
         else throw t;
       }
     }
+  }
+
+  // Read a returned *mut c_char (or null → Java null), freeing it via rift_free either way — never
+  // letting a free failure mask the read failure. Shared by recorded / serve_admin.
+  private String readAndFree(MemorySegment result) throws Throwable {
+    if (result.address() == 0L) {
+      return null;
+    }
+    Throwable primary = null;
+    try {
+      return result.reinterpret(Long.MAX_VALUE).getUtf8String(0);
+    } catch (Throwable t) {
+      primary = t;
+      throw t;
+    } finally {
+      try {
+        free.invoke(result);
+      } catch (Throwable t) {
+        if (primary != null) primary.addSuppressed(t);
+        else throw t;
+      }
+    }
+  }
+
+  /**
+   * The engine's thread-local last-error text ({@code rift_last_error}) recorded by a failed
+   * {@code rift_*} call on '''this''' thread, or {@code null} if none. Callers reading it after a
+   * returned sentinel (port {@code 0}, rc {@code -1}, null) MUST do so on the same thread as the
+   * failing call — the crate confines the error to that thread and clears it on read. Best-effort:
+   * never throws.
+   */
+  public String lastError() {
+    return lastErrorText();
+  }
+
+  // The thread-local last-error text from the engine (null when none). Reading it clears it on the
+  // crate side, and the buffer is freed via rift_free.
+  private String lastErrorText() {
+    try {
+      MemorySegment result = (MemorySegment) lastError.invoke();
+      return readAndFree(result);
+    } catch (Throwable t) {
+      return null; // best-effort diagnostics — never let error-reading mask the original failure
+    }
+  }
+
+  private String lastErrorSuffix() {
+    String msg = lastErrorText();
+    return (msg == null || msg.isEmpty()) ? "" : " (" + msg + ")";
+  }
+
+  private RuntimeException failure(String op, Throwable t) {
+    return new RuntimeException(op + " downcall failed" + lastErrorSuffix(), t);
   }
 }

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -279,24 +279,17 @@ private[rift] final case class RiftMockControl(
       else ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${spaceId.value}"))
     )
 
+  // The scenario pin/read calls are shared with the embedded adapter (RiftScenarioAdmin) so both
+  // reach the byte-identical admin endpoints from one implementation; readState maps the shared
+  // `Option` to this adapter's space-scoped InvalidDefinition on an undeclared scenario.
   private def putState(port: Int, flowId: String, name: String, state: ScenarioState): IO[MockError, Unit] =
-    for
-      u   <- url(s"/imposters/$port/scenarios/${enc(name)}/state")
-      body = Json.Obj("state" -> Json.Str(state.value), "flowId" -> Json.Str(flowId))
-      res <- send(jsonRequest(HttpMethod.PUT, u, body))
-      _   <- expectSuccess(s"set scenario '$name' state on imposter $port", res)
-    yield ()
+    RiftScenarioAdmin.putState(client, endpoint.adminBase, port, flowId, name, state)
 
   private def readState(port: Int, flowId: String, spaceId: SpaceId, name: String): IO[MockError, ScenarioState] =
-    for
-      u    <- url(s"/imposters/$port/scenarios?flowId=${enc(flowId)}")
-      res  <- send(Request(method = HttpMethod.GET, url = u))
-      body <- expectSuccess(s"read scenarios for imposter $port", res)
-      st   <- ZIO.fromEither(RiftProtocol.parseScenarioState(body, name)).mapError(MockError.CommunicationError(_))
-      out <- st match
-               case Some(s) => ZIO.succeed(ScenarioState(s))
-               case None    => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${spaceId.value}"))
-    yield out
+    RiftScenarioAdmin.readState(client, endpoint.adminBase, port, flowId, name).flatMap {
+      case Some(s) => ZIO.succeed(ScenarioState(s))
+      case None    => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${spaceId.value}"))
+    }
 
   // ---------------------------------------------------------------------------
 

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftScenarioAdmin.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftScenarioAdmin.scala
@@ -1,0 +1,91 @@
+package zio.bdd.mock.rift
+
+import zio.*
+import zio.bdd.mock.{MockError, ScenarioState}
+import zio.http.{Body, Client, Header, MediaType, Request, URL, Method as HttpMethod}
+import zio.json.*
+import zio.json.ast.Json
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
+
+/**
+ * The scenario / flow-state control-plane calls over Rift's admin API, factored
+ * out so both adapters that reach it — the container adapter
+ * ([[RiftMockControl]] over the mapped admin port) and the embedded adapter
+ * (over the v2 in-process admin plane, rift#343) — issue the byte-identical
+ * calls with a single implementation.
+ *
+ * These are the endpoints the C-ABI could not reach before v2: pin the initial
+ * state (`PUT /imposters/:port/scenarios/:name/state`) and read the current
+ * state (`GET /imposters/:port/scenarios?flowId=…`). `flowId` addresses the
+ * state slice a request resolves to — the imposter port (PerInstance) or the
+ * correlation value (Correlated). The stub registration + `Ref` bookkeeping
+ * stay in each adapter (they differ by transport and isolation); only this HTTP
+ * glue and the [[RiftProtocol]] codec are shared.
+ */
+private[rift] object RiftScenarioAdmin:
+
+  /**
+   * Pin scenario `name` on `(port, flowId)` to `state` (`PUT
+   * …/scenarios/:name/state`).
+   */
+  def putState(
+    client: Client,
+    adminBase: String,
+    port: Int,
+    flowId: String,
+    name: String,
+    state: ScenarioState
+  ): IO[MockError, Unit] =
+    for
+      u   <- url(adminBase, s"/imposters/$port/scenarios/${enc(name)}/state")
+      body = Json.Obj("state" -> Json.Str(state.value), "flowId" -> Json.Str(flowId))
+      res <- send(client, jsonRequest(HttpMethod.PUT, u, body))
+      _   <- expectSuccess(s"set scenario '$name' state on imposter $port", res)
+    yield ()
+
+  /**
+   * The current state of scenario `name` on `(port, flowId)`, or `None` if the
+   * scenario isn't declared (`GET …/scenarios?flowId=…`). Callers map `None` to
+   * their own space-scoped error.
+   */
+  def readState(
+    client: Client,
+    adminBase: String,
+    port: Int,
+    flowId: String,
+    name: String
+  ): IO[MockError, Option[String]] =
+    for
+      u    <- url(adminBase, s"/imposters/$port/scenarios?flowId=${enc(flowId)}")
+      res  <- send(client, Request(method = HttpMethod.GET, url = u))
+      body <- expectSuccess(s"read scenarios for imposter $port", res)
+      st   <- ZIO.fromEither(RiftProtocol.parseScenarioState(body, name)).mapError(MockError.CommunicationError(_))
+    yield st
+
+  private def enc(s: String): String = URLEncoder.encode(s, UTF_8)
+
+  private def url(adminBase: String, path: String): IO[MockError, URL] =
+    ZIO
+      .fromEither(URL.decode(adminBase + path))
+      .mapError(e => MockError.CommunicationError(s"invalid admin URL $adminBase$path: ${e.getMessage}"))
+
+  private def jsonRequest(method: HttpMethod, u: URL, body: Json): Request =
+    Request(method = method, url = u, body = Body.fromString(body.toJson))
+      .addHeader(Header.ContentType(MediaType.application.json))
+
+  private def send(client: Client, req: Request): IO[MockError, (Int, String)] =
+    Client
+      .batched(req)
+      .flatMap(resp => resp.body.asString.map(body => (resp.status.code, body)))
+      .provideEnvironment(ZEnvironment(client))
+      .mapError { t =>
+        val msg = Option(t.getMessage).filter(_.nonEmpty).fold("")(m => s": $m")
+        MockError.CommunicationError(s"${t.getClass.getSimpleName}$msg")
+      }
+
+  private def expectSuccess(action: String, res: (Int, String)): IO[MockError, String] =
+    val (code, body) = res
+    if code >= 200 && code < 300 then ZIO.succeed(body)
+    else ZIO.fail(MockError.CommunicationError(s"$action: Rift returned HTTP $code: ${body.take(1000)}"))

--- a/rift/src/test/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
+++ b/rift/src/test/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
@@ -2,23 +2,25 @@ package zio.bdd.mock.rift.embedded
 
 import zio.*
 import zio.bdd.mock.*
+import zio.bdd.mock.rift.FakeRift
+import zio.http.Client
 import zio.json.*
 import zio.json.ast.Json
 import zio.test.*
 
 /**
- * Unit gate for the embedded (FFI) adapter's optional-capability wiring (#185).
+ * Unit gate for the embedded (FFI) adapter's v2 wiring (#193) — no native
+ * library. The data plane is a recording [[EmbeddedEngine]] double (echoes the
+ * requested port, captures the latest replace-stubs JSON per port, records
+ * `deleteImposter` calls), and the in-process admin plane is stood in for by
+ * [[FakeRift]] (the same fake the container adapter's unit spec uses), so the
+ * scenario/state control-plane calls the v2 adapter routes over the admin URL
+ * can be asserted with no Docker and no engine.
  *
- * The FFI surface is exactly create-imposter / replace-stubs / read-recorded,
- * so every stub-based capability (faults, scripting, proxy/record, templating)
- * is realised as a whole-imposter `rift_replace_stubs` with the capability stub
- * registered ahead of the tracked rules (first-match). This spec drives the
- * adapter against a recording [[EmbeddedEngine]] double — no native library —
- * and asserts the emitted stub JSON, so it runs in a plain `sbt test`.
- *
- * StatefulScenarios + StateInspection stay unsupported: they need the
- * scenario-state endpoints (pin/read/reset initial state) the C-ABI does not
- * expose, so the embedded capability set is deliberately those four.
+ * With the v2 admin plane up the adapter is capability-complete: all six
+ * capabilities are advertised; the stub-based four are realised as
+ * whole-imposter `rift_replace_stubs`, the stateful two route to the admin
+ * client, and `destroy` frees the port via `rift_delete_imposter`.
  */
 object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
 
@@ -29,13 +31,19 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
   private val pingSource = MockSource.Dsl(MockSpec(List(pingRule)))
 
   // A recording engine that echoes the requested port (parsed from the config, like the real
-  // engine) and keeps the latest replace-stubs JSON per port so the test can inspect the wire.
-  private final class RecordingEngine(replaced: Ref[Map[Int, String]]) extends EmbeddedEngine:
+  // engine), keeps the latest replace-stubs JSON per port, and records deleteImposter calls. The v2
+  // admin-plane methods aren't exercised here (the adapter is built directly with a FakeRift-backed
+  // Admin), so they return canned values.
+  private final class RecordingEngine(replaced: Ref[Map[Int, String]], deleted: Ref[Chunk[Int]]) extends EmbeddedEngine:
     def createImposter(configJson: String): IO[MockError, Int] =
       ZIO.succeed(portOf(configJson))
     def replaceStubs(port: Int, stubsJson: String): IO[MockError, Unit] =
       replaced.update(_.updated(port, stubsJson))
     def recorded(port: Int): IO[MockError, String] = ZIO.succeed("[]")
+    def serveAdmin(optionsJson: String): IO[MockError, EmbeddedEngine.AdminInfo] =
+      ZIO.succeed(EmbeddedEngine.AdminInfo("http://unused", 0))
+    def deleteImposter(port: Int): IO[MockError, Unit]     = deleted.update(_ :+ port)
+    def buildInfo: IO[MockError, EmbeddedEngine.BuildInfo] = ZIO.succeed(EmbeddedEngine.BuildInfo("test"))
 
     private def portOf(cfg: String): Int =
       cfg
@@ -48,39 +56,55 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
   private def portFromUri(baseUri: String): Int = baseUri.substring(baseUri.lastIndexOf(':') + 1).toInt
 
   private def withControl(
-    use: (MockControl, Ref[Map[Int, String]]) => IO[Any, TestResult]
-  ): ZIO[Provisioning, Any, TestResult] =
-    for
-      prov     <- ZIO.service[Provisioning]
-      replaced <- Ref.make(Map.empty[Int, String])
-      control  <- EmbeddedRiftMockControl.make(RecordingEngine(replaced), prov)
-      result   <- use(control, replaced)
-    yield result
+    use: (MockControl, Ref[Map[Int, String]], Ref[Chunk[Int]], FakeRift) => IO[Any, TestResult]
+  ): ZIO[Client & Provisioning, Any, TestResult] =
+    ZIO.scoped {
+      for
+        prov            <- ZIO.service[Provisioning]
+        client          <- ZIO.service[Client]
+        replaced        <- Ref.make(Map.empty[Int, String])
+        deleted         <- Ref.make(Chunk.empty[Int])
+        adminAndFake    <- FakeRift.started
+        (adminUrl, fake) = adminAndFake
+        control <- EmbeddedRiftMockControl.make(
+                     RecordingEngine(replaced, deleted),
+                     prov,
+                     EmbeddedRiftMockControl.Admin(adminUrl, client)
+                   )
+        result <- use(control, replaced, deleted, fake)
+      yield result
+    }
 
   def spec = suite("EmbeddedRiftCapabilities")(
-    test("advertises exactly the four stub-based capabilities and every accessor succeeds") {
-      withControl { (control, _) =>
+    test("advertises all six capabilities and every accessor succeeds") {
+      withControl { (control, _, _, _) =>
         for
           faultsE   <- control.faults.either
           scriptE   <- control.scripting.either
           proxyE    <- control.proxyRecord.either
           templateE <- control.templating.either
+          scenE     <- control.scenarios.either
+          siE       <- control.stateInspection.either
         yield assertTrue(
           control.capabilities == Set(
             Capability.Faults,
             Capability.Scripting,
             Capability.ProxyRecord,
-            Capability.Templating
+            Capability.Templating,
+            Capability.StatefulScenarios,
+            Capability.StateInspection
           ),
           faultsE.isRight,
           scriptE.isRight,
           proxyE.isRight,
-          templateE.isRight
+          templateE.isRight,
+          scenE.isRight,
+          siE.isRight
         )
       }
     },
     test("faults.inject rebuilds the imposter with a first-match _rift.fault stub ahead of the rules") {
-      withControl { (control, replaced) =>
+      withControl { (control, replaced, _, _) =>
         for
           space  <- control.provision(pingSource).map(_.head)
           port    = portFromUri(space.baseUri)
@@ -96,7 +120,7 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
       }
     },
     test("scripting/proxyRecord/templating each rebuild with a first-match capability stub ahead of the rules") {
-      withControl { (control, replaced) =>
+      withControl { (control, replaced, _, _) =>
         for
           space    <- control.provision(pingSource).map(_.head)
           port      = portFromUri(space.baseUri)
@@ -115,8 +139,6 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
           json.contains("rhai") && json.contains("/s"),
           json.contains("proxyOnce") && json.contains("http://up") && json.contains("/p"),
           json.contains("copy") && json.contains("${V}") && json.contains("/t"),
-          // each capability stub wins first-match — the `contains` guards above ensure these index
-          // comparisons aren't satisfied vacuously by a `-1` (absent) match.
           json.indexOf("/s") < json.indexOf("/ping"),
           json.indexOf("/p") < json.indexOf("/ping"),
           json.indexOf("/t") < json.indexOf("/ping")
@@ -124,7 +146,7 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
       }
     },
     test("an injected capability rule is tracked and removable; the rebuild drops the stub, unknown ids fail") {
-      withControl { (control, replaced) =>
+      withControl { (control, replaced, _, _) =>
         for
           space  <- control.provision(pingSource).map(_.head)
           port    = portFromUri(space.baseUri)
@@ -135,15 +157,15 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
           ghostE <- control.removeRule(space, RuleId("ghost")).either
         yield assertTrue(
           rmE.isRight,
-          !json.contains("CONNECTION_RESET_BY_PEER"), // the fault stub is gone after removal
+          !json.contains("CONNECTION_RESET_BY_PEER"),
           !json.contains("/boom"),
-          json.contains("/ping"), // the normal rule survives
+          json.contains("/ping"),
           ghostE == Left(MockError.RuleNotFound(space.id, RuleId("ghost")))
         )
       }
     },
     test("an injected extra survives a later addRule/replaceRules and stays first-match ahead of the new rules") {
-      withControl { (control, replaced) =>
+      withControl { (control, replaced, _, _) =>
         val addedRule = MockRule(RequestMatch(path = PathMatch.Exact("/added")), ResponseDef(status = 200))
         val replRule  = MockRule(RequestMatch(path = PathMatch.Exact("/replaced")), ResponseDef(status = 200))
         for
@@ -156,27 +178,129 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
           _         <- control.replaceRules(space, List(replRule))
           afterRepl <- replaced.get.map(_.getOrElse(port, ""))
         yield assertTrue(
-          // addRule keeps the fault stub, still ahead of the newly-added rule
           afterAdd.contains("CONNECTION_RESET_BY_PEER") && afterAdd.contains("/added"),
           afterAdd.indexOf("/boom") < afterAdd.indexOf("/added"),
-          // replaceRules swaps the ruleset but preserves the injected fault, still first-match
           afterRepl.contains("CONNECTION_RESET_BY_PEER") && afterRepl.contains("/replaced"),
           !afterRepl.contains("/added"),
           afterRepl.indexOf("/boom") < afterRepl.indexOf("/replaced")
         )
       }
     },
-    test("scenarios + stateInspection stay unsupported and are not advertised") {
-      withControl { (control, _) =>
+    test("scenarios: define registers the stateful stubs (FFI) and pins the initial state (admin plane)") {
+      withControl { (control, replaced, _, fake) =>
+        val invoice = ScenarioDef(
+          "invoice",
+          List(
+            StatefulRule(
+              ScenarioState("Unpaid"),
+              RequestMatch(method = Some(Method.Post), path = PathMatch.Exact("/pay")),
+              ResponseDef(status = 200),
+              thenState = Some(ScenarioState("Paid"))
+            )
+          ),
+          initial = ScenarioState("Unpaid")
+        )
         for
-          scenE <- control.scenarios.either
-          siE   <- control.stateInspection.either
+          space <- control.provision(pingSource).map(_.head)
+          port   = portFromUri(space.baseUri)
+          ss    <- control.scenarios
+          _     <- ss.define(space, invoice)
+          stubs <- replaced.get.map(_.getOrElse(port, ""))
+          puts  <- fake.scenarioPuts.get
         yield assertTrue(
-          scenE == Left(Unsupported(Capability.StatefulScenarios, "embedded")),
-          siE == Left(Unsupported(Capability.StateInspection, "embedded")),
-          !control.capabilities.contains(Capability.StatefulScenarios),
-          !control.capabilities.contains(Capability.StateInspection)
+          // the stateful stub is registered via rift_replace_stubs, ahead of the /ping rule
+          stubs.contains("\"scenarioName\":\"invoice\""),
+          stubs.contains("\"requiredScenarioState\":\"Unpaid\""),
+          stubs.contains("\"newScenarioState\":\"Paid\""),
+          stubs.indexOf("/pay") < stubs.indexOf("/ping"),
+          // define pins the initial state via PUT …/scenarios/invoice/state {state, flowId=port}
+          puts.exists(p =>
+            p.startsWith(s"$port/invoice") && p.contains("\"state\":\"Unpaid\"") && p.contains(s"\"flowId\":\"$port\"")
+          )
+        )
+      }
+    },
+    test("stateInspection: currentState reads the admin view; setState/reset pin; unknown scenarios fail") {
+      withControl { (control, _, _, fake) =>
+        val sc = ScenarioDef("s", List.empty, initial = ScenarioState("A"))
+        for
+          space  <- control.provision(pingSource).map(_.head)
+          port    = portFromUri(space.baseUri)
+          ss     <- control.scenarios
+          si     <- control.stateInspection
+          _      <- ss.define(space, sc)
+          _      <- fake.setScenarios(s"""{"flowId":"$port","scenarios":[{"name":"s","state":"B"}]}""")
+          cur    <- si.currentState(space, "s")
+          gets   <- fake.scenarioGets.get
+          _      <- si.setState(space, "s", ScenarioState("C"))
+          _      <- ss.reset(space, "s")
+          puts   <- fake.scenarioPuts.get
+          ghostS <- si.currentState(space, "ghost").either
+          ghostR <- ss.reset(space, "ghost").either
+          // setState guards on the locally-tracked scenarios (a distinct path from currentState's
+          // admin-view check and reset's map lookup) — an unknown name must fail before any PUT.
+          ghostSet  <- si.setState(space, "ghost", ScenarioState("Z")).either
+          putsAfter <- fake.scenarioPuts.get
+        yield assertTrue(
+          cur == ScenarioState("B"),
+          gets.exists(_ == s"$port?$port"),                                            // GET …/scenarios?flowId=port
+          puts.exists(p => p.startsWith(s"$port/s") && p.contains("\"state\":\"C\"")), // setState
+          puts.exists(p => p.startsWith(s"$port/s") && p.contains("\"state\":\"A\"")), // reset → initial
+          ghostS == Left(MockError.InvalidDefinition(s"no scenario 'ghost' on space ${space.id.value}")),
+          ghostR == Left(MockError.InvalidDefinition(s"no scenario 'ghost' on space ${space.id.value}")),
+          ghostSet == Left(MockError.InvalidDefinition(s"no scenario 'ghost' on space ${space.id.value}")),
+          !putsAfter.exists(_.startsWith(s"$port/ghost")) // the guard rejects before issuing any PUT
+        )
+      }
+    },
+    test("a defined scenario's stubs survive a later addRule/replaceRules, staying ahead of the new rules") {
+      withControl { (control, replaced, _, _) =>
+        val invoice = ScenarioDef(
+          "invoice",
+          List(
+            StatefulRule(
+              ScenarioState("Unpaid"),
+              RequestMatch(method = Some(Method.Post), path = PathMatch.Exact("/pay")),
+              ResponseDef(status = 200),
+              thenState = Some(ScenarioState("Paid"))
+            )
+          ),
+          initial = ScenarioState("Unpaid")
+        )
+        val addedRule = MockRule(RequestMatch(path = PathMatch.Exact("/added")), ResponseDef(status = 200))
+        val replRule  = MockRule(RequestMatch(path = PathMatch.Exact("/replaced")), ResponseDef(status = 200))
+        for
+          space     <- control.provision(pingSource).map(_.head)
+          port       = portFromUri(space.baseUri)
+          ss        <- control.scenarios
+          _         <- ss.define(space, invoice)
+          _         <- control.addRule(space, addedRule, Priority.Base)
+          afterAdd  <- replaced.get.map(_.getOrElse(port, ""))
+          _         <- control.replaceRules(space, List(replRule))
+          afterRepl <- replaced.get.map(_.getOrElse(port, ""))
+        yield assertTrue(
+          // the whole-imposter rebuild threads scenarioStubs through addRule, still ahead of the new rule
+          afterAdd.contains("\"scenarioName\":\"invoice\"") && afterAdd.contains("/added"),
+          afterAdd.indexOf("/pay") < afterAdd.indexOf("/added"),
+          // replaceRules swaps the ruleset but preserves the scenario stub, still first-match
+          afterRepl.contains("\"scenarioName\":\"invoice\"") && afterRepl.contains("/replaced"),
+          !afterRepl.contains("/added"),
+          afterRepl.indexOf("/pay") < afterRepl.indexOf("/replaced")
+        )
+      }
+    },
+    test("destroy frees the port via rift_delete_imposter; later ops on the space fail SpaceNotFound") {
+      withControl { (control, _, deleted, _) =>
+        for
+          space   <- control.provision(pingSource).map(_.head)
+          port     = portFromUri(space.baseUri)
+          _       <- control.destroy(space)
+          deletes <- deleted.get
+          goneE   <- control.received(space).either
+        yield assertTrue(
+          deletes == Chunk(port),
+          goneE == Left(MockError.SpaceNotFound(space.id))
         )
       }
     }
-  ).provide(Provisioning.live) @@ TestAspect.withLiveClock
+  ).provide(Provisioning.live, Client.default) @@ TestAspect.withLiveClock

--- a/rift/src/test/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRiftFfiSpec.scala
+++ b/rift/src/test/jdk21/zio/bdd/mock/rift/embedded/EmbeddedRiftFfiSpec.scala
@@ -168,5 +168,79 @@ object EmbeddedRiftFfiSpec extends ZIOSpecDefault:
             result <- control.provision(MockSource.Dir(dir.toString)).either
           yield assertTrue(result.isLeft))
           .provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
+    },
+    test("v2: rift_serve_admin yields a loopback admin URL and rift_build_info a non-empty version") {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
+      else
+        ZIO.scoped(
+          for
+            engine <- EmbeddedRift.startEngine.mapError(asT)
+            info   <- engine.serveAdmin("""{"host":"127.0.0.1","port":0}""").mapError(asT)
+            build  <- engine.buildInfo.mapError(asT)
+          yield assertTrue(
+            info.adminUrl.startsWith("http://127.0.0.1:"),
+            info.adminPort > 0,
+            build.version.nonEmpty
+          )
+        )
+    },
+    test("v2: capability set is all six and stateful scenarios round-trip over the in-process admin plane") {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
+      else
+        val checkout =
+          ScenarioDef(
+            "checkout",
+            List(
+              StatefulRule(
+                ScenarioState.Started,
+                RequestMatch(method = Some(Method.Get), path = PathMatch.Exact("/step")),
+                ResponseDef(status = 200, body = Body.Text("one")),
+                thenState = Some(ScenarioState("Done"))
+              )
+            ),
+            initial = ScenarioState.Started
+          )
+        (for
+          control <- ZIO.service[MockControl]
+          space   <- control.provision(pingSource).mapError(asT).map(_.head)
+          ss      <- control.scenarios.mapError(u => new RuntimeException(s"Unsupported: $u"))
+          si      <- control.stateInspection.mapError(u => new RuntimeException(s"Unsupported: $u"))
+          _       <- ss.define(space, checkout).mapError(asT)
+          s0      <- si.currentState(space, "checkout").mapError(asT)
+          stepped <- SutClient.make(space).send(Method.Get, "/step")
+          s1      <- si.currentState(space, "checkout").mapError(asT)
+          _       <- ss.reset(space, "checkout").mapError(asT)
+          s2      <- si.currentState(space, "checkout").mapError(asT)
+          _       <- control.destroy(space).mapError(asT)
+        yield assertTrue(
+          control.capabilities == Set(
+            Capability.Faults,
+            Capability.Scripting,
+            Capability.ProxyRecord,
+            Capability.Templating,
+            Capability.StatefulScenarios,
+            Capability.StateInspection
+          ),
+          s0 == ScenarioState.Started,
+          stepped.status == 200 && stepped.body == "one",
+          s1 == ScenarioState("Done"), // serving /step advanced the FSM
+          s2 == ScenarioState.Started  // reset re-pinned the initial state
+        )).provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
+    },
+    test("v2: destroy frees the port via rift_delete_imposter — an immediate re-provision serves again") {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
+      else
+        (for
+          control <- ZIO.service[MockControl]
+          first   <- control.provision(pingSource).mapError(asT).map(_.head)
+          r1      <- SutClient.make(first).send(Method.Get, "/ping")
+          _       <- control.destroy(first).mapError(asT)
+          second  <- control.provision(pingSource).mapError(asT).map(_.head)
+          r2      <- SutClient.make(second).send(Method.Get, "/ping")
+          _       <- control.destroy(second).mapError(asT)
+        yield assertTrue(
+          r1.status == 200 && r1.body == "pong",
+          r2.status == 200 && r2.body == "pong" // re-provision after destroy serves — no port leak
+        )).provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
     }
   ) @@ TestAspect.withLiveClock


### PR DESCRIPTION
## Summary

Adopt Rift's C-ABI v2 (librift_ffi v0.9.0) in the embedded MockControl adapter. The engine starts the real admin API in-process on loopback and routes control-plane ops through a shared RiftScenarioAdmin helper (also used by the container adapter). Full capability support (all six) enables live conformance testing for stateful scenarios. Mandatory v2 FFM binding drops legacy fallback.

Closes #193

## Verification

- Rift native tests: 79/79 green
- Conformance tests: 28/28 green (2 Docker-gated ignored)
- Live FFI bridge validated on v0.9.0 natives, including stateful round-trip

## Note

This change drops the issue's stated legacy compatibility contract (pre-v2 library support) per repo-owner direction. A follow-up finding (zio-bdd#195) tracked rift-version drift for future hardening.