### PR TITLE
docs: document the MockControl mocking feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ object AccountSpec extends ZIOSteps[Any, AccountState]:
 - **Step reuse** — `HasService[A, R]` typeclass lets step traits express service requirements without coupling to a concrete `R`
 - **Typed table extraction** — `table[T]` reads Gherkin data tables into `List[T]` using ZIO Schema
 - **Scalar extractors** — `string`, `word`, `int`, `long`, `double`, `boolean`, `bigDecimal`, `uuid`, `docString`
+- **HTTP mocking** — a portable `MockControl` SPI with Rift (container **and** no-Docker embedded FFM) and WireMock adapters; a type-safe mock DSL; capability negotiation; `@mock(...)` Gherkin fixtures — write one scenario, run it across backends (see [Mocking](docs/mocking.md))
 
 ## Installation
 
@@ -93,11 +94,13 @@ Both bundle the language server, so there is no separate setup step.
 | [docs/concepts.md](docs/concepts.md) | Mental model: how the framework works |
 | [docs/step-dsl.md](docs/step-dsl.md) | Step DSL, extractors, and patterns |
 | [docs/property-testing.md](docs/property-testing.md) | `@property(...)` tag, `HasGen[T]` registry, named generator overrides, failure replay, JUnit XML output |
+| [docs/mocking.md](docs/mocking.md) | HTTP mocking — portable `MockControl` SPI, DSL, adapters (Rift container + embedded, WireMock), `@mock` fixtures, capabilities |
 | [docs/index.md](docs/index.md) | Full documentation index — Gherkin syntax, state, layers, hooks, reporters, feature flags, cookbook, migrating from Cucumber, troubleshooting |
 
 ## Used by
 
 - [zio-openfeature](https://github.com/EtaCassiopeia/zio-openfeature) — ZIO bindings for the OpenFeature spec, using zio-bdd for conformance testing
+- [Rift](https://github.com/EtaCassiopeia/rift) — a Mountebank-compatible HTTP chaos proxy; drives its adapter conformance suite with zio-bdd (exercising a real backend end-to-end)
 
 ## License
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -575,3 +575,4 @@ WhenS("transfer " / bigDecimal / " from " / string) { s => (amount: BigDecimal, 
 | Capture state before an operation for comparison | `withSnapshot(_.field) { before => ... }` |
 | Run setup before every scenario | `beforeScenario { _ => ... }` |
 | Run setup only for tagged scenarios | `beforeScenarioTagged("tag") { meta => ... }` |
+| Mock an HTTP dependency in a scenario | See the [Mock Cookbook](mock-cookbook.md) — stand up a backend, `MockSteps`, `@mock(...)` fixtures, faults |

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,11 +36,27 @@ New to zio-bdd?  Read in this order:
 
 ---
 
+## Mocking
+
+Portable HTTP mocking — write a scenario once and run it across Rift (container **and** no-Docker
+embedded FFM) and WireMock, negotiating capabilities per backend.
+
+| Document | What it covers |
+|----------|----------------|
+| [Mocking Overview](mocking.md) | The portable `MockControl` SPI, `MockSpace` + isolation (PerInstance/Correlated), the request/response model, `MockSource` variants |
+| [Mock DSL](mock-dsl.md) | The `zio.bdd.mock.dsl.*` builder — matching requests, building responses, rule precedence, the stateful-scenario builder, raw JSON sources |
+| [Mock Adapters](mock-adapters.md) | Rift (`managed`/`connect`), WireMock, and the **embedded FFM** provider (JDK 21/22 matrix + artifacts, LuaJIT); the capability × adapter matrix; choosing one |
+| [Mock Gherkin Integration](mock-gherkin.md) | `MockSteps` mixin, the `@mock(name)` tag + `MockFixtures`, the catalog pattern, `Stage` |
+| [Mock Advanced](mock-advanced.md) | Capability accessors (faults, scenarios, state inspection, scripting, proxy/record, templating), the `provisionNative` escape hatch, capability negotiation |
+
+---
+
 ## Guides
 
 | Document | Use when |
 |----------|----------|
 | [Cookbook](cookbook.md) | You have a specific task: structuring a multi-module suite, passing data between steps, writing HTTP tests, date-relative parameters, soft assertions, selective tagging |
+| [Mock Cookbook](mock-cookbook.md) | You want mocking recipes: stand up a backend as a layer, a portable `MockSteps` scenario, `@mock(...)` fixtures, injecting faults across adapters |
 | [Troubleshooting](troubleshooting.md) | Something is wrong: compiler errors, startup failures, state not updating, missing step definitions, timeouts |
 | [Migrating from Cucumber](migrating.md) | You are converting a Cucumber-JVM + cucumber-scala suite to zio-bdd |
 

--- a/docs/layers.md
+++ b/docs/layers.md
@@ -323,3 +323,22 @@ isolation to the lower tiers.
 By default `globalLayer` delegates to `featureLayer`.  If you override neither,
 both tiers use whatever `environment` returns, which is the same single layer
 evaluated once per feature (the pre-3.0 behaviour).
+
+---
+
+## 8. Providing a `MockControl` mock backend
+
+The HTTP-mocking feature is delivered as an ordinary `ZLayer[…, …, MockControl]`, so a mock backend
+plugs into the same three-tier model. Add it to whichever tier owns the mock's lifetime — usually
+`environment`/`featureLayer` for a shared backend, or `scenarioLayer` when each scenario gets fresh,
+isolated mock spaces (e.g. with `@mock(...)` fixtures):
+
+```scala
+// a WireMock backend (in-process, JDK 11+, no Docker) available to every step:
+override def environment: ZLayer[Any, Throwable, MockControl] =
+  Provisioning.live >>> WireMock.correlated()
+```
+
+Swap that one layer to run the same suite on Rift (container or embedded) — see
+[Mock Adapters](mock-adapters.md). For per-scenario fixtures wired into `scenarioLayer`, see
+[Mock Gherkin Integration](mock-gherkin.md).

--- a/docs/mock-adapters.md
+++ b/docs/mock-adapters.md
@@ -1,0 +1,269 @@
+# Mock Adapters
+
+Three backends implement `MockControl`: a Docker-based Rift container, an
+in-process WireMock server, and a no-Docker embedded Rift bound via FFM. This
+page covers their coordinates, capabilities, and ZLayer wiring, and how to
+pick one.
+
+---
+
+## 1. The three backends at a glance
+
+| Adapter | Coordinates (1.2.0) | Docker? | JDK | Isolation default | Capabilities |
+|---|---|---|---|---|---|
+| Rift container | `zio-bdd-rift` | yes (testcontainers) | 11+ | PerInstance | all six |
+| WireMock | `zio-bdd-wiremock` | no | 11+ | Correlated (via `.correlated`) | Faults, StatefulScenarios, StateInspection only |
+| Rift embedded | `zio-bdd-rift-embedded` / `zio-bdd-rift-embedded-jdk21` | no (FFM) | 22+ / 21 | PerInstance | all six |
+
+### Capability × adapter matrix
+
+| Capability | Rift container | Rift embedded | WireMock |
+|---|---|---|---|
+| Faults | yes | yes | yes |
+| StatefulScenarios | yes | yes | yes |
+| StateInspection | yes | yes | yes |
+| Scripting | yes | yes | no |
+| ProxyRecord | yes | yes | no |
+| Templating | yes | yes | no |
+
+Rift container and Rift embedded are **capability-complete** — embedded is a
+pure backend swap for the container adapter, not a reduced subset. WireMock
+implements exactly the three capabilities in the first column; requesting
+`Capability.Scripting`, `Capability.ProxyRecord`, or `Capability.Templating`
+against it fails with `Unsupported` (§3 below, and see
+[Mocking overview](mocking.md) for the `MockError`/`Unsupported` model).
+
+---
+
+## 2. Rift container (`zio-bdd-rift`)
+
+```scala
+"io.github.etacassiopeia" %% "zio-bdd-rift" % "1.2.0"
+```
+
+Two entry points, both requiring a zio-http `Client` and a `Provisioning` in
+the environment:
+
+- **`Rift.managed(...)`** starts the pinned Rift image via testcontainers and
+  stops it when the layer's scope closes:
+
+  ```scala
+  def managed(
+    image: String = DefaultImage,
+    poolSize: Int = DefaultPoolSize,
+    adminPort: Int = DefaultAdminPort,
+    imposterBasePort: Int = DefaultImposterBase,
+    mode: RiftMode = RiftMode.PerInstance
+  ): ZLayer[Client & Provisioning, MockError, MockControl]
+  ```
+
+  `DefaultImage` is the pinned Rift image, currently `zainalpour/rift-proxy:v0.9.0`
+  — derived from the single `riftVersion` in `build.sbt`, so treat it as "the
+  pinned Rift image" rather than a hardcoded tag.
+
+- **`Rift.connect(...)`** targets an already-running Rift admin endpoint
+  instead of starting a container (used by tests, or when Rift runs
+  out-of-band):
+
+  ```scala
+  def connect(
+    adminBase: String,
+    imposterPorts: List[Int],
+    mode: RiftMode = RiftMode.PerInstance
+  )(hostFor: Int => String): URLayer[Client & Provisioning, MockControl]
+  ```
+
+Both take a `RiftMode`: `RiftMode.PerInstance` (default — one imposter port
+per `MockSpace`) or `RiftMode.Correlated(correlation)` / the `RiftMode.correlated`
+shorthand (one shared imposter, spaces tagged by a correlation header).
+
+Wiring, lifted from the sample corpus's `support/Backends.scala`:
+
+```scala
+import zio.bdd.mock.*
+import zio.bdd.mock.rift.Rift
+import zio.http.Client
+
+val provisioning: ULayer[Provisioning] = ZLayer(Provisioning.make)
+
+val mockControl: ZLayer[Any, Throwable, MockControl] =
+  (Client.default ++ provisioning) >>> Rift.managed().mapError(e => new RuntimeException(s"Rift: $e"))
+```
+
+See [layers](layers.md) for how this composes into a suite's `environment`.
+
+---
+
+## 3. WireMock (`zio-bdd-wiremock`)
+
+```scala
+"io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.2.0"
+```
+
+In-process, no Docker, runs on JDK 11+. Only requires `Provisioning`:
+
+```scala
+def correlated(correlation: Correlation = Correlation.spaceHeader): ZLayer[Provisioning, Throwable, MockControl]
+val perInstance: ZLayer[Provisioning, Throwable, MockControl]
+```
+
+- **`WireMock.correlated()`** (default) — one shared server, spaces
+  distinguished by a correlation header (`X-Mock-Space` by default via
+  `Correlation.spaceHeader`); isolation is `Isolation.Correlated`.
+- **`WireMock.perInstance`** — a fresh server per `MockSpace`; isolation is
+  `Isolation.PerInstance`.
+
+```scala
+import zio.bdd.mock.wiremock.WireMock
+
+val mockControl: ZLayer[Any, Throwable, MockControl] =
+  provisioning >>> WireMock.correlated()
+```
+
+WireMock is the cheapest adapter to stand up but is capped at three
+capabilities — Faults, StatefulScenarios, StateInspection. It has no
+Scripting, ProxyRecord, or Templating support; code that calls
+`.require(Capability.Scripting)` (or the equivalent direct accessor) against a
+WireMock-backed `MockControl` fails with `Unsupported`, by design — that's
+capability negotiation working as intended, not a bug to work around.
+
+---
+
+## 4. Embedded Rift (no-Docker, FFM)
+
+The embedded provider drives the Rift engine in-process over `librift_ffi` via
+Project Panama FFM — no container, no external process — while remaining
+**capability-complete** (parity with the container adapter, all six
+capabilities). This is the adapter to reach for when you want full fidelity
+without Docker.
+
+### Two version-locked artifacts
+
+FFM is a class-file-level lock: a class compiled against JDK 21's preview FFM
+API won't load on JDK 22+, and vice versa. So the embedded provider is
+published as **two variants built from the same source**, and you pick
+exactly one for your build's JDK:
+
+```scala
+"io.github.etacassiopeia" %% "zio-bdd-rift-embedded"       % "1.2.0" // JDK 22+ (stable FFM)
+"io.github.etacassiopeia" %% "zio-bdd-rift-embedded-jdk21" % "1.2.0" // JDK 21   (preview FFM)
+```
+
+Both additionally need the native library on the classpath (or an explicit
+override), and neither is scala-versioned — note the single `%`, not `%%`:
+
+```scala
+"io.github.etacassiopeia" % "zio-bdd-rift-embedded-natives" % "1.2.0" % Test
+```
+
+`zio-bdd-rift-embedded-natives` bundles the per-platform `librift_ffi`
+cdylibs; the loader extracts the one matching your host to a temp file and
+loads it automatically. If you'd rather point at a library you built or
+installed yourself, skip the natives jar and set `-Drift.ffi.lib=<path>`
+instead.
+
+### Host prerequisite: LuaJIT
+
+The embedded engine's Scripting capability needs LuaJIT installed on the host
+running the tests:
+
+```bash
+# Debian/Ubuntu
+apt install libluajit-5.1-dev
+
+# macOS
+brew install luajit
+```
+
+### Test-JVM flags
+
+Both variants need `--enable-native-access` to silence the restricted-method
+warning; the JDK 21 variant additionally needs `--enable-preview` to load its
+preview-compiled bridge:
+
+```scala
+// build.sbt — JDK 22+ (zio-bdd-rift-embedded)
+Test / fork := true,
+Test / javaOptions += "--enable-native-access=ALL-UNNAMED"
+
+// build.sbt — JDK 21 (zio-bdd-rift-embedded-jdk21)
+Test / fork := true,
+Test / javaOptions ++= Seq("--enable-preview", "--enable-native-access=ALL-UNNAMED")
+```
+
+### Which JDK / which artifact
+
+| Your test JDK | Artifact | Test JVM flags |
+|---|---|---|
+| 22 or newer | `zio-bdd-rift-embedded` | `--enable-native-access=ALL-UNNAMED` |
+| 21 | `zio-bdd-rift-embedded-jdk21` | `--enable-preview --enable-native-access=ALL-UNNAMED` |
+| 11–20 | neither — use WireMock or Rift container | — |
+
+### API and wiring
+
+```scala
+def available: Boolean                                          // true iff a native lib resolves for this host/JDK
+def layer: ZLayer[Provisioning, MockError, MockControl]
+```
+
+`EmbeddedRift.available` lets a harness park the backend (skip) rather than
+fail outright when no native library resolves for the current host/JDK
+combination — check it before wiring `EmbeddedRift.layer` in environments
+where the host isn't guaranteed to have a matching native lib.
+
+```scala
+import zio.bdd.mock.rift.embedded.EmbeddedRift
+
+val mockControl: ZLayer[Any, Throwable, MockControl] =
+  provisioning >>> EmbeddedRift.layer.mapError(e => new RuntimeException(s"Embedded Rift: $e"))
+```
+
+Unlike the container adapter, `EmbeddedRift.layer` needs only `Provisioning`
+in its environment — it builds its own loopback admin client internally, so
+no `Client` layer is required.
+
+---
+
+## 5. Choosing an adapter
+
+- **No Docker, need all six capabilities, JDK 22+ available** → Rift embedded
+  (`zio-bdd-rift-embedded`). Full fidelity, zero container overhead.
+- **No Docker, stuck on JDK 21** → Rift embedded
+  (`zio-bdd-rift-embedded-jdk21`) with `--enable-preview`, or fall back to
+  WireMock if the three-capability limit is acceptable.
+- **Already on WireMock, or need to run on JDK 11** → WireMock
+  (`zio-bdd-wiremock`). Cheapest to stand up; covers Faults,
+  StatefulScenarios, StateInspection.
+- **Full fidelity and Docker is available (e.g. CI with testcontainers)** →
+  Rift container (`zio-bdd-rift`). Same capability set as embedded, closer to
+  a production Rift deployment.
+
+The sample corpus's `support/Backends.scala` shows the pattern for switching
+adapters at runtime via an environment variable, so a suite's `environment`
+stays fixed at compile time while CI picks the backend per job:
+
+```scala
+object Backends:
+  val selected: String = sys.env.getOrElse("MOCK_BACKEND", "wiremock")
+
+  private val provisioning: ULayer[Provisioning] = ZLayer(Provisioning.make)
+
+  val mockControl: ZLayer[Any, Throwable, MockControl] =
+    selected match
+      case "wiremock"    => provisioning >>> WireMock.correlated()
+      case "wiremock-pi" => provisioning >>> WireMock.perInstance
+      case "rift"        => (Client.default ++ provisioning) >>> Rift.managed().mapError(e => new RuntimeException(s"Rift: $e"))
+      case "embedded"    => provisioning >>> EmbeddedRift.layer.mapError(e => new RuntimeException(s"Embedded Rift: $e"))
+      case other =>
+        ZLayer.fail(new IllegalArgumentException(s"unknown MOCK_BACKEND='$other'"))
+```
+
+Capability differences between backends are handled by excluding tags per
+backend at the harness level (e.g. skipping `@scripting` on WireMock runs),
+never by branching adapter-specific logic into step definitions — code
+written against `MockControl` stays adapter-agnostic (see
+[Mocking overview](mocking.md)).
+
+---
+
+Next: [Gherkin integration](mock-gherkin.md) · [Cookbook](mock-cookbook.md)

--- a/docs/mock-advanced.md
+++ b/docs/mock-advanced.md
@@ -1,0 +1,378 @@
+# Advanced Mocking: Capabilities, the Native Escape Hatch, Negotiation
+
+Beyond the core `MockControl` port (provision/addRule/received/…) an adapter
+may advertise optional capabilities: fault injection, stateful FSM scenarios,
+direct state inspection, backend scripting, proxy/record, and response
+templating. This page covers all six, the `provisionNative` escape hatch for
+when the portable model isn't enough, and how a suite negotiates capabilities
+so a missing one fails fast and by name instead of mid-scenario.
+
+---
+
+## 1. Capabilities overview
+
+Every capability accessor on `MockControl` returns `IO[Unsupported, X]`: fetch
+the capability instance first, then call its methods. If the backend doesn't
+advertise the capability, the accessor fails fast with
+`Unsupported(capability, backendName)` instead of the capability's method ever
+running:
+
+```scala
+sc <- ZIO.serviceWithZIO[MockControl](_.scenarios).mapError(u => new RuntimeException(u.message))
+_  <- sc.define(space, defineRetry(path))
+```
+
+| Capability | Accessor | Rift container | Rift embedded | WireMock |
+|---|---|---|---|---|
+| `Capability.Faults` | `faults: IO[Unsupported, Faults]` | yes | yes | yes |
+| `Capability.StatefulScenarios` | `scenarios: IO[Unsupported, StatefulScenarios]` | yes | yes | yes |
+| `Capability.StateInspection` | `stateInspection: IO[Unsupported, StateInspection]` | yes | yes | yes |
+| `Capability.Scripting` | `scripting: IO[Unsupported, Scripting]` | yes | yes | no |
+| `Capability.ProxyRecord` | `proxyRecord: IO[Unsupported, ProxyRecord]` | yes | yes | no |
+| `Capability.Templating` | `templating: IO[Unsupported, Templating]` | yes | yes | no |
+
+Faults, StatefulScenarios, and StateInspection are portable across all three
+adapters. Scripting, ProxyRecord, and Templating are Rift-only (container or
+embedded — embedded is capability-complete, a pure backend swap for the
+container, not a reduced subset); WireMock does not advertise them. See
+[Adapters](mock-adapters.md) for the full per-adapter breakdown and
+[Mocking overview](mocking.md) for the `MockControl` port these accessors sit
+on.
+
+---
+
+## 2. Faults
+
+`Faults.inject` installs a fault for requests matching `m` in `space`,
+returning the fault rule's id (removable via `MockControl#removeRule`). The
+four connection kinds make the SUT's HTTP client observe a transport-level
+failure; `FaultKind.LatencySpike` instead delays an otherwise normal 200
+response. A fault takes precedence over a normal rule on the same match:
+
+```scala
+enum FaultKind:
+  case ConnectionReset
+  case EmptyResponse
+  case MalformedChunk
+  case RandomThenClose
+  case LatencySpike(delay: Duration)
+```
+
+From `Faults11Suite` in the sample corpus:
+
+```scala
+Given("the backend supports faults") {
+  requiring(Capability.Faults)
+}
+
+Given("a " / string / " fault is injected for GET " / string) { (kind: String, path: String) =>
+  for
+    space <- activeSpace
+    fk    <- faultKind(kind)
+    fs    <- ZIO.serviceWithZIO[MockControl](_.faults).mapError(u => new RuntimeException(u.message))
+    _     <- fs.inject(space, get(path), fk).mapError(e => new RuntimeException(s"$e"))
+  yield ()
+}
+
+Given("a latency fault of " / int / " millis is injected for GET " / string) { (ms: Int, path: String) =>
+  for
+    space <- activeSpace
+    fs    <- ZIO.serviceWithZIO[MockControl](_.faults).mapError(u => new RuntimeException(u.message))
+    _     <- fs.inject(space, get(path), FaultKind.LatencySpike(ms.millis)).mapError(e => new RuntimeException(s"$e"))
+  yield ()
+}
+```
+
+---
+
+## 3. Stateful scenarios + state inspection
+
+`StatefulScenarios` runs a single-token FSM per scenario: a request eligible
+in the scenario's current state serves its response and (optionally)
+transitions the state. Build the FSM with the `scenario(...)` DSL builder (see
+[the DSL](mock-dsl.md) §5), then install it with `define` and rewind it with
+`reset`:
+
+```scala
+private def defineRetry(path: String) =
+  scenario("retry")
+    .startingAt("Started")
+    .when("Started", get(path)).respond(status(503)).goTo("Attempt1")
+    .when("Attempt1", get(path)).respond(status(503)).goTo("Attempt2")
+    .when("Attempt2", get(path)).respond(ok.text("ok")).goTo("Done")
+    .build
+
+Given("the backend supports stateful scenarios") {
+  requiring(Capability.StatefulScenarios)
+}
+
+Given("a fail-twice-then-succeed scenario for GET " / string) { (path: String) =>
+  for
+    space <- activeSpace
+    sc    <- ZIO.serviceWithZIO[MockControl](_.scenarios).mapError(u => new RuntimeException(u.message))
+    _     <- sc.define(space, defineRetry(path)).mapError(e => new RuntimeException(s"$e"))
+  yield ()
+}
+
+When("the scenario " / string / " is reset") { (name: String) =>
+  for
+    space <- activeSpace
+    sc    <- ZIO.serviceWithZIO[MockControl](_.scenarios).mapError(u => new RuntimeException(u.message))
+    _     <- sc.reset(space, name).mapError(e => new RuntimeException(s"$e"))
+  yield ()
+}
+```
+
+(Lifted from `Stateful12Suite`.)
+
+`StateInspection` is split out from `StatefulScenarios` because not every
+backend exposes direct state poking: `currentState` reads a scenario's
+current state and `setState` forces a transition, both without driving any
+request. From `StateInspect13Suite`:
+
+```scala
+Given("the backend supports state inspection") {
+  requiring(Capability.StateInspection)
+}
+
+When("the state of " / string / " is forced to " / string) { (name: String, to: String) =>
+  for
+    space <- activeSpace
+    s     <- ZIO.serviceWithZIO[MockControl](_.stateInspection).mapError(u => new RuntimeException(u.message))
+    _     <- s.setState(space, name, ScenarioState(to)).mapError(e => new RuntimeException(s"$e"))
+  yield ()
+}
+
+Then("the current state of " / string / " is " / string) { (name: String, expected: String) =>
+  for
+    space <- activeSpace
+    s     <- ZIO.serviceWithZIO[MockControl](_.stateInspection).mapError(u => new RuntimeException(u.message))
+    cur   <- s.currentState(space, name).mapError(e => new RuntimeException(s"$e"))
+    _     <- Assertions.assertEquals(cur.value, expected, s"current state of '$name'")
+  yield ()
+}
+```
+
+---
+
+## 4. Scripting
+
+`Scripting.inject` installs a script that computes the response for requests
+matching `m`, running on the backend's own scripting engine and able to read
+the matched request. Rift only:
+
+```scala
+final case class Script(engine: ScriptEngine, code: String)
+
+enum ScriptEngine:
+  case Rhai, Lua, JavaScript
+```
+
+From `Scripting14Suite` — a Rhai script that echoes the request method into
+the body (a static stub couldn't do this, so a passing round-trip proves the
+engine actually ran the script):
+
+```scala
+private val rhaiEchoMethod =
+  "fn should_inject(request, flow_store) { #{inject: true, fault: \"error\", status: 200, " +
+    "body: `scripted-${request.method}`, headers: #{\"Content-Type\": \"text/plain\"}} }"
+
+Given("the backend supports scripting") {
+  requiring(Capability.Scripting)
+}
+
+Given("a " / string / " script echoing the method for GET " / string) { (engine: String, path: String) =>
+  val eng = engine match
+    case "Rhai"       => ScriptEngine.Rhai
+    case "Lua"        => ScriptEngine.Lua
+    case "JavaScript" => ScriptEngine.JavaScript
+    case other        => throw new IllegalArgumentException(s"unknown engine '$other'")
+  for
+    space <- activeSpace
+    sc    <- ZIO.serviceWithZIO[MockControl](_.scripting).mapError(u => new RuntimeException(u.message))
+    _     <- sc.inject(space, get(path), Script(eng, rhaiEchoMethod)).mapError(e => new RuntimeException(s"$e"))
+  yield ()
+}
+```
+
+---
+
+## 5. Proxy / record
+
+`ProxyRecord.proxy` proxies requests matching `m` to a real `upstream`,
+recording the first response and replaying it on subsequent calls — so the
+SUT keeps getting the recorded response even after the upstream goes down.
+Rift only. The recording is owned by the backend, not the port: once a
+request has recorded a response, removing the proxy rule is unreliable, and
+on a `Correlated` space any rule mutation rebuilds the space and discards the
+recording — inject a proxy on its own space and don't mutate rules after the
+first recorded call.
+
+From `ProxyRecord15Suite`:
+
+```scala
+Given("the backend supports proxy/record") {
+  requiring(Capability.ProxyRecord)
+}
+
+When("a proxy to " / string / " is installed for GET " / string) { (upstream: String, path: String) =>
+  for
+    space <- activeSpace
+    pr    <- ZIO.serviceWithZIO[MockControl](_.proxyRecord).mapError(u => new RuntimeException(u.message))
+    id    <- pr.proxy(space, get(path), upstream).mapError(e => new RuntimeException(s"$e"))
+    _     <- Assertions.assertTrue(id.value.nonEmpty, "proxy rule id should be non-empty")
+  yield ()
+}
+```
+
+---
+
+## 6. Templating
+
+`Templating.inject` installs a templated response for requests matching `m`:
+each `TemplateCapture` in the template pulls a value from the request and
+substitutes its token into the response body. Rift only:
+
+```scala
+final case class ResponseTemplate(body: String, captures: List[TemplateCapture], status: Int = 200)
+final case class TemplateCapture(token: String, source: TemplateSource, regex: String)
+
+enum TemplateSource:
+  case Path, Body
+```
+
+From `Templating16Suite`:
+
+```scala
+Given("the backend supports templating") {
+  requiring(Capability.Templating)
+}
+
+Given("a template greeting the last path segment at " / string) { (pathRegex: String) =>
+  for
+    space <- activeSpace
+    t     <- ZIO.serviceWithZIO[MockControl](_.templating).mapError(u => new RuntimeException(u.message))
+    template = ResponseTemplate("Hello ${NAME}", List(TemplateCapture("${NAME}", TemplateSource.Path, "[^/]+$")))
+    _ <- t.inject(space, RequestMatch(path = PathMatch.Regex(pathRegex)), template).mapError(e => new RuntimeException(s"$e"))
+  yield ()
+}
+
+Given("a body-echo template for POST " / string) { (path: String) =>
+  for
+    space <- activeSpace
+    t     <- ZIO.serviceWithZIO[MockControl](_.templating).mapError(u => new RuntimeException(u.message))
+    template = ResponseTemplate("echo:${WHO}", List(TemplateCapture("${WHO}", TemplateSource.Body, "\\w+")))
+    _ <- t.inject(space, post(path), template).mapError(e => new RuntimeException(s"$e"))
+  yield ()
+}
+```
+
+---
+
+## 7. The `provisionNative` escape hatch
+
+`provisionNative[B <: Backend](spec: NativeSpec[B])` stands up a space from a
+raw, backend-specific document instead of the portable model — the escape
+hatch for when you need one backend's native format:
+
+```scala
+enum NativeSpec[B <: Backend]:
+  case Rift(imposterJson: String) extends NativeSpec[Backend.Rift]
+  case WireMock(stubMappingJson: String) extends NativeSpec[Backend.WireMock]
+```
+
+`NativeSpec` is **not** a `MockSource` — it lives in `MockControl.scala` as a
+separate path that bypasses normalization entirely. A `NativeSpec[Backend.Rift]`
+only provisions against a Rift adapter and a `NativeSpec[Backend.WireMock]`
+only against WireMock; the phantom `Backend` type parameter pins the spec to
+one concrete backend at compile time, so the escape hatch is honest about the
+portability it trades away. A natively-provisioned `MockSpace` still
+participates in `destroy`/`received`/overlays/isolation exactly like a
+portable one — only its *definition* is backend-pinned, so use it when you
+need full-fidelity access to a backend's raw feature set (e.g. a Mountebank
+imposter field or a WireMock stub-mapping option the canonical model doesn't
+expose), not for anything you expect to run against a second adapter.
+
+From `Native17Suite` — each scenario is tagged for its backend and the
+harness runs the matching one:
+
+```scala
+Given("a native WireMock stub for GET " / string / " returning " / string) { (path: String, body: String) =>
+  val json =
+    s"""{"request":{"method":"GET","urlPath":"$path"},"response":{"status":200,"body":"$body"}}"""
+  provisionNativeSpec(NativeSpec.WireMock(json))
+}
+
+Given("a native Rift imposter for GET " / string / " returning " / string) { (path: String, body: String) =>
+  val json =
+    s"""{"port":0,"protocol":"http","stubs":[{"predicates":[{"equals":{"method":"GET","path":"$path"}}],""" +
+      s""""responses":[{"is":{"statusCode":200,"body":"$body"}}]}]}"""
+  provisionNativeSpec(NativeSpec.Rift(json))
+}
+
+private def provisionNativeSpec[B <: Backend](spec: NativeSpec[B]) =
+  for
+    spaces <- ctl(_.provisionNative(spec))
+    space  <- ZIO.fromOption(spaces.headOption).orElseFail(new IllegalStateException("no space"))
+    _      <- Stage.put(space)
+  yield ()
+```
+
+---
+
+## 8. Capability negotiation
+
+`require(Capability*): IO[Unsupported, Unit]` fails fast — before any rule is
+staged or request sent — when a needed capability isn't in `capabilities:
+Set[Capability]`, naming both the missing capability and the backend via
+`Unsupported.message`. Run it at wiring/setup time so a backend gap surfaces
+immediately, not mid-scenario; the typed accessors (`faults`, `scripting`, …)
+remain the same per-call gate `require` just moves earlier.
+
+From `Negotiation19Suite` — verifying negotiation itself, not assuming it:
+
+```scala
+Then("the backend advertises capability " / string) { (name: String) =>
+  ZIO
+    .serviceWith[MockControl](_.capabilities.contains(cap(name)))
+    .flatMap(has => Assertions.assertTrue(has, s"backend does not advertise $name"))
+}
+
+Then("requiring " / string / " succeeds") { (name: String) =>
+  ZIO.serviceWithZIO[MockControl](_.require(cap(name))).mapError(u => new RuntimeException(u.message)).unit
+}
+
+When("requiring " / string / " is attempted") { (name: String) =>
+  ZIO
+    .serviceWithZIO[MockControl](_.require(cap(name)).either)
+    .flatMap {
+      case Left(u)  => Stage.put(RequireOutcome(failed = true, u.message))
+      case Right(_) => Stage.put(RequireOutcome(failed = false, ""))
+    }
+}
+
+Then("it fails naming the missing capability " / string) { (name: String) =>
+  Stage
+    .get[RequireOutcome]
+    .mapError(e => new IllegalStateException(e.message))
+    .flatMap(o => Assertions.assertTrue(o.failed && o.message.contains(name), s"outcome=$o"))
+}
+```
+
+A portable suite that needs, say, Scripting `require`s it up front: against
+Rift (container or embedded) that succeeds and the suite runs; against
+WireMock it fails with `Unsupported`, and the harness's per-backend tag
+exclusion is what turns that into a clean SKIP instead of a failed run — the
+capability gap is real, not a bug to route around in step code. The
+conformance suite in the sample corpus is the executable spec of "correctly
+implements `MockControl`": every adapter runs the same portable scenarios,
+and the negotiation/exclusion machinery above is what lets a capability
+adapters don't share (Scripting/ProxyRecord/Templating on WireMock) skip
+cleanly rather than fail the suite.
+
+---
+
+Next: [Cookbook](mock-cookbook.md)
+
+See also: [Mocking overview](mocking.md) · [the DSL](mock-dsl.md) ·
+[Adapters](mock-adapters.md)

--- a/docs/mock-cookbook.md
+++ b/docs/mock-cookbook.md
@@ -1,0 +1,251 @@
+# Mock Cookbook: Recipes for MockControl
+
+Task-oriented recipes for the portable mocking SPI. Each section stands alone — pick the
+one matching what you're trying to do. For concepts and the full API surface, start at
+[Mocking overview](mocking.md).
+
+---
+
+## 1. Stand up a mock backend as a layer
+
+**Problem:** you want a `MockControl` in your suite's environment so steps can provision
+mock spaces, without installing Docker or writing backend-specific code.
+
+Add the WireMock adapter — it runs fully in-process on JDK 11+, no containers:
+
+```scala
+// build.sbt
+libraryDependencies ++= Seq(
+  "io.github.etacassiopeia" %% "zio-bdd"          % "1.2.0",
+  "io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.2.0" % Test
+)
+```
+
+Wire the layer in the suite:
+
+```scala
+import zio.*
+import zio.bdd.core.Suite
+import zio.bdd.core.step.ZIOSteps
+import zio.bdd.mock.*
+import zio.bdd.mock.wiremock.WireMock
+
+@Suite(featureDirs = Array("src/test/resources/features/mock"))
+object GreetingMockSuite extends ZIOSteps[MockControl, MockState]:
+
+  override def environment: ZLayer[Any, Throwable, MockControl] =
+    Provisioning.live >>> WireMock.correlated()
+
+  // steps that use ZIO.service[MockControl] go here
+```
+
+`Provisioning` allocates the ports a backend needs; `Provisioning.live` is the standard
+choice (equivalent to `ZLayer(Provisioning.make)`). `WireMock.correlated()` runs one
+shared in-process server and routes requests to the right scenario's stubs via a
+correlation header — no per-scenario process to start or stop.
+
+**Alternatives:** the Rift container adapter (`Rift.managed()`, needs Docker, gives you
+all six capabilities including Faults and Scripting) and embedded Rift
+(`EmbeddedRift.layer`, capability-complete, no Docker, but needs a JDK-matched native
+build). See [Adapters](mock-adapters.md) for the full comparison and setup steps for both.
+
+---
+
+## 2. Write a portable scenario with `MockSteps`
+
+**Problem:** you want ready-made Gherkin steps for provisioning a mock space and sending a
+request through it, and you want the same `.feature` file to run unmodified against
+whichever backend you configure — WireMock today, a Rift container in CI tomorrow.
+
+Mix `zio.bdd.mock.steps.MockSteps` into a suite whose environment provides `MockControl`.
+The self-type is the only wiring required — no lens, no extra `given`:
+
+```scala
+import zio.*
+import zio.bdd.core.Suite
+import zio.bdd.core.step.ZIOSteps
+import zio.bdd.mock.*
+import zio.bdd.mock.steps.MockSteps
+
+@Suite(featureDirs = Array("src/test/resources/features/mock/basic.feature"))
+object BasicMockSuite
+    extends ZIOSteps[MockControl, MockState]
+    with MockSteps[MockControl, MockState]:
+
+  override def environment: ZLayer[Any, Throwable, MockControl] =
+    Provisioning.live >>> WireMock.correlated()
+```
+
+```gherkin
+Feature: Basic mock matching
+
+  Scenario: A simple stub answers a GET
+    Given a mock space returning 200 "hi" at "/hello"
+    When a "GET" "/hello" is sent through the space
+    Then the space response status is 200
+    And the space response body contains "hi"
+    And the space received 1 requests
+```
+
+`MockSteps` provisions the space, stages it (and the response) in `Stage`, and exposes the
+usual assertions (`the space response status is …`, `the space received … requests`, …).
+Because the feature text never mentions a backend, you can switch adapters purely by
+changing `environment` — for example, reading `MOCK_BACKEND` from the environment and
+branching between `WireMock.correlated()`, `WireMock.perInstance`, `Rift.managed()`, and
+`EmbeddedRift.layer` the way `support/Backends.scala` does in the zio-bdd-samples corpus:
+
+```scala
+val mockControl: ZLayer[Any, Throwable, MockControl] =
+  sys.env.getOrElse("MOCK_BACKEND", "wiremock") match
+    case "wiremock" => Provisioning.live >>> WireMock.correlated()
+    // Rift and embedded fail with the typed `MockError` (not a `Throwable`), so map it into the
+    // layer's `Throwable` error channel — exactly as support/Backends.scala does:
+    case "rift"     => (Client.default ++ Provisioning.live) >>> Rift.managed().mapError(e => new RuntimeException(s"Rift: $e"))
+    case "embedded" => Provisioning.live >>> EmbeddedRift.layer.mapError(e => new RuntimeException(s"Embedded Rift: $e"))
+```
+
+Run the same suite against each backend from the command line by setting the env var
+before `sbt test`. See [Gherkin integration](mock-gherkin.md) for the full step catalog and
+[Adapters](mock-adapters.md) for what each backend needs at runtime.
+
+---
+
+## 3. Parameterize mocks with `@mock(...)` fixtures
+
+**Problem:** several scenarios each need a different pre-built mock space, and you don't
+want every scenario writing out its own `Given` rule-builder steps.
+
+Define a catalog once — a `Map[String, MockSource]` — and reference entries by name from
+the feature file with `@mock(name)`:
+
+```scala
+import zio.bdd.mock.*
+import zio.bdd.mock.dsl.*
+
+object Catalog:
+  val entries: Map[String, MockSource] = Map(
+    "greeting" -> mock(get("/hello").respondWith(ok.text("hi"))).source,
+    "farewell" -> mock(get("/bye").respondWith(ok.text("bye"))).source
+  )
+```
+
+Wire `MockFixtures.scenario` into `scenarioLayer` so the tagged entries are provisioned
+fresh per scenario and torn down automatically when the scenario's fixture scope closes.
+The environment then carries both `MockControl` and the resulting `MockFixture`:
+
+```scala
+import zio.*
+import zio.bdd.core.Suite
+import zio.bdd.core.step.ZIOSteps
+import zio.bdd.gherkin.ScenarioMetadata
+import zio.bdd.mock.*
+import zio.bdd.mock.fixtures.{MockFixture, MockFixtures}
+
+@Suite(featureDirs = Array("src/test/resources/features/mock/fixtures.feature"))
+object FixturesSuite extends ZIOSteps[MockControl & MockFixture, MockState]:
+
+  override def scenarioLayer(meta: ScenarioMetadata): ZLayer[Any, Throwable, MockControl & MockFixture] =
+    Provisioning.live >>> WireMock.correlated() >+> MockFixtures.scenario(meta, Catalog.entries)
+
+  Then("the fixture provisioned " / int / " spaces") { (n: Int) =>
+    ZIO.service[MockFixture].flatMap(fx => Assertions.assertEquals(fx.spaces.size, n, "fixture spaces"))
+  }
+```
+
+```gherkin
+@mock @fixtures
+Feature: Scenario-tier mock fixtures
+
+  @mock(greeting)
+  Scenario: The greeting fixture is deployed for the tagged scenario
+    Then the fixture provisioned 1 spaces
+    When the client sends "GET" "/hello"
+    Then the response body is "hi"
+
+  @mock(greeting, farewell)
+  Scenario: Two named fixtures are deployed together
+    Then the fixture provisioned 2 spaces
+```
+
+A scenario can list several names in one `@mock(a, b)` tag; each resolves to its catalog
+entry and all are provisioned together. A name with no catalog entry fails the scenario
+at setup, not later inside a step. See [Gherkin integration](mock-gherkin.md) for
+`MockFixtures.feature` (feature-tier, shared across a feature's scenarios) and
+`MockFixtures.byFlag` (drive the entry from a `@flags(...)` value).
+
+---
+
+## 4. Inject a fault across adapters
+
+**Problem:** you want to verify a client's failure handling — a dropped connection, a
+malformed response, a slow backend — without every scenario hardcoding which adapter it
+runs against.
+
+Faults are a capability (`Capability.Faults`), reached through `MockControl.faults`.
+Guard the scenario with `require` so it fails fast and legibly on a backend that doesn't
+advertise the capability, instead of failing deep inside an assertion:
+
+```scala
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.dsl.*
+
+Given("the backend supports faults") {
+  ZIO.serviceWithZIO[MockControl](_.require(Capability.Faults)).mapError(u => new RuntimeException(u.message))
+}
+
+Given("a " / string / " fault is injected for GET " / string) { (kind: String, path: String) =>
+  for
+    space <- activeSpace // your own helper: the scenario's provisioned MockSpace, from Stage
+    fs    <- ZIO.serviceWithZIO[MockControl](_.faults).mapError(u => new RuntimeException(u.message))
+    _     <- fs.inject(space, get(path), FaultKind.ConnectionReset).mapError(e => new RuntimeException(s"$e"))
+  yield ()
+}
+
+Given("a latency fault of " / int / " millis is injected for GET " / string) { (ms: Int, path: String) =>
+  for
+    space <- activeSpace
+    fs    <- ZIO.serviceWithZIO[MockControl](_.faults).mapError(u => new RuntimeException(u.message))
+    _     <- fs.inject(space, get(path), FaultKind.LatencySpike(ms.millis)).mapError(e => new RuntimeException(s"$e"))
+  yield ()
+}
+```
+
+```gherkin
+@mock @faults
+Feature: Fault injection
+
+  Scenario: A connection reset aborts the client connection
+    Given the backend supports faults
+    And a "ConnectionReset" fault is injected for GET "/boom"
+    When GET "/boom" is attempted
+    Then the request fails at the transport level
+
+  @slow
+  Scenario: A latency spike delays an otherwise normal response
+    Given the backend supports faults
+    And a latency fault of 300 millis is injected for GET "/slow"
+    When GET "/slow" is attempted
+    Then the request succeeds after at least 300 millis
+```
+
+`FaultKind.ConnectionReset`, `EmptyResponse`, `MalformedChunk`, and `RandomThenClose` all
+abort the transport; `LatencySpike(duration)` delays an otherwise-normal response instead
+of breaking it. WireMock, Rift container, and embedded Rift all advertise
+`Capability.Faults`, so this recipe runs on every adapter in the [capability
+matrix](mock-adapters.md) — the `require` step is what lets the *same* feature file degrade
+into an explicit skip/fail on a hypothetical backend that lacks the capability, rather than
+an assertion failure that hides the real cause. See [Advanced](mock-advanced.md) for the
+other five capabilities (stateful scenarios, state inspection, scripting, proxy-record,
+templating) and how negotiation composes with `require`.
+
+---
+
+## See also
+
+- [Mocking overview](mocking.md) — concepts: `MockControl`, `MockSpace`, isolation, capabilities.
+- [the DSL](mock-dsl.md) — the fluent rule-builder (`get`, `.where`, `.respondWith`, …).
+- [Adapters](mock-adapters.md) — WireMock vs Rift container vs embedded Rift, capability matrix, JDK/Docker requirements.
+- [Gherkin integration](mock-gherkin.md) — `MockSteps`, the `@mock(...)` tag, `MockFixtures`.
+- [Advanced](mock-advanced.md) — stateful scenarios, state inspection, scripting, proxy-record, templating.
+- [Cookbook](cookbook.md) — general suite-writing recipes (state, steps, tagging) that apply outside mocking too.

--- a/docs/mock-dsl.md
+++ b/docs/mock-dsl.md
@@ -1,0 +1,266 @@
+# Mock DSL Reference
+
+`zio.bdd.mock.dsl` is a set of fluent builders over the canonical mock model.
+It never adds capability — every builder returns (or composes) one of the
+plain value types from the model, so DSL output is structurally identical to
+the same rule written by hand. Use it when you want type-checked, refactorable
+stubs in Scala; use raw JSON sources when you're porting an existing
+Mountebank/WireMock fixture (see §6).
+
+---
+
+## 1. Import + shape
+
+```scala
+import zio.bdd.mock.dsl.*
+```
+
+A rule pairs a request matcher with a response:
+
+```scala
+<request>.respondWith(<response>)   // => MockRule
+```
+
+Assemble rules into a spec, then wrap the spec as a source your backend can
+provision:
+
+```scala
+mock(rule1, rule2, rule3)    // MockSpec  — rules.toList
+mock(rule1, rule2).source    // MockSource.Dsl(spec)
+dslSource(rule1, rule2)      // shorthand for mock(rules*).source
+```
+
+`MockSpec` also carries an *advisory* `port` (`.onPort(8080)`) — it's always
+stripped on provisioning; the backend assigns a fresh free port regardless.
+
+---
+
+## 2. Matching requests
+
+Start from a method + path entry point, or `anyRequest` for no constraint at
+all:
+
+```scala
+get(path)      // Method.Get
+post(path)     // Method.Post
+put(path)      // Method.Put
+delete(path)   // Method.Delete
+patch(path)    // Method.Patch
+head(path)     // Method.Head
+options(path)  // Method.Options
+request(method, path)  // any Method
+anyRequest              // no method, no path constraint
+```
+
+Each entry point produces a `RequestMatch` with an **exact-path** matcher by
+default. Refine it with `.where(...)`, passing one or more clauses:
+
+```scala
+get(path).where(header(h).equalTo(v)).respondWith(ok.text(body))
+
+get(path).where(header(h).contains(v)).respondWith(ok.text(body))
+
+get(path).where(query(q).matches(re)).respondWith(ok.text(body))
+
+post(path).where(bodyEquals(b)).respondWith(ok.text(body))
+
+post(path).where(bodyContains(b)).respondWith(ok.text(body))
+
+post(path).where(jsonPath(jp).equalTo(v)).respondWith(ok.text(body))
+```
+
+(Verbatim from `Value03Suite` / `Body04Suite` in the samples.)
+
+To match on something other than an exact path, replace the path matcher with
+`.withPath(...)`:
+
+```scala
+get("/ignored").withPath(PathMatch.Regex(pattern)).respondWith(ok.text(body))
+get("/ignored").withPath(PathMatch.Template(tmpl)).respondWith(ok.text(body))
+anyRequest.withPath(PathMatch.Any).respondWith(ok.text(body))
+```
+
+The `get("/ignored")` base is only there to pick the HTTP method — `withPath`
+overwrites whatever path matcher the entry point set.
+
+| Clause | Produces | Notes |
+|---|---|---|
+| `header(name).equalTo(v)` | `ValueMatch.Equals` | exact header value |
+| `header(name).contains(v)` | `ValueMatch.Contains` | substring match |
+| `header(name).matches(re)` | `ValueMatch.Matches` | regex match |
+| `query(name).equalTo(v)` / `.contains(v)` / `.matches(re)` | same as above, on a query param | |
+| `jsonPath(path).exists` | `BodyMatch.JsonPath(path, None)` | path must exist in body |
+| `jsonPath(path).equalTo(v)` | `BodyMatch.JsonPath(path, Some(v))` | path's value must equal `v` |
+| `bodyEquals(v)` | `BodyMatch.Equals(v)` | whole body equals `v` |
+| `bodyContains(v)` | `BodyMatch.Contains(v)` | body contains `v` |
+| `bodyMatches(re)` | `BodyMatch.Matches(re)` | body matches regex `re` |
+| `xPath(path)` | `BodyMatch.XPath(path, None)` | XML path must exist |
+| `.withPath(PathMatch.Regex(p))` | overrides the path matcher | anchors are backend-defined |
+| `.withPath(PathMatch.Template(t))` | overrides the path matcher | e.g. `"/users/{id}"` |
+
+`header`/`query` clauses stack per-name in `.where(...)` — only body clauses
+are mutually exclusive (each rule has at most one `BodyMatch`; the last one in
+`.where(...)` wins).
+
+---
+
+## 3. Building responses
+
+Two entry points:
+
+```scala
+ok             // ResponseDef(status = 200), empty body
+status(code)   // ResponseDef(status = code), empty body
+```
+
+Refine with extension methods, chaining freely:
+
+```scala
+status(code).text(body)     // Body.Text
+status(code).json(body)     // Body.Json
+ok.base64(b64)              // Body.Base64
+ok.withStatus(code)         // override the status after the fact
+ok.withBody(Body.Empty)     // set an arbitrary Body value directly
+ok.withHeader(name, value)  // append a response header
+ok.withLatency(ms.millis)   // delay the response by a zio.Duration
+```
+
+Calling `.withHeader(name, v)` twice for the same name **appends** rather than
+overwrites, producing a multi-value response header:
+
+```scala
+stageRule(get(path).respondWith(ok.withHeader(name, v1).withHeader(name, v2)))
+```
+
+Chained example from the samples (base64 body + delayed text):
+
+```scala
+stageRule(get(path).respondWith(ok.base64(b64)))
+
+stageRule(get(path).respondWith(ok.text(body).withLatency(ms.millis)))
+```
+
+---
+
+## 4. Rule ids + precedence
+
+Give a rule an explicit id with `.withId(...)` so you can target it later
+(e.g. with `MockControl#removeRule`):
+
+```scala
+extension (rule: MockRule) def withId(id: String): MockRule
+```
+
+```scala
+val rule = get(path).respondWith(ok.text(body)).withId("greeting-stub")
+```
+
+Rules added via `MockControl#addRule` take a `Priority`, which decides
+ordering when more than one rule matches the same request:
+
+```scala
+ctl(_.addRule(space, get(path).respondWith(ok.text(body)), Priority.Overlay))
+```
+
+`Priority.Overlay` rules sit above `Priority.Base` rules — an overlay added on
+top of a base stub shadows it for matching requests until it's removed
+(`removeRule`) or the base rules are swapped out wholesale (`replaceRules`).
+See [Mocking overview](mocking.md) for how spaces and isolation relate to rule
+precedence, and [Adapters](mock-adapters.md) for how each backend implements
+overlay/base ordering.
+
+---
+
+## 5. Stateful scenario builder
+
+`scenario(name)` builds a `ScenarioDef` — a single-token FSM — fluently. Each
+`.when(state, request).respond(response)` edge fires while the scenario is in
+`state` and an incoming request matches; it then either transitions
+(`.goTo(nextState)`) or stays (`.stay`):
+
+```scala
+private def defineRetry(path: String) =
+  scenario("retry")
+    .startingAt("Started")
+    .when("Started", get(path)).respond(status(503)).goTo("Attempt1")
+    .when("Attempt1", get(path)).respond(status(503)).goTo("Attempt2")
+    .when("Attempt2", get(path)).respond(ok.text("ok")).goTo("Done")
+    .build
+```
+
+`.startingAt(state)` overrides the default initial state
+(`ScenarioState.Started`). `.build` produces the `ScenarioDef` you hand to the
+`StatefulScenarios` capability:
+
+```scala
+sc <- ZIO.serviceWithZIO[MockControl](_.scenarios)
+_  <- sc.define(space, defineRetry(path))
+```
+
+The scenario runs entirely inside the backend once defined — the DSL only
+builds the definition. See [Advanced](mock-advanced.md) for the
+`StatefulScenarios` capability itself (`define`/`reset`/inspecting state) and
+which adapters support it.
+
+---
+
+## 6. Raw JSON sources vs the DSL
+
+`MockSource` is an enum with five cases; only `Dsl` goes through the builders
+above:
+
+```scala
+enum MockSource:
+  case Dsl(spec: MockSpec)
+  case Json(raw: String)
+  case Resource(path: String)
+  case File(path: String)
+  case Dir(path: String)
+```
+
+`Json`/`Resource`/`File`/`Dir` carry raw backend wire text (e.g. a Mountebank
+imposter or WireMock mapping) instead of a `MockSpec`:
+
+```scala
+provisionSource(mock(get(path).respondWith(ok.text(body))).source)  // Dsl
+
+provisionSource(MockSource.Resource("mocksources/rift/orders.json"))
+provisionSource(MockSource.File(path))
+provisionSource(MockSource.Dir(path))   // one space per file in the directory
+```
+
+A resource file looks like a plain imposter body:
+
+```json
+{
+  "port": 0,
+  "protocol": "http",
+  "stubs": [
+    {
+      "predicates": [{ "equals": { "method": "GET", "path": "/from-resource" } }],
+      "responses": [{ "is": { "statusCode": 200, "body": "resource-body" } }]
+    }
+  ]
+}
+```
+
+All four raw variants still go through the same `Provisioning` normalization
+path as `Dsl` — `port` is stripped/reassigned the same way. The practical
+difference is portability: raw JSON is backend wire format (a Rift imposter
+won't parse as a WireMock mapping), so a `File`/`Dir`/`Resource`/`Json` source
+generally needs a `@rift`- or `@wiremock`-tagged scenario, while `Dsl` sources
+run unmodified against any adapter that implements the base capabilities.
+
+Reach for raw sources when a team already maintains Mountebank/WireMock
+fixtures and porting them to the DSL isn't worth the churn, or when a fixture
+needs adapter-native features the portable model doesn't expose. Reach for the
+DSL for everything else — it's refactorable, type-checked, and portable across
+backends.
+
+Note: `NativeSpec` (`NativeSpec.Rift(imposterJson)` / `NativeSpec.WireMock(json)`)
+looks similar but is **not** a `MockSource` — it's a separate, backend-pinned
+path (`MockControl#provisionNative`) that bypasses normalization entirely.
+
+---
+
+Next: [Adapters](mock-adapters.md) · [Gherkin integration](mock-gherkin.md)

--- a/docs/mock-gherkin.md
+++ b/docs/mock-gherkin.md
@@ -1,0 +1,252 @@
+# Gherkin Integration
+
+`zio.bdd.mock.steps.MockSteps` and `zio.bdd.mock.fixtures.MockFixtures` connect
+the portable mocking SPI to Gherkin: ready-made step definitions for the mock
+space itself, and tag-driven fixtures that deploy named catalog entries around
+each scenario or feature.
+
+---
+
+## 1. `MockSteps[R, S]`
+
+`MockSteps` is a mixin, not a base class — it requires the self-type
+`ZIOSteps[R & MockControl, S]`, so any suite whose environment provides a
+`MockControl` can mix it in and get a full set of mock-space steps for free:
+
+```scala
+trait MockSteps[R, S] { self: ZIOSteps[R & MockControl, S] =>
+  ...
+}
+```
+
+The active `MockSpace` and the last response live in [`Stage`](#4-stage-for-mock-data),
+not scenario state — a `MockSpace` carries a function (`inject`) and isn't
+Schema-serialisable, so it can't be `S`.
+
+### Registered steps
+
+| Step | Effect |
+|---|---|
+| `Given a mock space returning {int} {string} at {string}` | Provisions a space with one rule (`status`, `body`, `path`); stages the resulting `MockSpace` |
+| `When the space overlays {int} {string} at {string}` | Adds an overlay rule to the staged space via `addRule(space, rule, Priority.Overlay)` |
+| `When a {string} {string} is sent through the space` | Sends `method path` through the staged space (honours `inject`, the isolation decoration); stages the `MockResponse` |
+| `Then the space response status is {int}` | Asserts the staged response's status |
+| `Then the space response body contains {string}` | Asserts the staged response's body contains a substring |
+| `Then the space response header {string} is {string}` | Asserts a header on the staged response |
+| `Then the space received {int} requests` | Asserts `received(space).size` |
+| `Then a {string} request to {string} was recorded` | Asserts at least one recorded request matches method + path |
+| `Then exactly {int} {string} requests to {string} were recorded` | Asserts an exact recorded count for method + path |
+
+`Given a mock space returning ...` and `When the space overlays ...` build a
+single-rule `MockRule(RequestMatch(path = PathMatch.Exact(path)), ResponseDef(status, Body.Text(body)))`
+— reach for a catalog entry (§3) or the DSL ([the DSL](mock-dsl.md)) once a
+scenario needs more than an exact-path text response.
+
+### Mixing it in
+
+```scala
+import zio.bdd.core.step.ZIOSteps
+import zio.bdd.mock.*
+import zio.bdd.mock.steps.MockSteps
+
+object SpaceSuite extends ZIOSteps[MockControl, Unit] with MockSteps[MockControl, Unit]:
+  override def scenarioLayer(meta: zio.bdd.gherkin.ScenarioMetadata) =
+    Backends.mockControl
+```
+
+Every step MockSteps registers is now available to that suite's `.feature`
+files — no lens, no extra `given`, just `MockControl` in the environment.
+
+---
+
+## 2. The `@mock(name, ...)` tag + fixtures
+
+`@mock(name, other)` on a `Scenario` names catalog entries to deploy for that
+scenario. `MockFixtures` resolves the names against a `Map[String, MockSource]`
+catalog, provisions each source, and exposes the result as `MockFixture`:
+
+```scala
+final case class MockFixture(spaces: List[MockSpace])
+```
+
+Three constructors, one per fixture tier:
+
+- **`MockFixtures.scenario(meta, catalog)`** — reads `@mock(...)` names off
+  `meta.tags` (via `MockTag.extract`), resolves each against `catalog`, and
+  provisions them fresh for that scenario. Share-nothing: a name with no
+  catalog entry fails the scenario at setup. Wire it into `scenarioLayer` so
+  it deploys and tears down per scenario.
+- **`MockFixtures.feature(sources*)`** — provisions a fixed list of sources
+  once per feature (the three-tier layer model memoizes this at the feature
+  scope). Use it for heavy, read-only fixtures shared by every scenario in the
+  feature, wired into a suite's feature-tier layer instead of `scenarioLayer`.
+- **`MockFixtures.byFlag(reader, flag, catalog)`** — deploys the single
+  catalog entry named by the *value* of `flag`, read through a `FlagReader`.
+  `FlagReader.fromMetadata(meta)` reads the scenario's `@flags(k=v)` matrix tag
+  (`meta.flagValues`) — the in-framework source, no SDK required (an
+  OpenFeature-backed reader can plug in the same trait from outside zio-bdd).
+  This composes with `@flags` expansion so one tagged scenario exercises each
+  flag branch against its matching mock — see
+  [Feature Flag Testing](testing-flags.md).
+
+All three return `ZLayer[MockControl, Throwable, MockFixture]` and provision
+through `ZIO.acquireRelease`: each source is its own scoped acquisition, so a
+failure partway through still tears down the spaces already created, and a
+teardown failure is logged and skipped rather than stranding its siblings.
+
+---
+
+## 3. The catalog pattern
+
+A catalog is nothing more than `Map[String, MockSource]` — named, reusable
+mock sources built with [the DSL](mock-dsl.md) and lifted with `.source`. From
+the samples corpus, `support/Catalog.scala`:
+
+```scala
+package samples.mock.support
+
+import zio.bdd.mock.*
+import zio.bdd.mock.dsl.*
+
+/**
+ * Named mock sources deployed by scenario-tier `@mock(name)` fixtures
+ * ([[zio.bdd.mock.fixtures.MockFixtures]]). A scenario tagged `@mock(greeting)`
+ * gets the `greeting` space provisioned fresh and torn down in its fixture scope.
+ */
+object Catalog:
+  val entries: Map[String, MockSource] = Map(
+    "greeting" -> mock(get("/hello").respondWith(ok.text("hi"))).source,
+    "farewell" -> mock(get("/bye").respondWith(ok.text("bye"))).source
+  )
+```
+
+Keep catalogs in a `support` object alongside a suite, one entry per named
+fixture a `.feature` file references by `@mock(name)`. Nothing stops a catalog
+entry from being `MockSource.Json(raw)`, `.Resource(path)`, `.File(path)`, or
+`.Dir(path)` instead of `.Dsl(...)` — the catalog only fixes the *name*, not
+the source kind.
+
+---
+
+## 4. `Stage` for mock data
+
+A `MockSpace` carries a function (`inject`) and a `MockResponse` isn't part of
+most suites' scenario state `S` — so both are threaded between steps with
+`Stage`, not `S`:
+
+```scala
+def put[A: ClassTag](value: A): UIO[Unit]
+def get[A: ClassTag]: IO[StagingError, A]
+```
+
+`MockSteps` uses exactly this pattern internally:
+
+```scala
+Given("a mock space returning " / int / " " / string / " at " / string) { (status: Int, body: String, path: String) =>
+  for
+    spaces <- mock(_.provision(MockSource.Dsl(MockSpec(List(ruleFor(status, body, path))))))
+    space  <- ZIO.fromOption(spaces.headOption).orElseFail(new IllegalStateException("provision returned no space"))
+    _      <- Stage.put(space)
+  yield ()
+}
+
+When("a " / string / " " / string / " is sent through the space") { (method: String, path: String) =>
+  for
+    space <- activeSpace          // Stage.get[MockSpace]
+    resp  <- sendThrough(space, method, path)
+    _     <- Stage.put(resp)       // MockResponse, read by the Then steps
+  yield ()
+}
+```
+
+`Stage.get[A]` fails with `StagingError` (`NotFound`/`TypeMismatch`) if nothing
+of that type was staged yet — the same reason `MockSteps`'s `activeSpace` and
+`stagedResponse` helpers wrap it with a clearer message ("no active mock
+space — deploy one first"). Custom step definitions that provision or send
+through a space directly should follow the same convention: `Stage.put` the
+`MockSpace` after provisioning, `Stage.put` the response after sending, so
+downstream `Then` steps can `Stage.get` either without touching `S`.
+
+---
+
+## 5. Complete example
+
+`10-fixtures-tags.feature` — two scenarios, each tagged with `@mock(...)`:
+
+```gherkin
+@mock @fixtures @portable
+Feature: Scenario-tier mock fixtures — @mock(name) deploys catalog entries
+
+  @mock(greeting)
+  Scenario: The greeting fixture is deployed for the tagged scenario
+    Then the fixture provisioned 1 spaces
+    When the client sends "GET" "/hello"
+    Then the response body is "hi"
+
+  @mock(greeting, farewell)
+  Scenario: Two named fixtures are deployed together
+    Then the fixture provisioned 2 spaces
+```
+
+`Fixtures10Suite.scala` wires `MockFixtures.scenario` on top of the backend
+layer and reads the resulting `MockFixture` from the environment:
+
+```scala
+package samples.mock
+
+import zio.*
+import zio.bdd.core.Assertions
+import zio.bdd.core.Suite
+import zio.bdd.core.step.{Stage, ZIOSteps}
+import zio.bdd.gherkin.ScenarioMetadata
+import zio.bdd.mock.*
+import zio.bdd.mock.fixtures.{MockFixture, MockFixtures}
+import samples.mock.support.{Backends, Catalog, MockState}
+
+@Suite(
+  featureDirs = Array("src/test/resources/features/mock/10-fixtures-tags.feature"),
+  reporters = Array("pretty"),
+  scenarioParallelism = 1
+)
+object Fixtures10Suite extends ZIOSteps[MockControl & MockFixture, MockState]:
+
+  override def scenarioLayer(meta: ScenarioMetadata): ZLayer[Any, Throwable, MockControl & MockFixture] =
+    Backends.mockControl >+> MockFixtures.scenario(meta, Catalog.entries)
+
+  When("the client sends " / string / " " / string) { (m: String, path: String) =>
+    for
+      method <- ZIO
+                  .fromOption(Method.values.find(_.toString.equalsIgnoreCase(m)))
+                  .orElseFail(new IllegalArgumentException(s"bad method $m"))
+      fx    <- ZIO.service[MockFixture]
+      space <- ZIO.fromOption(fx.spaces.headOption).orElseFail(new IllegalStateException("fixture provisioned no space"))
+      resp  <- SutClient.make(space).send(method, path)
+      _     <- Stage.put(resp)
+    yield ()
+  }
+
+  Then("the response body is " / string) { (expected: String) =>
+    Stage
+      .get[SutResponse]
+      .mapError(e => new IllegalStateException(e.message))
+      .flatMap(r => Assertions.assertEquals(r.body, expected, "response body"))
+  }
+
+  Then("the fixture provisioned " / int / " spaces") { (n: Int) =>
+    ZIO.service[MockFixture].flatMap(fx => Assertions.assertEquals(fx.spaces.size, n, "fixture spaces"))
+  }
+```
+
+`scenarioLayer(meta) = Backends.mockControl >+> MockFixtures.scenario(meta, Catalog.entries)`
+is the whole wiring: `Backends.mockControl` supplies `MockControl` (picking
+the adapter — see [Adapters](mock-adapters.md)), and `>+>` adds
+`MockFixtures.scenario`'s `MockFixture` alongside it, so the suite's
+environment is `MockControl & MockFixture` and every `@mock(...)`-tagged
+scenario gets its named spaces provisioned and torn down automatically.
+
+---
+
+Next: [Advanced](mock-advanced.md) · [Cookbook](mock-cookbook.md)
+
+See also: [Mocking overview](mocking.md) · [the DSL](mock-dsl.md) ·
+[Adapters](mock-adapters.md) · [Feature Flag Testing](testing-flags.md)

--- a/docs/mocking.md
+++ b/docs/mocking.md
@@ -1,0 +1,237 @@
+# Mocking with MockControl
+
+`zio-bdd-mock` gives you one portable API for stubbing HTTP dependencies —
+write a scenario's mocks once, then run the same scenario against a container,
+an embedded process, or an in-JVM server without touching a line of it.
+
+---
+
+## 1. What MockControl is
+
+`MockControl` is a backend-neutral SPI: a small, total port that every mocking
+adapter implements identically, plus a set of optional capabilities an adapter
+may advertise beyond the core. Code written against `MockControl` — Gherkin
+steps, hooks, overlays, assertions — never imports a concrete backend.
+
+Three adapters implement it today:
+
+| Adapter | Transport | Isolation default | Capabilities |
+|---|---|---|---|
+| Rift container (`Rift.managed`/`Rift.connect`) | Docker container | PerInstance | all six |
+| Rift embedded (`EmbeddedRift.layer`) | in-process (FFM) | PerInstance | all six (parity with container) |
+| WireMock (`WireMock.correlated`/`.perInstance`) | in-process JVM | Correlated (via `.correlated`) | Faults, StatefulScenarios, StateInspection only |
+
+The **cross-adapter portability guarantee**: any scenario built from the
+portable model (`MockSource`, `RequestMatch`, `ResponseDef`, …) provisions,
+matches, and tears down identically on every adapter that advertises the
+capabilities it uses. Swapping backends is a one-line layer change — see
+[Adapters](mock-adapters.md). A backend-pinned escape hatch (`provisionNative`)
+exists for when you need one backend's native format; it trades away that
+guarantee, so it's covered separately in [Advanced](mock-advanced.md).
+
+A minimal example, lifted from the sample corpus — a step definition that
+stages a stub rule and a suite that wires a `MockControl` layer to run it
+against:
+
+```scala
+import zio.bdd.mock.*
+import zio.bdd.mock.dsl.*
+
+Given("a stub GET /hello returns 200 text " / string) { (body: String) =>
+  stageRule(get("/hello").respondWith(ok.text(body)))
+}
+```
+
+`get("/hello")` builds a `RequestMatch`, `.respondWith(ok.text(body))` pairs it
+with a `ResponseDef` to form a `MockRule` — both are canonical model types
+(§4), assembled with the fluent DSL (§5, full reference in
+[the DSL](mock-dsl.md)). The suite itself only ever depends on `MockControl`:
+
+```scala
+object Basic01Suite extends ZIOSteps[MockControl, MockState] with MockSupport[MockState]:
+  // ...steps...
+  override def environment: ZLayer[Any, Throwable, MockControl] = Backends.mockControl
+```
+
+`Backends.mockControl` picks Rift, embedded Rift, or WireMock at runtime from
+an env var — the suite above never changes. See [Adapters](mock-adapters.md)
+for how each backend's layer is constructed.
+
+---
+
+## 2. The `MockControl` trait
+
+`MockControl` groups a handful of lifecycle/rule/verification operations that
+every adapter implements, plus typed accessors for the optional capabilities.
+
+### Lifecycle
+
+| Method | Signature | Purpose |
+|---|---|---|
+| `provision` | `(source: MockSource): IO[MockError, List[MockSpace]]` | Stand up one or more mock spaces from a portable source (§5). |
+| `provisionNative` | `[B <: Backend](spec: NativeSpec[B]): IO[MockError, List[MockSpace]]` | Backend-pinned escape hatch — see [Advanced](mock-advanced.md). |
+| `destroy` | `(space: MockSpace): IO[MockError, Unit]` | Tear down exactly this space, never a global reset. |
+
+### Rules
+
+| Method | Signature | Purpose |
+|---|---|---|
+| `addRule` | `(space: MockSpace, rule: MockRule, priority: Priority = Priority.Overlay): IO[MockError, RuleId]` | Add a rule; overlay rules sit above base rules. |
+| `removeRule` | `(space: MockSpace, id: RuleId): IO[MockError, Unit]` | Remove a single rule by id. |
+| `replaceRules` | `(space: MockSpace, rules: List[MockRule]): IO[MockError, Unit]` | Replace all of a space's rules with the given set. |
+
+### Verification
+
+| Method | Signature | Purpose |
+|---|---|---|
+| `received` | `(space: MockSpace): IO[MockError, List[RecordedRequest]]` | The requests this space recorded, for assertions. |
+
+### Capability accessors
+
+Each accessor returns the capability instance when the adapter advertises it,
+or fails fast with `Unsupported(capability, backendName)` otherwise. Gate a
+suite's requirements up front with `require(Capability*): IO[Unsupported, Unit]`
+(e.g. at layer-construction time) so a backend gap fails before any scenario
+runs, not mid-scenario. Full behaviour of each capability is in
+[Advanced](mock-advanced.md).
+
+| Accessor | Returns | Capability |
+|---|---|---|
+| `faults` | `IO[Unsupported, Faults]` | `Capability.Faults` — inject transport failures or latency. |
+| `scenarios` | `IO[Unsupported, StatefulScenarios]` | `Capability.StatefulScenarios` — per-scenario request/response FSM. |
+| `stateInspection` | `IO[Unsupported, StateInspection]` | `Capability.StateInspection` — read/force FSM state directly. |
+| `scripting` | `IO[Unsupported, Scripting]` | `Capability.Scripting` — compute responses with a backend script. |
+| `proxyRecord` | `IO[Unsupported, ProxyRecord]` | `Capability.ProxyRecord` — proxy to and record from a real upstream. |
+| `templating` | `IO[Unsupported, Templating]` | `Capability.Templating` — substitute captured request values into a response body. |
+
+Two more members round out the port: `backendName: String` (named in every
+`Unsupported` this adapter raises) and `capabilities: Set[Capability]` (what
+it advertises).
+
+---
+
+## 3. `MockSpace` and `Isolation`
+
+A `MockSpace` is the unit of isolation — one mock backend "instance" a
+scenario provisions, targets, and destroys independently of every other space:
+
+```scala
+final case class MockSpace(
+  baseUri: String,
+  inject: HttpRequest => HttpRequest,
+  id: SpaceId
+)
+```
+
+- `baseUri` — where the SUT should send requests for this space.
+- `inject` — decorates an outgoing `HttpRequest` (e.g. stamping a correlation
+  header) so it reaches the right space under share-nothing isolation.
+- `id` — the space's `SpaceId`, used to address it in adapter-internal state.
+
+Steps never need to know *how* isolation works — they read `baseUri` and apply
+`inject`, and the behaviour is correct under either model. The model itself is
+one of two `Isolation` values, reported via `MockControl.isolation`:
+
+- **`Isolation.PerInstance`** — each space gets a unique `baseUri`; `inject`
+  is the identity. This is the default, and how both Rift adapters isolate
+  (each space is its own imposter/port).
+- **`Isolation.Correlated`** — every space in a run shares one `baseUri`;
+  `inject` stamps a correlation header the backend uses to route the request
+  to the right space's rules. This is how `WireMock.correlated` isolates
+  without spinning up a server per space.
+
+---
+
+## 4. The canonical request/response model
+
+Every adapter normalises its own wire format to this backend-neutral model
+(`zio.bdd.mock.*`) before it reaches an adapter — Gherkin steps, hooks,
+overlays and assertions program against these types only.
+
+| Type | Meaning |
+|---|---|
+| `Method` | HTTP method enum: `Get`, `Post`, `Put`, `Delete`, `Patch`, `Head`, `Options`, `Trace`, `Connect`. |
+| `PathMatch` | How a path is matched: `Any` (default), `Exact(path)`, `Regex(pattern)`, `Template(template)` (e.g. `"/users/{id}"`). |
+| `ValueMatch` | How a single scalar (query param or header) is matched: `Equals`, `Contains`, `Matches(regex)`. |
+| `BodyMatch` | How a request body is matched: `Equals`, `Contains`, `Matches(regex)`, `JsonPath(path, expected)`, `XPath(path, expected)`. |
+| `Body` | A response body payload: `Empty`, `Text(value)`, `Json(value)`, `Base64(value)`. |
+| `Priority` | Rule ordering bucket: `Base` or `Overlay` — overlay rules sit above base rules. |
+| `RequestMatch` | What to match on an incoming request: `method`, `path` (default `Any`), `query`, `headers`, `body` — every field optional/permissive by default. |
+| `ResponseDef` | The response a matched rule serves: `status` (default `200`), `headers`, `body` (default `Empty`), `delay`. |
+| `MockRule` | One stub: `` `match`: RequestMatch ``, `respond: ResponseDef`, `id: Option[RuleId]`. |
+| `RecordedRequest` | A request the backend recorded: `method`, `uri`, `headers`, `body` — what `received` returns. |
+| `Headers` | Opaque multi-map type (lower-cased keys, ordered values per key) shared by requests, matches and responses. |
+
+`ValueMatch`/`BodyMatch` (this model's matchers) are distinct from the DSL's
+fluent `ValueClause` (§5/[the DSL](mock-dsl.md)) that builds them, and a
+response's `Body` is distinct from a request matcher's `BodyMatch` — same
+shape family, different purpose (serve vs. match).
+
+---
+
+## 5. `MockSource` — feeding mocks in
+
+`MockSource` is where mock definitions come from. Every case normalises
+through one internal provisioning path to a per-space normalized form before
+reaching an adapter, so adapters never re-implement loading or auto-port
+assignment:
+
+```scala
+enum MockSource:
+  case Dsl(spec: MockSpec)
+  case Json(raw: String)
+  case Resource(path: String)
+  case File(path: String)
+  case Dir(path: String)
+```
+
+- **`Dsl(spec)`** — already-canonical rules built in-code via
+  `zio.bdd.mock.dsl.*` (e.g. `mock(get("/hello").respondWith(ok)).source`).
+- **`Json(raw)`** — a raw backend wire document, inline as a string.
+- **`Resource(path)`** — a classpath resource holding a raw wire document.
+- **`File(path)`** — a filesystem file holding a raw wire document.
+- **`Dir(path)`** — a filesystem directory; each regular file becomes one
+  space.
+
+The `Json`/`Resource`/`File`/`Dir` cases stay unparsed at this layer — each
+adapter parses its own wire format. `provision(source: MockSource)` is the
+single portable way in; the backend-pinned `provisionNative(NativeSpec)` is a
+separate, non-portable path (`NativeSpec` is *not* a `MockSource`) covered in
+[Advanced](mock-advanced.md). Full DSL builder reference — `get`/`post`/…,
+`.where(...)`, response builders, scenario builder — lives in
+[the DSL](mock-dsl.md).
+
+---
+
+## 6. `MockError` — the typed failures
+
+Core `MockControl` operations fail with the typed `MockError`, never a bare
+`Throwable`:
+
+```scala
+enum MockError:
+  case ProvisionFailed(reason: String)
+  case SpaceNotFound(space: SpaceId)
+  case RuleNotFound(space: SpaceId, rule: RuleId)
+  case InvalidDefinition(reason: String)
+  case CommunicationError(reason: String)
+```
+
+- **`ProvisionFailed`** — `provision`/`provisionNative` couldn't stand up a
+  space (bad source, backend rejected the definition).
+- **`SpaceNotFound`** — an operation addressed a `MockSpace` the backend
+  doesn't know about (already destroyed, wrong adapter instance).
+- **`RuleNotFound`** — `removeRule` addressed a `RuleId` that doesn't exist on
+  that space.
+- **`InvalidDefinition`** — a rule or source failed backend-side validation.
+- **`CommunicationError`** — the adapter couldn't reach its backend (network,
+  container, process).
+
+Capability accessors use a separate, narrower error: `Unsupported(capability,
+backend)` with a `.message`, raised when an adapter doesn't advertise a
+requested capability — this is how WireMock rejects `require(Capability.Scripting)`
+or a direct `.scripting` call, since it lacks Scripting/ProxyRecord/Templating.
+
+---
+
+Next: [the DSL](mock-dsl.md) · [Adapters](mock-adapters.md)

--- a/scripts/check-mock-docs.sh
+++ b/scripts/check-mock-docs.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Gate for the MockControl docs (#188): objective accuracy checks over docs/. Fails (non-zero) on any
+# missing page, missing nav link, broken internal link, or stale/incorrect version/capability fact.
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 2
+fail=0
+err() { echo "FAIL: $*"; fail=1; }
+
+NEW_PAGES=(mocking mock-dsl mock-adapters mock-gherkin mock-advanced mock-cookbook)
+
+# 1. All six new pages exist
+for p in "${NEW_PAGES[@]}"; do
+  [[ -f "docs/$p.md" ]] || err "missing page docs/$p.md"
+done
+
+# 2. index.md links every new page
+for p in "${NEW_PAGES[@]}"; do
+  grep -q "$p.md" docs/index.md || err "docs/index.md does not link $p.md"
+done
+
+# 3. No broken internal .md links across docs/ (every [..](x.md) target must exist)
+while IFS= read -r line; do
+  f="${line%%:*}"; tgt="${line##*:}"
+  base="${tgt%%#*}"                      # strip anchors
+  [[ -z "$base" || "$base" == http* ]] && continue
+  [[ -f "docs/$base" ]] || err "broken internal link in $f -> $base"
+done < <(grep -rhoE "\]\(([a-zA-Z0-9._-]+\.md)(#[a-zA-Z0-9_-]+)?\)" docs/ 2>/dev/null \
+          | sed -E 's/\]\(//; s/\)//' | awk -F: '{print FILENAME":"$0}' FILENAME="docs" | sort -u \
+          || true)
+
+# 4. Version accuracy in the new mock pages
+MOCK_MD=$(printf 'docs/%s.md ' "${NEW_PAGES[@]}")
+grep -Rq '1.2.0' $MOCK_MD || err "no 1.2.0 version reference in the mock pages"
+if grep -RnE '"zio-bdd[a-z-]*" +% +"1\.(0|1)\.0"' $MOCK_MD; then err "stale 1.0.0/1.1.0 dependency version in a mock page"; fi
+if grep -Rn '1.2.0-SNAPSHOT' $MOCK_MD; then err "SNAPSHOT version leaked into a mock page"; fi
+
+# 5. Rift container image: current default is v0.9.0; no stale v0.8.0 presented as the default
+if grep -RnE 'rift-proxy:v0\.8\.0' docs/mock-adapters.md; then err "stale Rift image v0.8.0 in mock-adapters.md"; fi
+
+# 6. Capability matrix: embedded is capability-complete (all six); no stale "no capabilities"/"four"
+if grep -RniE 'embedded[^.]{0,40}(no capabilit|four capabilit|only four)' $MOCK_MD; then err "stale 'embedded has no/four capabilities' claim"; fi
+grep -Rq 'StateInspection' docs/mock-adapters.md || err "capability matrix missing StateInspection in mock-adapters.md"
+
+# 7. Embedded JDK story: both artifacts + both JDKs + LuaJIT + native-access, in mock-adapters.md
+A=docs/mock-adapters.md
+grep -q 'zio-bdd-rift-embedded-jdk21' "$A" || err "mock-adapters.md missing the JDK-21 embedded artifact"
+grep -q 'zio-bdd-rift-embedded-natives' "$A" || err "mock-adapters.md missing the embedded-natives artifact"
+grep -qE 'JDK ?21' "$A" && grep -qE 'JDK ?22' "$A" || err "mock-adapters.md missing the JDK 21/22 split"
+grep -q 'enable-native-access' "$A" || err "mock-adapters.md missing --enable-native-access"
+grep -qiE 'luajit' "$A" || err "mock-adapters.md missing the LuaJIT prerequisite"
+
+# 8. Used By section seeded with Rift (README or docs landing)
+grep -RqiE 'used by' README.md docs/index.md && grep -RqiE '\[?rift\]?\(https://github.com/EtaCassiopeia/rift' README.md docs/index.md \
+  || err "no 'Used By' section listing Rift (README.md or docs/index.md)"
+
+if [[ $fail -eq 0 ]]; then echo "OK: mock docs gate passed"; fi
+exit $fail


### PR DESCRIPTION
## Summary

Add six new pages documenting the MockControl mocking feature: mocking (intro & SPI), mock-dsl (DSL syntax), mock-adapters (Rift container + embedded FFM, WireMock), mock-gherkin (@mock fixtures), mock-advanced (optional capabilities), mock-cookbook (task recipes). All code examples verified against compiling zio-bdd-samples and 1.2.0 API. Wire into docs nav (index.md), add MockControl note to layers.md, link recipes from cookbook.md, add Used-By section (README) seeded with Rift. Facts pinned to master: capability matrix (Rift + embedded = all six, WireMock = three), version 1.2.0, embedded JDK 21/22 two-artifact story with LuaJIT + flags. Adds scripts/check-mock-docs.sh as accuracy gate.

Closes #188

**Verification:** docs accuracy gate (scripts/check-mock-docs.sh) passes; opus accuracy audit against the real API + samples passed (one typecheck issue found and fixed); docs-only change (no Scala touched).