### PR TITLE
feat: expose mock catalog for static discovery (allMocks) for @mock(name) tooling

### DIFF
--- a/core/src/main/scala/zio/bdd/mock/steps/MockSteps.scala
+++ b/core/src/main/scala/zio/bdd/mock/steps/MockSteps.scala
@@ -46,6 +46,32 @@ final case class MockResponse(status: Int, body: String, headers: Headers)
  */
 trait MockSteps[R, S] { self: ZIOSteps[R & MockControl, S] =>
 
+  /**
+   * The `@mock(name)` catalog: the named [[MockSource]] entries this suite can
+   * deploy. Override it to declare the suite's catalog once, then reference it
+   * when wiring the scenario fixtures (e.g. `MockFixtures.scenario(meta,
+   * mockCatalog)`).
+   *
+   * Declaring it here — rather than only inline at layer-construction time —
+   * makes the catalog statically discoverable via [[allMocks]], so editor
+   * tooling can offer completion and unknown-name diagnostics for `@mock(...)`
+   * tags. Pure data: reading it provisions nothing.
+   */
+  def mockCatalog: Map[String, MockSource] = Map.empty
+
+  /**
+   * A static summary of every [[mockCatalog]] entry, for tooling discovery of
+   * `@mock(name)` tags — the catalog counterpart of `ZIOSteps.allDefinitions`.
+   *
+   * Reflectively callable from a no-arg-constructed suite instance without any
+   * live mock backend: it only reads the pure [[mockCatalog]] map and never
+   * provisions a space. Backend-agnostic — identical whether the suite runs on
+   * Rift container, Rift embedded, or WireMock. Ordered by `name` so tooling
+   * gets a stable list (the underlying map has no defined order).
+   */
+  def allMocks: List[MockSummary] =
+    mockCatalog.toList.sortBy(_._1).map { case (name, source) => MockSummary(name, source.productPrefix) }
+
   Given("a mock space returning " / int / " " / string / " at " / string) { (status: Int, body: String, path: String) =>
     for
       spaces <- mock(_.provision(MockSource.Dsl(MockSpec(List(ruleFor(status, body, path))))))

--- a/core/src/main/scala/zio/bdd/mock/steps/MockSummary.scala
+++ b/core/src/main/scala/zio/bdd/mock/steps/MockSummary.scala
@@ -1,0 +1,16 @@
+package zio.bdd.mock.steps
+
+/**
+ * A static summary of one `@mock(name)` catalog entry, produced by
+ * `MockSteps.allMocks`. Consumed by external tooling (LSP server, IntelliJ
+ * plugin) to offer completion and unknown-name diagnostics for `@mock(...)`
+ * tags without a live mock backend — the catalog counterpart of
+ * [[zio.bdd.core.step.StepSummary]].
+ *
+ * @param name
+ *   the catalog key referenced by `@mock(name)`
+ * @param sourceKind
+ *   the [[zio.bdd.mock.MockSource]] variant backing the entry (e.g. `"Dsl"`,
+ *   `"Json"`, `"Resource"`, `"File"`, `"Dir"`)
+ */
+final case class MockSummary(name: String, sourceKind: String)

--- a/core/src/test/scala/zio/bdd/mock/steps/AllMocksSpec.scala
+++ b/core/src/test/scala/zio/bdd/mock/steps/AllMocksSpec.scala
@@ -1,0 +1,81 @@
+package zio.bdd.mock.steps
+
+import zio.*
+import zio.bdd.core.step.ZIOSteps
+import zio.bdd.mock.*
+import zio.schema.{DeriveSchema, Schema}
+import zio.test.*
+
+final case class AllMocksState()
+object AllMocksState:
+  given Schema[AllMocksState] = DeriveSchema.gen[AllMocksState]
+
+// Real zio-bdd suites are top-level objects: `object MySuite extends ZIOSteps...`.
+// Modelled the same here so the reflection test walks the same path tooling does
+// (module `MODULE$`), and so no live backend is ever provisioned.
+object CatalogSuite extends ZIOSteps[MockControl, AllMocksState] with MockSteps[MockControl, AllMocksState]:
+  // No live backend: static discovery must not touch it.
+  override def environment: ZLayer[Any, Throwable, MockControl] =
+    ZLayer.fail(new RuntimeException("no backend during static discovery"))
+
+  override def mockCatalog: Map[String, MockSource] = Map(
+    "payments"  -> MockSource.Resource("wire/payments.json"),
+    "inventory" -> MockSource.Dsl(MockSpec(Nil)),
+    "ledger"    -> MockSource.Json("{}"),
+    "orders"    -> MockSource.File("orders.json"),
+    "catalog"   -> MockSource.Dir("mocks/")
+  )
+
+// A suite that mixes MockSteps but declares no catalog (backward-compat).
+object EmptyCatalogSuite extends ZIOSteps[MockControl, AllMocksState] with MockSteps[MockControl, AllMocksState]:
+  override def environment: ZLayer[Any, Throwable, MockControl] =
+    ZLayer.fail(new RuntimeException("no backend"))
+
+/**
+ * Gate for #204: the static-discovery contract of `allMocks`.
+ *
+ * Mirrors the `allDefinitions` tooling contract — the zio-bdd StepLoader
+ * reflects a suite instance and reads the catalog WITHOUT provisioning any mock
+ * backend. These suites never provide a `MockControl`; `environment`
+ * deliberately fails so a regression that touches the backend during discovery
+ * would surface.
+ */
+object AllMocksSpec extends ZIOSpecDefault:
+  def spec = suite("allMocks — static catalog discovery")(
+    test("AC1: exposes name + sourceKind for each catalog entry, no backend needed") {
+      val mocks = CatalogSuite.allMocks
+      assertTrue(
+        // stable, name-sorted order so tooling completion is deterministic
+        mocks.map(_.name) == List("catalog", "inventory", "ledger", "orders", "payments"),
+        mocks.forall(_.sourceKind.nonEmpty)
+      )
+    },
+    test("AC2: sourceKind reflects the MockSource variant") {
+      val byName = CatalogSuite.allMocks.map(m => m.name -> m.sourceKind).toMap
+      assertTrue(
+        byName("payments") == "Resource",
+        byName("inventory") == "Dsl",
+        byName("ledger") == "Json",
+        byName("orders") == "File",
+        byName("catalog") == "Dir"
+      )
+    },
+    test("AC3: reflectively callable on a backend-free instance; name/sourceKind readable via reflection") {
+      // The StepLoader path: resolve the suite module, invoke `allMocks`, read fields.
+      val module = Class.forName("zio.bdd.mock.steps.CatalogSuite$").getField("MODULE$").get(null)
+      val result = module.getClass.getMethod("allMocks").invoke(module).asInstanceOf[List[?]]
+      val entries = result.map { m =>
+        val name       = m.getClass.getMethod("name").invoke(m).asInstanceOf[String]
+        val sourceKind = m.getClass.getMethod("sourceKind").invoke(m).asInstanceOf[String]
+        name -> sourceKind
+      }.toMap
+      assertTrue(
+        result.size == 5,
+        entries("payments") == "Resource",
+        entries("inventory") == "Dsl"
+      )
+    },
+    test("AC4: default (no override) exposes an empty catalog") {
+      assertTrue(EmptyCatalogSuite.allMocks.isEmpty)
+    }
+  )

--- a/docs/mock-gherkin.md
+++ b/docs/mock-gherkin.md
@@ -126,6 +126,27 @@ entry from being `MockSource.Json(raw)`, `.Resource(path)`, `.File(path)`, or
 `.Dir(path)` instead of `.Dsl(...)` — the catalog only fixes the *name*, not
 the source kind.
 
+### Static discovery for tooling (`allMocks`)
+
+Override `MockSteps.mockCatalog` on the suite to declare the catalog once, then
+reference it when wiring the scenario fixtures — the same map drives live
+provisioning *and* becomes statically discoverable:
+
+```scala
+object MySuite extends ZIOSteps[MockControl, S] with MockSteps[MockControl, S]:
+  override def mockCatalog: Map[String, MockSource] = Catalog.entries
+  override def scenarioLayer = MockFixtures.scenario(meta, mockCatalog)
+```
+
+`MockSteps.allMocks` then returns a `List[MockSummary]` (each `name` +
+`sourceKind`, name-sorted) — the catalog counterpart of `ZIOSteps.allDefinitions`
+([step discovery](step-dsl.md)). Like `allDefinitions`, it is a pure reflection
+target the editor tooling (LSP server, IntelliJ plugin) reads from a
+no-arg-constructed suite instance with **no** live mock backend — provisioning
+nothing — so it can offer `@mock(name)` completion and unknown-name diagnostics.
+It is backend-agnostic: identical whether the suite runs on Rift container, Rift
+embedded, or WireMock.
+
 ---
 
 ## 4. `Stage` for mock data


### PR DESCRIPTION
Adds a reflective, side-effect-free `allMocks: List[MockSummary]` to the `MockSteps` mixin, derived from an overridable `def mockCatalog: Map[String, MockSource]`. This mirrors `ZIOSteps.allDefinitions`: editor tooling (LSP/IntelliJ `StepLoader`) can read a suite's `@mock(name)` catalog from a no-arg / module suite instance with **no** live mock backend, so it can offer completion and unknown-name diagnostics.

- `mockCatalog` (overridable, defaults empty): declare the catalog once; the same map drives live provisioning and static discovery.
- `allMocks`: pure, name-sorted `List[MockSummary]` (`name` + `sourceKind`); `sourceKind` is the `MockSource` variant via `productPrefix`.
- `definedAt`/`SourcePos` (go-to-definition) intentionally deferred — optional in the issue and needs source-position capture not cheaply available; the two robust features (completion, diagnostics) need only name + sourceKind.
- Documented in `docs/mock-gherkin.md` alongside the catalog pattern.

Verified: `scalafmtCheckAll` clean; `core/test` 542 passed (4 new in `AllMocksSpec` covering name/sourceKind, per-variant kinds, reflective invocation, and empty-default backward-compat).

Closes #204
Milestone: none (standalone mock-spi enhancement; not in the M1–M4 SPI epic roadmap)