### PR TITLE
docs: bump install snippets to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ object AccountSpec extends ZIOSteps[Any, AccountState]:
 
 ```scala
 // build.sbt
-libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.0.0" % Test
+libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.2.0" % Test
 
 Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,7 +9,7 @@ as a concrete example throughout.
 In `build.sbt`:
 
 ```scala
-libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.0.0" % Test
+libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.2.0" % Test
 
 Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
 ```


### PR DESCRIPTION
The README and quickstart `build.sbt` snippets still showed `zio-bdd % "1.0.0"`; bump both to the just-released **1.2.0** so new users copy current coordinates.

- `README.md`
- `docs/quickstart.md`

(`docs/gherkin.md`'s `SimpleSavings | 1.0.0` is example table data, not a dependency version — left as-is.)

The full mocking + embedded/FFM documentation (both JDK variants, coordinates, flags, LuaJIT) is captured in #188.