### PR TITLE
chore: fix compile warnings

### DIFF
--- a/core/src/main/scala/zio/bdd/core/Default.scala
+++ b/core/src/main/scala/zio/bdd/core/Default.scala
@@ -15,6 +15,11 @@ object Default:
    * startup if no default.
    */
   transparent inline given schemaDefault[T](using schema: Schema[T]): Default[T] =
+    fromSchema(schema)
+
+  // The Default instance is built here (a regular method), not inline, so the anonymous class is
+  // compiled once rather than duplicated at every `schemaDefault` call site (Scala 3 E197).
+  private def fromSchema[T](schema: Schema[T]): Default[T] =
     new Default[T]:
       val default: T = schema.defaultValue match
         case Right(value) => value

--- a/core/src/test/scala/zio/bdd/core/LogCollectorSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/LogCollectorSpec.scala
@@ -147,14 +147,17 @@ object LogCollectorSpec extends ZIOSpecDefault {
     ),
     suite("Logger augmentation")(
       test("ZIO.log* calls do not throw even if collection fails") {
-        // The .ignore ensures logging never kills a fiber
-        ZIO
-          .logAnnotate("scenarioId", "x") {
-            ZIO.logAnnotate("stepId", "y") {
-              ZIO.logInfo("safe log") *> ZIO.succeed(assertCompletes)
-            }
-          }
-          .provide(LogCollector.live(debugConfig))
+        // The custom logger's collection is `.ignore`d, so logging never kills a fiber. Depend on the
+        // LogCollector service explicitly — the layer installs that logger, so it's a real dependency
+        // here (not an unused, over-provided layer), even though this test only asserts logging is safe.
+        (for
+          _ <- ZIO.service[LogCollector]
+          _ <- ZIO.logAnnotate("scenarioId", "x") {
+                 ZIO.logAnnotate("stepId", "y") {
+                   ZIO.logInfo("safe log")
+                 }
+               }
+        yield assertCompletes).provide(LogCollector.live(debugConfig))
       }
     )
   )

--- a/core/src/test/scala/zio/bdd/core/step/StepRegistrySpec.scala
+++ b/core/src/test/scala/zio/bdd/core/step/StepRegistrySpec.scala
@@ -13,20 +13,20 @@ object StepRegistrySpec extends ZIOSpecDefault with DefaultTypedExtractor {
   private val givenUser = makeStep(
     StepType.GivenStep,
     StepExpression(List(Literal("user "), Extractor(string))),
-    { case Tuple1(name) => ZIO.debug(s"user: $name") }
+    (t: Tuple1[String]) => ZIO.debug(s"user: ${t._1}")
   )
 
   private val whenAge = makeStep(
     StepType.WhenStep,
     StepExpression(List(Literal("age is "), Extractor(int))),
-    { case Tuple1(age) => ZIO.debug(s"age: $age") }
+    (t: Tuple1[Int]) => ZIO.debug(s"age: ${t._1}")
   )
 
   // This And step acts as universal glue for any keyword
   private val andRole = makeStep(
     StepType.AndStep,
     StepExpression(List(Literal("role is "), Extractor(string))),
-    { case Tuple1(role) => ZIO.debug(s"role: $role") }
+    (t: Tuple1[String]) => ZIO.debug(s"role: ${t._1}")
   )
 
   private def registry(steps: List[StepDef[Any, Unit]]) = StepRegistryLive[Any, Unit](steps)


### PR DESCRIPTION
## Summary

- **Default.scala (E197)**: Eliminated duplicate Default instance construction at call sites by extracting the anonymous instance from the transparent-inline body to a regular fromSchema method.
- **StepRegistrySpec (E029)**: Fixed non-exhaustive pattern match warnings by adding explicit Tuple1 parameter types to lambda expressions.
- **LogCollectorSpec (ZIO)**: Resolved over-provided-layer warning by explicitly depending on the LogCollector service instead of providing it only for its side effect.

## Verification

Full-build compile is warning-free; core suite 538/538 passing; scalafmt green.

Note: the remaining JDK-21 preview class-file zinc notes are inherent to the FFM bridge and are not code warnings.