### PR TITLE
build: bump rift to v0.9.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ import java.security.MessageDigest
 // Single source of truth for the pinned Rift release (#195). Both the FFI natives (riftNativesVersion,
 // downloaded into the embedded-natives jar) and the container image tag (Rift.DefaultImage, via the
 // generated RiftBuildInfo below) derive from it, so a version bump touches exactly one line.
-val riftVersion        = "0.9.0"
+val riftVersion        = "0.9.1"
 val riftNativesVersion = riftVersion
 
 // The (os, arch, ext) cdylibs bundled into the natives jar — linux/macOS × x86_64/aarch64 (#134).

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
@@ -14,9 +14,9 @@ object RiftBuildInfoSpec extends ZIOSpecDefault:
   def spec = suite("RiftBuildInfo")(
     test("DefaultImage is derived from the single rift-version source of truth") {
       assertTrue(
-        RiftBuildInfo.riftVersion == "0.9.0",
+        RiftBuildInfo.riftVersion == "0.9.1",
         Rift.DefaultImage == s"zainalpour/rift-proxy:v${RiftBuildInfo.riftVersion}",
-        Rift.DefaultImage == "zainalpour/rift-proxy:v0.9.0"
+        Rift.DefaultImage == "zainalpour/rift-proxy:v0.9.1"
       )
     }
   )


### PR DESCRIPTION
Point the single `riftVersion` source of truth (build.sbt, #195/#197) at the just-released Rift **v0.9.1**; the FFI natives version and the container image tag (`Rift.DefaultImage` → `zainalpour/rift-proxy:v0.9.1`) both derive from it — one line.

Verified locally: all four v0.9.1 `librift_ffi` cdylibs download + checksum-verify against the v0.9.1 release; `rift` compiles with the derived `DefaultImage`; the v0.9.1 GitHub release, Docker image, and natives are all published.