### PR TITLE
docs: prepare 1.3.1 release notes and bump install snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to zio-bdd are documented here.
 
 ## [Unreleased]
 
+## [1.3.1] — 2026-07-05
+
+### Added
+
+- **Opt-in fixed imposter port** — `MockSpec.onPort(n)` now binds the Rift container and embedded
+  imposters on exactly that port instead of always auto-allocating a random one; the auto-assigned
+  free port remains the default. This removes the runtime port-discovery handoff for
+  externally-configured clients (proxies, containers, sidecars). A fixed port is never returned to
+  the internal port pool. (#211)
+
 ## [1.3.0] — 2026-07-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ object AccountSpec extends ZIOSteps[Any, AccountState]:
 
 ```scala
 // build.sbt
-libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.3.0" % Test
+libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.3.1" % Test
 
 Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
 ```

--- a/docs/mock-adapters.md
+++ b/docs/mock-adapters.md
@@ -9,7 +9,7 @@ pick one.
 
 ## 1. The three backends at a glance
 
-| Adapter | Coordinates (1.3.0) | Docker? | JDK | Isolation default | Capabilities |
+| Adapter | Coordinates (1.3.1) | Docker? | JDK | Isolation default | Capabilities |
 |---|---|---|---|---|---|
 | Rift container | `zio-bdd-rift` | yes (testcontainers) | 11+ | PerInstance | all six |
 | WireMock | `zio-bdd-wiremock` | no | 11+ | Correlated (via `.correlated`) | Faults, StatefulScenarios, StateInspection only |
@@ -38,7 +38,7 @@ against it fails with `Unsupported` (§3 below, and see
 ## 2. Rift container (`zio-bdd-rift`)
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd-rift" % "1.3.0"
+"io.github.etacassiopeia" %% "zio-bdd-rift" % "1.3.1"
 ```
 
 Two entry points, both requiring a zio-http `Client` and a `Provisioning` in
@@ -97,7 +97,7 @@ See [layers](layers.md) for how this composes into a suite's `environment`.
 ## 3. WireMock (`zio-bdd-wiremock`)
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.3.0"
+"io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.3.1"
 ```
 
 In-process, no Docker, runs on JDK 11+. Only requires `Provisioning`:
@@ -145,15 +145,15 @@ published as **two variants built from the same source**, and you pick
 exactly one for your build's JDK:
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd-rift-embedded"       % "1.3.0" // JDK 22+ (stable FFM)
-"io.github.etacassiopeia" %% "zio-bdd-rift-embedded-jdk21" % "1.3.0" // JDK 21   (preview FFM)
+"io.github.etacassiopeia" %% "zio-bdd-rift-embedded"       % "1.3.1" // JDK 22+ (stable FFM)
+"io.github.etacassiopeia" %% "zio-bdd-rift-embedded-jdk21" % "1.3.1" // JDK 21   (preview FFM)
 ```
 
 Both additionally need the native library on the classpath (or an explicit
 override), and neither is scala-versioned — note the single `%`, not `%%`:
 
 ```scala
-"io.github.etacassiopeia" % "zio-bdd-rift-embedded-natives" % "1.3.0" % Test
+"io.github.etacassiopeia" % "zio-bdd-rift-embedded-natives" % "1.3.1" % Test
 ```
 
 `zio-bdd-rift-embedded-natives` bundles the per-platform `librift_ffi`

--- a/docs/mock-cookbook.md
+++ b/docs/mock-cookbook.md
@@ -16,8 +16,8 @@ Add the WireMock adapter — it runs fully in-process on JDK 11+, no containers:
 ```scala
 // build.sbt
 libraryDependencies ++= Seq(
-  "io.github.etacassiopeia" %% "zio-bdd"          % "1.3.0",
-  "io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.3.0" % Test
+  "io.github.etacassiopeia" %% "zio-bdd"          % "1.3.1",
+  "io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.3.1" % Test
 )
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,7 +9,7 @@ as a concrete example throughout.
 In `build.sbt`:
 
 ```scala
-libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.3.0" % Test
+libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.3.1" % Test
 
 Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
 ```


### PR DESCRIPTION
Release prep for **1.3.1**. Docs-only — no code changes.

- CHANGELOG: new `[1.3.1]` section for the opt-in fixed imposter port (`MockSpec.onPort`, #211/#212).
- Install snippets bumped `1.3.0 → 1.3.1` across README and docs.

After merge, `v1.3.1` will be tagged on the merge commit to trigger `sbt ci-release`.