### PR TITLE
Embedded MockControl should honour a caller-requested imposter port

### DIFF
--- a/mock/src/main/scala/zio/bdd/mock/Dsl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Dsl.scala
@@ -111,7 +111,9 @@ object dsl:
 
   extension (spec: MockSpec)
     /**
-     * Set the advisory port (always stripped on provision — see [[MockSpec]]).
+     * Pin the imposter to a fixed port — the opt-in fixed-port path (#211): the
+     * Rift adapters bind exactly this port instead of auto-assigning a free
+     * one. Omit it for the share-nothing default (a fresh free port per space).
      */
     def onPort(port: Int): MockSpec = spec.copy(port = Some(port))
 

--- a/mock/src/main/scala/zio/bdd/mock/MockSource.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockSource.scala
@@ -2,12 +2,12 @@ package zio.bdd.mock
 
 /**
  * A minimal, portable spec a [[MockSource.Dsl]] carries: canonical rules plus
- * an *advisory* port. The fluent builders that produce a `MockSpec` land in
- * #112 — here it is just the neutral payload the DSL source wraps.
+ * an optional fixed port.
  *
- * `port` is advisory only: [[Provisioning]] always strips it and auto-assigns a
- * fresh free port (see the fixed-port trap in #111). It is retained on the
- * normalized form purely for diagnostics.
+ * `port` is the opt-in fixed port (#211, set via `onPort`): when present the
+ * Rift adapters bind exactly it instead of auto-assigning; when absent each
+ * space gets a fresh free port (the share-nothing default, and the
+ * fixed-port-trap-safe behaviour of #111).
  */
 final case class MockSpec(rules: List[MockRule], port: Option[Int] = None)
 

--- a/mock/src/main/scala/zio/bdd/mock/Provisioning.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Provisioning.scala
@@ -14,8 +14,10 @@ import java.nio.file.{Files, Paths}
  *     "dsl"/"json"/the resource or file base name otherwise).
  *   - `payload` : canonical rules (from the DSL) or raw backend wire text (from
  *     json/resource/file) the adapter parses itself.
- *   - `authoredPort`: the advisory port the author requested, if any. Always
- *     stripped on provision — kept only for diagnostics.
+ *   - `authoredPort`: the port the author requested, if any. Honoured as an
+ *     opt-in fixed port by the adapters' port selection
+ *     ([[Provisioning.choosePort]], #211); when absent a fresh free port is
+ *     auto-assigned (the default).
  */
 final case class NormalizedSource(name: String, payload: SourcePayload, authoredPort: Option[Int])
 
@@ -37,13 +39,15 @@ private object MockIO:
 
 /**
  * Hands out localhost ports that are free at the moment of issue and distinct
- * across the allocator's lifetime — the antidote to the fixed-port trap: an
- * authored port is never honored, every space gets its own auto-assigned port.
+ * across the allocator's lifetime — the default (no authored port) path, and
+ * the antidote to the fixed-port trap: every auto-assigned space gets its own
+ * port. (An explicitly authored port bypasses the allocator entirely — see
+ * [[Provisioning.choosePort]], #211.)
  *
  * Allocation probes the OS (`ServerSocket(0)`) and closes the probe, so there
  * is an inherent TOCTOU window before the caller binds the port; distinctness
- * within the allocator removes the *self*-collision (provisioning the same
- * fixed-port source twice), which is the trap this issue targets.
+ * within the allocator removes the *self*-collision (auto-assigning the same
+ * port to two spaces).
  */
 trait PortAllocator:
   def freePort: IO[MockError, Int]
@@ -77,12 +81,24 @@ object PortAllocator:
 /**
  * The single provisioning entry point (#111). Normalizes any [[MockSource]] to
  * one [[NormalizedSource]] per space — memoizing the parsed form so repeated
- * provisioning of the same source is cheap — then for each space strips the
- * authored port, auto-assigns a free one, asks the adapter to serve the
- * payload, and assembles the resolved [[MockSpace]] whose `baseUri` reflects
- * the auto-assigned port.
+ * provisioning of the same source is cheap. This convenience always
+ * auto-assigns a free port; adapters that support an opt-in fixed port select
+ * via [[choosePort]] on their own serve path instead (#211).
  */
 final case class Provisioning(allocator: PortAllocator, cache: Ref[Map[MockSource, List[NormalizedSource]]]):
+
+  /**
+   * Select the port to bind an imposter on: honour a caller-authored port
+   * verbatim (the opt-in fixed-port path, #211 — e.g. `MockSpec.onPort(n)`),
+   * otherwise auto-assign a fresh free one (the share-nothing default). An
+   * authored port that is already bound is not worked around here — the adapter
+   * surfaces the backend's bind failure rather than silently falling back to a
+   * random port.
+   */
+  def choosePort(authoredPort: Option[Int]): IO[MockError, Int] =
+    authoredPort match
+      case Some(port) => ZIO.succeed(port)
+      case None       => allocator.freePort
 
   /** Resolve a source to one normalized form per space; memoized by source. */
   def normalize(source: MockSource): IO[MockError, List[NormalizedSource]] =

--- a/mock/src/test/scala/zio/bdd/mock/ProvisioningSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/ProvisioningSpec.scala
@@ -117,6 +117,19 @@ object ProvisioningSpec extends ZIOSpecDefault:
           space.inject(HttpRequest(Method.Get, "http://x/")) == HttpRequest(Method.Get, "http://x/")
         )
     },
+    test("choosePort honours an authored port verbatim (the opt-in fixed-port seam, #211)") {
+      for
+        prov <- Provisioning.make
+        p    <- prov.choosePort(Some(9998))
+      yield assertTrue(p == 9998)
+    },
+    test("choosePort auto-allocates a distinct free port when none is authored (default preserved)") {
+      for
+        prov <- Provisioning.make
+        a    <- prov.choosePort(None)
+        b    <- prov.choosePort(None)
+      yield assertTrue(a > 0, b > 0, a != b)
+    },
     test("normalize memoizes: a source deleted after first normalize still resolves from cache") {
       ZIO.scoped {
         for

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
@@ -362,12 +362,13 @@ private[embedded] final case class EmbeddedRiftMockControl(
 
   // ===== PerInstance — one imposter per space =====================================
 
-  // Stand up one imposter for `src` on its own OS-assigned localhost port. The host allocates a
-  // free port (PortAllocator) and the engine binds it directly (`rift_create_imposter` echoes the
-  // requested port); a mismatch means the port was taken in the bind window — surfaced, not hidden.
+  // Stand up one imposter for `src`. Honour a caller-authored port verbatim (#211), else auto-assign
+  // a free localhost port (the share-nothing default) — `Provisioning.choosePort` picks. The engine
+  // binds the chosen port directly (`rift_create_imposter` echoes the requested port); a mismatch
+  // means the port was taken in the bind window — surfaced as a MockError, never hidden or retried.
   private def serveImposter(src: NormalizedSource): IO[MockError, MockSpace] =
     for
-      port  <- provisioning.allocator.freePort
+      port  <- provisioning.choosePort(src.authoredPort)
       built <- buildImposter(port, src)
       bound <- engine.createImposter(built.configJson)
       _ <- ZIO.unless(bound == port)(

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
@@ -76,6 +76,19 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
     }
 
   def spec = suite("EmbeddedRiftCapabilities")(
+    test("#211: an authored port is honoured — the imposter binds on it and baseUri reflects it") {
+      withControl { (control, _, _, _) =>
+        for
+          space <- control.provision(MockSource.Dsl(MockSpec(List(pingRule), port = Some(9998)))).map(_.head)
+        yield assertTrue(portFromUri(space.baseUri) == 9998, space.baseUri == "http://localhost:9998")
+      }
+    },
+    test("#211: omitting the port keeps the auto-assigned default (a nonzero free port, not 9998)") {
+      withControl { (control, _, _, _) =>
+        for space <- control.provision(pingSource).map(_.head)
+        yield assertTrue(portFromUri(space.baseUri) > 0, portFromUri(space.baseUri) != 9998)
+      }
+    },
     test("advertises all six capabilities and every accessor succeeds") {
       withControl { (control, _, _, _) =>
         for

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -314,22 +314,33 @@ private[rift] final case class RiftMockControl(
 
   // ===== PerInstance — one imposter per space =====================================
 
+  // Honour a caller-authored port (#211): bind the imposter on exactly that port instead of taking
+  // a pool port, and never fall back to a random one — a bind failure surfaces via `postImposter`.
+  // The authored port is the container-internal imposter port; the caller is responsible for it
+  // being reachable (published/host-networked), just as the pool ports are. Without an authored
+  // port the share-nothing default holds: take a pool port and return it to the pool on failure.
   private def serveImposter(src: NormalizedSource): IO[MockError, MockSpace] =
-    endpoint.acquirePort.flatMap { port =>
-      val stand =
-        for
-          bodyAndCount <- imposterBody(port, src)
-          (body, count) = bodyAndCount
-          _            <- postImposter(port, body)
-          ruleIds      <- freshIds(count)
-          stubs        <- Ref.make(ruleIds)
-          scen         <- Ref.make(Map.empty[String, ScenarioState])
-          id            = SpaceId(s"${src.name}-$port")
-          space         = MockSpace(endpoint.baseUriFor(port), identity, id)
-          _            <- spaces.update(_.updated(id, Imposter(port, stubs, scen)))
-        yield space
-      stand.onError(_ => endpoint.releasePort(port))
-    }
+    src.authoredPort match
+      case Some(port) => standImposter(port, src, pooled = false)
+      case None =>
+        endpoint.acquirePort.flatMap(port =>
+          standImposter(port, src, pooled = true).onError(_ => endpoint.releasePort(port))
+        )
+
+  // `pooled` records whether `port` came from the endpoint pool — so `piDestroy` returns only pooled
+  // ports to the pool and never an authored fixed port (which would corrupt the pool, #211).
+  private def standImposter(port: Int, src: NormalizedSource, pooled: Boolean): IO[MockError, MockSpace] =
+    for
+      bodyAndCount <- imposterBody(port, src)
+      (body, count) = bodyAndCount
+      _            <- postImposter(port, body)
+      ruleIds      <- freshIds(count)
+      stubs        <- Ref.make(ruleIds)
+      scen         <- Ref.make(Map.empty[String, ScenarioState])
+      id            = SpaceId(s"${src.name}-$port")
+      space         = MockSpace(endpoint.baseUriFor(port), identity, id)
+      _            <- spaces.update(_.updated(id, Imposter(port, stubs, scen, pooled)))
+    yield space
 
   private def piAddRule(imp: Imposter, rule: MockRule, priority: Priority): IO[MockError, RuleId] =
     for
@@ -371,7 +382,7 @@ private[rift] final case class RiftMockControl(
       u   <- url(s"/imposters/${imp.port}")
       res <- send(Request(method = HttpMethod.DELETE, url = u))
       _   <- ZIO.unless(res._1 == 404)(expectSuccess(s"destroy imposter ${imp.port}", res))
-      _   <- endpoint.releasePort(imp.port)
+      _   <- ZIO.when(imp.pooled)(endpoint.releasePort(imp.port)) // never return an authored fixed port (#211)
       _   <- spaces.update(_ - space.id)
     yield ()
 
@@ -577,7 +588,8 @@ private[rift] object RiftMockControl:
   final case class Imposter(
     port: Int,
     stubs: Ref[Vector[RuleId]],
-    scenarios: Ref[Map[String, ScenarioState]] // defined scenario name -> initial state (for reset)
+    scenarios: Ref[Map[String, ScenarioState]], // defined scenario name -> initial state (for reset)
+    pooled: Boolean                             // port drawn from the endpoint pool (vs. a caller-authored fixed port, #211)
   )
   final case class CorrSpace(
     port: Int,

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -83,6 +83,51 @@ object RiftMockControlSpec extends ZIOSpecDefault:
           )
       }
     },
+    test("#211: an authored port binds the imposter on THAT port — baseUri and the create body both use it") {
+      val fixed = 9998 // outside withAdapter's 4545..4600 pool, so a pool port can't masquerade as a pass
+      withAdapter { (control, fake) =>
+        for
+          spacesE <- control.provision(MockSource.Dsl(MockSpec(List(pingRule), port = Some(fixed)))).either
+          posted  <- fake.posted.get
+        yield
+          val space = spacesE.toOption.toList.flatten.head
+          assertTrue(
+            spacesE.isRight,
+            space.baseUri == s"http://localhost:$fixed",
+            posted.exists(b => FakeRift.portOf(b).contains(fixed))
+          )
+      }
+    },
+    test("#211: omitting the port preserves the default — the imposter gets an auto-assigned pool port") {
+      withAdapterPool(List(4600)) { (control, _) =>
+        for spacesE <- control.provision(pingSource).either
+        yield assertTrue(spacesE.toOption.toList.flatten.head.baseUri == "http://localhost:4600")
+      }
+    },
+    test("#211: a create rejection on the authored port surfaces as a descriptive MockError — no silent fallback") {
+      withAdapter { (control, fake) =>
+        for
+          _      <- fake.failProvision.set(true)
+          result <- control.provision(MockSource.Dsl(MockSpec(List(pingRule), port = Some(9998)))).either
+        yield assertTrue(
+          result.isLeft,
+          result.swap.toOption.exists(_.toString.contains("9998")) // names the port, not a swallowed generic error
+        )
+      }
+    },
+    test("#211: destroying an authored-port space does not return the fixed port to the pool") {
+      withAdapterPool(List(4600)) { (control, _) => // pool holds exactly one port: 4600
+        for
+          fixedE <- control.provision(MockSource.Dsl(MockSpec(List(pingRule), port = Some(9998)))).either
+          fixed   = fixedE.toOption.toList.flatten.head
+          _      <- control.destroy(fixed).either
+          autoE  <- control.provision(pingSource).either // must draw the pool's own 4600, never the freed 9998
+        yield assertTrue(
+          fixedE.isRight,
+          autoE.toOption.toList.flatten.head.baseUri == "http://localhost:4600"
+        )
+      }
+    },
     test("destroy(A) deletes only A's imposter — never the global reset — and leaves B intact") {
       withAdapter { (control, fake) =>
         for


### PR DESCRIPTION
MockControl now supports an opt-in fixed port via MockSpec.onPort / authoredPort.
The container and embedded Rift adapters bind the requested port instead of always
auto-allocating, keeping random auto-port as the default. A fixed port is never
returned to the endpoint pool.

Closes #211