### PR TITLE
ci: deploy docs via a dedicated GitHub Actions workflow (manual + docs-only)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,43 @@
+name: Docs
+
+on:
+  # Deploy only when the docs (or this workflow) actually change — not on every merge to master, which
+  # is what the built-in "deploy from a branch" Pages build did (and kept failing). Plus a manual run.
+  push:
+    branches: [master]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deployment at a time; don't cancel a deploy already in flight.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+      - uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The built-in "Deploy from a branch" Pages build (`pages-build-deployment`) fires on **every** push to `master` and its deploy step has been failing ([example run](https://github.com/EtaCassiopeia/zio-bdd/actions/runs/28711612543)).

Mirrors the fix in the [Rift repo](https://github.com/EtaCassiopeia/rift/blob/master/.github/workflows/docs.yml): a dedicated `docs.yml` that builds the Jekyll site from `docs/` and deploys to Pages via GitHub Actions, triggered **only** on `docs/**` changes or a manual `workflow_dispatch` — not after unrelated code merges.

### Follow-up required (repo setting, cannot be done in the PR)
Switch **Settings → Pages → Build and deployment → Source** from "Deploy from a branch" to **"GitHub Actions"** (equivalently `PATCH /repos/:owner/:repo/pages` with `build_type=workflow`). Until then both paths coexist. I will flip this via the API once the workflow is on `master`.