### PR TITLE
docs: prepare 1.3.0 release notes and bump install snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to zio-bdd are documented here.
 
 ## [Unreleased]
 
+## [1.3.0] — 2026-07-04
+
+### Added
+
+- **`allMocks` static catalog discovery** — `MockSteps` now exposes an overridable
+  `mockCatalog: Map[String, MockSource]` and a pure, reflectively-callable
+  `allMocks: List[MockSummary]` (`name` + `sourceKind`, name-sorted), mirroring
+  `ZIOSteps.allDefinitions`. Editor tooling (LSP / IntelliJ) can read a suite's `@mock(name)`
+  catalog from a no-arg-constructed instance with no live mock backend, to offer completion and
+  unknown-name diagnostics. (#204)
+- **rift-embedded Correlated (space-based) isolation** — the embedded FFM provider gains the
+  Correlated isolation model (a shared imposter keyed by correlation id), matching the container
+  and WireMock adapters. (#203)
+
+### Fixed
+
+- **Core artifacts no longer require Java 22** — the published non-FFM modules (`zio-bdd`,
+  `zio-bdd-gherkin`, `zio-bdd-mock`, `zio-bdd-rift`, `zio-bdd-wiremock`) now pin `-release:11`, so
+  their bytecode is class 55 and loadable on Java 11+ regardless of the JDK that cuts the release.
+  1.2.0 was accidentally published as class-66 (Java 22) bytecode that even JDK 21 could not load.
+  The FFM/embedded modules keep their JDK 21/22 split. (#205)
+
+### Changed
+
+- Bumped the pinned Rift release to v0.9.1. (#209)
+
+## [1.2.0] — 2026-07-04
+
+### Added
+
+- **Portable MockControl SPI** — a backend-neutral mocking API (`MockControl`, `MockSource`, the
+  canonical request/response model, fail-fast capability negotiation) with a fluent DSL,
+  `@mock(name)` / `@flags` scenario fixtures, the `MockSteps[R, S]` mixin, and SUT base-URL
+  injection for share-nothing isolation.
+- **Adapters** — Rift (container, via testcontainers) and in-process WireMock, plus an embedded
+  in-process Rift provider over Panama FFM (`MockControl.embedded`, JDK-21 preview / JDK-22 stable
+  variants with bundled native libraries).
+- **Capabilities** — Faults, StatefulScenarios + StateInspection, Scripting, ProxyRecord, and
+  Templating, verified by a conformance harness + matrix runner across adapters.
+
+## [1.1.0] — 2026-06-26
+
 ### Added
 
 - **Property-based testing (Mode P)** — `@property(samples=N, seed=S, shrink=true, ...)` on a

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ object AccountSpec extends ZIOSteps[Any, AccountState]:
 
 ```scala
 // build.sbt
-libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.2.0" % Test
+libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.3.0" % Test
 
 Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
 ```

--- a/docs/mock-adapters.md
+++ b/docs/mock-adapters.md
@@ -9,7 +9,7 @@ pick one.
 
 ## 1. The three backends at a glance
 
-| Adapter | Coordinates (1.2.0) | Docker? | JDK | Isolation default | Capabilities |
+| Adapter | Coordinates (1.3.0) | Docker? | JDK | Isolation default | Capabilities |
 |---|---|---|---|---|---|
 | Rift container | `zio-bdd-rift` | yes (testcontainers) | 11+ | PerInstance | all six |
 | WireMock | `zio-bdd-wiremock` | no | 11+ | Correlated (via `.correlated`) | Faults, StatefulScenarios, StateInspection only |
@@ -38,7 +38,7 @@ against it fails with `Unsupported` (§3 below, and see
 ## 2. Rift container (`zio-bdd-rift`)
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd-rift" % "1.2.0"
+"io.github.etacassiopeia" %% "zio-bdd-rift" % "1.3.0"
 ```
 
 Two entry points, both requiring a zio-http `Client` and a `Provisioning` in
@@ -97,7 +97,7 @@ See [layers](layers.md) for how this composes into a suite's `environment`.
 ## 3. WireMock (`zio-bdd-wiremock`)
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.2.0"
+"io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.3.0"
 ```
 
 In-process, no Docker, runs on JDK 11+. Only requires `Provisioning`:
@@ -145,15 +145,15 @@ published as **two variants built from the same source**, and you pick
 exactly one for your build's JDK:
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd-rift-embedded"       % "1.2.0" // JDK 22+ (stable FFM)
-"io.github.etacassiopeia" %% "zio-bdd-rift-embedded-jdk21" % "1.2.0" // JDK 21   (preview FFM)
+"io.github.etacassiopeia" %% "zio-bdd-rift-embedded"       % "1.3.0" // JDK 22+ (stable FFM)
+"io.github.etacassiopeia" %% "zio-bdd-rift-embedded-jdk21" % "1.3.0" // JDK 21   (preview FFM)
 ```
 
 Both additionally need the native library on the classpath (or an explicit
 override), and neither is scala-versioned — note the single `%`, not `%%`:
 
 ```scala
-"io.github.etacassiopeia" % "zio-bdd-rift-embedded-natives" % "1.2.0" % Test
+"io.github.etacassiopeia" % "zio-bdd-rift-embedded-natives" % "1.3.0" % Test
 ```
 
 `zio-bdd-rift-embedded-natives` bundles the per-platform `librift_ffi`

--- a/docs/mock-cookbook.md
+++ b/docs/mock-cookbook.md
@@ -16,8 +16,8 @@ Add the WireMock adapter — it runs fully in-process on JDK 11+, no containers:
 ```scala
 // build.sbt
 libraryDependencies ++= Seq(
-  "io.github.etacassiopeia" %% "zio-bdd"          % "1.2.0",
-  "io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.2.0" % Test
+  "io.github.etacassiopeia" %% "zio-bdd"          % "1.3.0",
+  "io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.3.0" % Test
 )
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,7 +9,7 @@ as a concrete example throughout.
 In `build.sbt`:
 
 ```scala
-libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.2.0" % Test
+libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.3.0" % Test
 
 Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
 ```


### PR DESCRIPTION
Release prep for **1.3.0** (see the answer to "cut 1.3.0"). Docs-only — no code changes.

- **CHANGELOG:** new `[1.3.0]` section covering everything since v1.2.0 — `allMocks` static catalog discovery (#204), rift-embedded Correlated isolation (#203), the `-release:11` core Java-floor fix (#205), and the rift v0.9.1 bump (#209).
- **Backfill:** added the missing `[1.2.0]` (the portable MockControl SPI + Rift/WireMock/embedded adapters + capabilities), and relabeled the stale `[Unreleased]` block to `[1.1.0]` — its property-testing content (#95) shipped in v1.1.0 but was never moved out of Unreleased.
- **Install snippets:** bumped `1.2.0 → 1.3.0` across README and docs (quickstart, mock-cookbook, mock-adapters), matching the #201 convention.

After this merges, the `v1.3.0` tag will be cut on the merge commit to trigger `sbt ci-release`.