### PR TITLE
build: set a -release:11 floor on core artifacts so JDK 21 consumers can load them

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -143,6 +143,17 @@ inThisBuild(
   )
 )
 
+// Java-version floor for the published NON-FFM modules (#205). Without a pinned `-release`, Scala 3
+// targets the build JDK's class-file version, so a release cut on JDK 22 produced class-66 bytecode
+// that even JDK 21 cannot load. These modules use no Java-22 API (the container adapter + core are
+// JDK-11 by design, see the FFM note above), so pin class 55 — loadable on Java 11+ — regardless of
+// the JDK that cuts the release. The FFM/embedded modules are deliberately NOT given this floor: they
+// are version-locked to JDK 21/22 by their own `--release` and must stay so.
+lazy val javaFloorSettings: Seq[Def.Setting[_]] = Seq(
+  Compile / scalacOptions += "-release:11",
+  Compile / javacOptions ++= Seq("--release", "11")
+)
+
 lazy val commonDependencies = Seq(
   "dev.zio" %% "zio"                   % "2.1.17",
   "dev.zio" %% "zio-schema"            % "1.6.6",
@@ -244,6 +255,7 @@ lazy val core = (project in file("core"))
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     stepMethodGeneratorSettings,
+    javaFloorSettings,
     mimaSettings
   )
 
@@ -251,6 +263,7 @@ lazy val gherkin = (project in file("gherkin"))
   .settings(
     name := "zio-bdd-gherkin",
     libraryDependencies ++= commonDependencies,
+    javaFloorSettings,
     mimaSettings
   )
 
@@ -261,6 +274,7 @@ lazy val mock = (project in file("mock"))
     name := "zio-bdd-mock",
     libraryDependencies ++= commonDependencies,
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    javaFloorSettings,
     // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
     mimaPreviousArtifacts := Set.empty
   )
@@ -296,6 +310,7 @@ lazy val rift = Project("rift", file("rift"))
       )
       Seq(out)
     }.taskValue,
+    javaFloorSettings,
     // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
     mimaPreviousArtifacts := Set.empty
   )
@@ -358,6 +373,7 @@ lazy val wiremock = (project in file("wiremock"))
       "org.wiremock" % "wiremock" % "3.9.2"
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
+    javaFloorSettings,
     // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
     mimaPreviousArtifacts := Set.empty
   )


### PR DESCRIPTION
The published 1.2.0 core artifacts are Java-22 bytecode (class 66) — cut on a JDK-22 machine with no pinned `-release`, so Scala 3 defaulted to the build JDK's class-file version. JDK 21 (class 65) and below cannot load `zio-bdd_3` at all, even though core touches no Java-22 API.

Fix: add `javaFloorSettings` (`Compile / scalacOptions += "-release:11"`, `Compile / javacOptions ++= Seq("--release","11")`) to the five published non-FFM modules — **core, gherkin, mock, rift (container adapter), wiremock** — pinning class-55 bytecode regardless of the JDK that cuts the release.

**Floor is Java 11** (not the issue's primary 21): build.sbt's own comment says "core stay JDK-11", the old SNAPSHOT was class 55, and the downstream consumer (rift-conformance#38) is Java 11. The build compiles + tests green on JDK 11, so nothing in these modules uses a >11 API. Class 55 satisfies the acceptance ("class ≤ 65") and is strictly more compatible than 21.

The FFM/embedded modules (`zio-bdd-rift-embedded` `--release 22`, `zio-bdd-rift-embedded-jdk21` `--release 21 --enable-preview`) are deliberately left untouched — they are version-locked to JDK 21/22 by design.

Verified: `sbt show <module>/Compile/scalacOptions` carries `-release:11` on all five; `javap -v` on `zio.bdd.core.Suite` shows `major version: 55`; embedded split unchanged; full `compile` + `scalafmtCheckAll` + `test` (538 + 57 + others, 0 failed) green.

Closes #205
Milestone: none (standalone build fix; not in the M1–M4 SPI epic roadmap)