### PR TITLE
build: couple riftNativesVersion and the container DefaultImage tag to one rift-version source of truth

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,11 @@ import java.security.MessageDigest
 // preview API on JDK 21, so the embedded code stays JDK-21-gated; see embeddedNativeSettings.)
 // NOTE: build.sbt is compiled with the Scala 2.12 dialect — keep these blocks 2.12-compatible.
 
-val riftNativesVersion = "0.9.0"
+// Single source of truth for the pinned Rift release (#195). Both the FFI natives (riftNativesVersion,
+// downloaded into the embedded-natives jar) and the container image tag (Rift.DefaultImage, via the
+// generated RiftBuildInfo below) derive from it, so a version bump touches exactly one line.
+val riftVersion        = "0.9.0"
+val riftNativesVersion = riftVersion
 
 // The (os, arch, ext) cdylibs bundled into the natives jar — linux/macOS × x86_64/aarch64 (#134).
 val riftNativeTriples: Seq[(String, String, String)] = Seq(
@@ -262,6 +266,22 @@ lazy val rift = {
         "com.dimafeng" %% "testcontainers-scala-core"  % "0.41.4"
       ),
       testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+      // Generate RiftBuildInfo from `riftVersion` (the single source of truth, #195) so Rift.DefaultImage
+      // derives its image tag from the same val the FFI natives version does — no hand-maintained literal.
+      Compile / sourceGenerators += Def.task {
+        val out = (Compile / sourceManaged).value / "zio" / "bdd" / "mock" / "rift" / "RiftBuildInfo.scala"
+        IO.write(
+          out,
+          s"""package zio.bdd.mock.rift
+             |
+             |// GENERATED from `riftVersion` in build.sbt (#195) — do not edit. The single source of truth
+             |// for the pinned Rift release; Rift.DefaultImage and the FFI natives version both derive from it.
+             |private[rift] object RiftBuildInfo:
+             |  val riftVersion: String = "$riftVersion"
+             |""".stripMargin
+        )
+        Seq(out)
+      }.taskValue,
       // The embedded adapter (#133) lives in JDK-21-only source dirs (src/{main,test}/jdk21) and is
       // compiled with --release 21 --enable-preview — added by embeddedNativeSettings only on a 21+ JDK,
       // so on the JDK-11 baseline the rift module builds (and publishes) without the FFM bridge.

--- a/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
@@ -52,13 +52,13 @@ object RiftMode:
  */
 object Rift:
 
-  // Pinned to v0.9.0. Floor is v0.8.0: the adapter emits the flat
-  // `_rift.flowState.flowIdSource` shape (EtaCassiopeia/rift#266, #268), which
-  // Rift only reads from v0.8.0 on — earlier images expect the dropped
-  // `mountebankStateMapping` wrapper and return 404/empty on the correlated
-  // path. v0.8.0 also carries the v0.4.0 correlated-isolation endpoints (#223)
-  // and the v0.2.0 keep-alive teardown fix (#207).
-  val DefaultImage: String     = "zainalpour/rift-proxy:v0.9.0"
+  // The version is `riftVersion` in build.sbt (the single source of truth, #195), surfaced here via
+  // the generated RiftBuildInfo so the image tag and the FFI natives version never drift apart.
+  // Floor is v0.8.0: the adapter emits the flat `_rift.flowState.flowIdSource` shape
+  // (EtaCassiopeia/rift#266, #268), which Rift only reads from v0.8.0 on — earlier images expect the
+  // dropped `mountebankStateMapping` wrapper and return 404/empty on the correlated path. v0.8.0 also
+  // carries the v0.4.0 correlated-isolation endpoints (#223) and the v0.2.0 keep-alive teardown fix (#207).
+  val DefaultImage: String     = s"zainalpour/rift-proxy:v${RiftBuildInfo.riftVersion}"
   val DefaultAdminPort: Int    = 2525
   val DefaultImposterBase: Int = 4545
   val DefaultPoolSize: Int     = 16

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
@@ -1,0 +1,22 @@
+package zio.bdd.mock.rift
+
+import zio.test.*
+
+/**
+ * Pins the single-source-of-truth wiring (#195): `Rift.DefaultImage` must be
+ * derived from the generated [[RiftBuildInfo.riftVersion]] (which build.sbt
+ * generates from its `riftVersion` val, the same val the FFI natives version
+ * derives from) — not an independently-maintained literal. A bump to
+ * `riftVersion` in build.sbt then flows here automatically; a drift between the
+ * image tag and the version constant fails this test.
+ */
+object RiftBuildInfoSpec extends ZIOSpecDefault:
+  def spec = suite("RiftBuildInfo")(
+    test("DefaultImage is derived from the single rift-version source of truth") {
+      assertTrue(
+        RiftBuildInfo.riftVersion == "0.9.0",
+        Rift.DefaultImage == s"zainalpour/rift-proxy:v${RiftBuildInfo.riftVersion}",
+        Rift.DefaultImage == "zainalpour/rift-proxy:v0.9.0"
+      )
+    }
+  )


### PR DESCRIPTION
Single riftVersion source of truth in build.sbt; natives version and generated RiftBuildInfo both derive from it. DefaultImage interpolates the tag instead of hard-coding, ensuring they never drift apart. Hand-rolled sourceGenerator (no plugin added). Behavior unchanged: DefaultImage is still zainalpour/rift-proxy:v0.9.0.

Closes #195

Verification: rift 80/80 (incl. new RiftBuildInfoSpec pinning DefaultImage == derived value), conformance 28/28 (2 Docker-gated ignored), scalafmtCheckAll green