### PR TITLE
Dynamic scenarioParallelism — env-aware runtime override

### DIFF
--- a/core/src/main/scala/zio/bdd/ZIOBDDFramework.scala
+++ b/core/src/main/scala/zio/bdd/ZIOBDDFramework.scala
@@ -192,8 +192,10 @@ class ZIOBDDTask(
     val program = suiteInstance
       .run(
         updateFeatures,
-        featureParallelism = config.featureParallelism,
-        scenarioParallelism = config.scenarioParallelism,
+        featureParallelism =
+          ZIOBDDTask.effectiveParallelism(suiteInstance.featureParallelism, config.featureParallelism),
+        scenarioParallelism =
+          ZIOBDDTask.effectiveParallelism(suiteInstance.scenarioParallelism, config.scenarioParallelism),
         dryRun = config.dryRun
       )
       .tap { results =>
@@ -290,13 +292,23 @@ class ZIOBDDTask(
       focused = args.contains("--focused")
     )
 
+    // Option B: CI-wide env override, slotted between the CLI flag and the annotation.
+    val envFeatureParallelism  = ZIOBDDTask.parseEnvParallelism(sys.env.get("ZIO_BDD_FEATURE_PARALLELISM"))
+    val envScenarioParallelism = ZIOBDDTask.parseEnvParallelism(sys.env.get("ZIO_BDD_SCENARIO_PARALLELISM"))
+
     BDDTestConfig(
       featureFiles = if (cliConfig.featureFiles.nonEmpty) cliConfig.featureFiles else annoConfig.featureFiles,
       reporters = if (cliConfig.reporters.nonEmpty) cliConfig.reporters else annoConfig.reporters,
-      featureParallelism =
-        if (cliConfig.featureParallelism != 1) cliConfig.featureParallelism else annoConfig.featureParallelism,
-      scenarioParallelism =
-        if (cliConfig.scenarioParallelism != 0) cliConfig.scenarioParallelism else annoConfig.scenarioParallelism,
+      featureParallelism = ZIOBDDTask.resolveFeatureParallelism(
+        cliConfig.featureParallelism,
+        envFeatureParallelism,
+        annoConfig.featureParallelism
+      ),
+      scenarioParallelism = ZIOBDDTask.resolveScenarioParallelism(
+        cliConfig.scenarioParallelism,
+        envScenarioParallelism,
+        annoConfig.scenarioParallelism
+      ),
       includeTags = if (cliConfig.includeTags.nonEmpty) cliConfig.includeTags else annoConfig.includeTags,
       excludeTags = if (cliConfig.excludeTags.nonEmpty) cliConfig.excludeTags else annoConfig.excludeTags,
       logLevel = if (cliConfig.logLevel != InternalLogLevel.Info) cliConfig.logLevel else annoConfig.logLevel,
@@ -489,6 +501,38 @@ class ZIOBDDTask(
 }
 
 object ZIOBDDTask {
+
+  /**
+   * Parse a `ZIO_BDD_*_PARALLELISM` env value: `"auto"` → `Some(0)`, a valid
+   * integer → `Some(n)`, and empty/absent/garbage → `None` (defer to the next
+   * source in the precedence chain).
+   */
+  def parseEnvParallelism(raw: Option[String]): Option[Int] =
+    raw.filter(_.nonEmpty).flatMap(s => if (s == "auto") Some(0) else s.toIntOption)
+
+  /**
+   * Resolve scenario parallelism across CLI > env > annotation. The CLI "unset"
+   * sentinel is `0` (auto), so a non-zero CLI value wins; otherwise the env
+   * value applies, else the annotation value.
+   */
+  def resolveScenarioParallelism(cli: Int, env: Option[Int], anno: Int): Int =
+    if (cli != 0) cli else env.getOrElse(anno)
+
+  /**
+   * Resolve feature parallelism across CLI > env > annotation. The CLI "unset"
+   * sentinel is `1` (sequential), so a CLI value other than `1` wins; otherwise
+   * the env value applies, else the annotation value.
+   */
+  def resolveFeatureParallelism(cli: Int, env: Option[Int], anno: Int): Int =
+    if (cli != 1) cli else env.getOrElse(anno)
+
+  /**
+   * Apply the suite-level override (Option A), which has the highest
+   * precedence: `Some(n)` wins over the already-resolved config value; `None`
+   * defers to it.
+   */
+  def effectiveParallelism(suiteOverride: Option[Int], configValue: Int): Int =
+    suiteOverride.getOrElse(configValue)
 
   /**
    * Apply include/exclude tag filters and the scenario-name filter to a list of

--- a/core/src/main/scala/zio/bdd/core/step/ZIOSteps.scala
+++ b/core/src/main/scala/zio/bdd/core/step/ZIOSteps.scala
@@ -504,6 +504,29 @@ trait ZIOSteps[R: Tag, S: Tag: Default]
   private[bdd] final def overrideStepTimeout(d: Duration): Unit =
     _annotationStepTimeout = Some(d)
 
+  /**
+   * Override to control scenario parallelism at runtime, with the highest
+   * precedence — it wins over the `@Suite` annotation, the
+   * `--scenario-parallelism` CLI flag, and the `ZIO_BDD_SCENARIO_PARALLELISM`
+   * env var. Return `None` to defer to those. `n = 0` means auto
+   * (availableProcessors).
+   *
+   * {{{
+   * // sequential locally (CI env var absent), full parallelism in CI
+   * override def scenarioParallelism: Option[Int] =
+   *   Option(System.getenv("CI")).map(_ => 0).orElse(Some(1))
+   * }}}
+   */
+  def scenarioParallelism: Option[Int] = None
+
+  /**
+   * Override to control feature parallelism at runtime, with the highest
+   * precedence (see [[scenarioParallelism]]). Return `None` to defer to the
+   * `@Suite` annotation, the `--parallelism` CLI flag, or the
+   * `ZIO_BDD_FEATURE_PARALLELISM` env var.
+   */
+  def featureParallelism: Option[Int] = None
+
   // ── Step DSL operators ──────────────────────────────────────────────────
 
   extension [Out <: Tuple](se: StepExpression[Out])

--- a/core/src/test/scala/zio/bdd/ParallelismResolutionSpec.scala
+++ b/core/src/test/scala/zio/bdd/ParallelismResolutionSpec.scala
@@ -1,0 +1,108 @@
+package zio.bdd
+
+import zio.test.*
+import zio.bdd.core.Default
+import zio.bdd.core.step.ZIOSteps
+
+/**
+ * Gate for issue #216 — env-aware / suite-overridable parallelism.
+ *
+ * Precedence (highest first):
+ *   1. suite override (ZIOSteps.scenarioParallelism / featureParallelism) 2.
+ *      --scenario-parallelism / --parallelism CLI flag 3.
+ *      ZIO_BDD_SCENARIO_PARALLELISM / ZIO_BDD_FEATURE_PARALLELISM env var 4.
+ *      \@Suite annotation value
+ */
+object ParallelismResolutionSpec extends ZIOSpecDefault {
+
+  private given Default[Unit] = Default.fromValue(())
+
+  // Minimal suite that keeps the default (None) hooks.
+  object DefaultSteps extends ZIOSteps[Any, Unit]
+
+  // Suite pinning both knobs at runtime (Option A).
+  object PinnedSteps extends ZIOSteps[Any, Unit] {
+    override def scenarioParallelism: Option[Int] = Some(1)
+    override def featureParallelism: Option[Int]  = Some(0)
+  }
+
+  private val envParsing = suite("parseEnvParallelism")(
+    test("None env → None") {
+      assertTrue(ZIOBDDTask.parseEnvParallelism(None).isEmpty)
+    },
+    test("empty string → None") {
+      assertTrue(ZIOBDDTask.parseEnvParallelism(Some("")).isEmpty)
+    },
+    test("'auto' → Some(0)") {
+      assertTrue(ZIOBDDTask.parseEnvParallelism(Some("auto")).contains(0))
+    },
+    test("numeric → Some(n)") {
+      assertTrue(ZIOBDDTask.parseEnvParallelism(Some("4")).contains(4))
+    },
+    test("non-numeric garbage → None") {
+      assertTrue(ZIOBDDTask.parseEnvParallelism(Some("banana")).isEmpty)
+    }
+  )
+
+  private val scenarioPrecedence = suite("resolveScenarioParallelism (CLI sentinel 0)")(
+    test("CLI value (non-zero) wins over env and annotation") {
+      assertTrue(ZIOBDDTask.resolveScenarioParallelism(cli = 3, env = Some(2), anno = 1) == 3)
+    },
+    test("env applies when CLI unset (0), overriding annotation") {
+      assertTrue(ZIOBDDTask.resolveScenarioParallelism(cli = 0, env = Some(2), anno = 1) == 2)
+    },
+    test("annotation preserved when CLI unset and no env (AC4)") {
+      assertTrue(ZIOBDDTask.resolveScenarioParallelism(cli = 0, env = None, anno = 1) == 1)
+    },
+    test("annotation auto (0) preserved when nothing else set") {
+      assertTrue(ZIOBDDTask.resolveScenarioParallelism(cli = 0, env = None, anno = 0) == 0)
+    }
+  )
+
+  private val featurePrecedence = suite("resolveFeatureParallelism (CLI sentinel 1)")(
+    test("CLI value (non-default) wins over env and annotation") {
+      assertTrue(ZIOBDDTask.resolveFeatureParallelism(cli = 3, env = Some(2), anno = 4) == 3)
+    },
+    test("env applies when CLI unset (1), overriding annotation") {
+      assertTrue(ZIOBDDTask.resolveFeatureParallelism(cli = 1, env = Some(2), anno = 4) == 2)
+    },
+    test("annotation preserved when CLI unset and no env") {
+      assertTrue(ZIOBDDTask.resolveFeatureParallelism(cli = 1, env = None, anno = 4) == 4)
+    }
+  )
+
+  private val suiteOverride = suite("effectiveParallelism (Option A — suite override)")(
+    test("suite override wins over the resolved config value") {
+      assertTrue(ZIOBDDTask.effectiveParallelism(Some(1), configValue = 8) == 1)
+    },
+    test("None defers to the resolved config value") {
+      assertTrue(ZIOBDDTask.effectiveParallelism(None, configValue = 8) == 8)
+    },
+    test("override of 0 (auto) passes through") {
+      assertTrue(ZIOBDDTask.effectiveParallelism(Some(0), configValue = 8) == 0)
+    }
+  )
+
+  private val traitHooks = suite("ZIOSteps parallelism hooks")(
+    test("default hooks are None (AC1, AC6)") {
+      assertTrue(
+        DefaultSteps.scenarioParallelism.isEmpty,
+        DefaultSteps.featureParallelism.isEmpty
+      )
+    },
+    test("overrides expose the pinned values") {
+      assertTrue(
+        PinnedSteps.scenarioParallelism.contains(1),
+        PinnedSteps.featureParallelism.contains(0)
+      )
+    }
+  )
+
+  def spec = suite("ParallelismResolutionSpec")(
+    envParsing,
+    scenarioPrecedence,
+    featurePrecedence,
+    suiteOverride,
+    traitHooks
+  )
+}

--- a/docs/running.md
+++ b/docs/running.md
@@ -289,6 +289,51 @@ sbt "testOnly com.example.MySuite -- --parallelism 4 --scenario-parallelism 2"
 This runs up to 4 features concurrently, each with up to 2 scenarios concurrently,
 for a maximum of 8 concurrent scenario executions.
 
+### Runtime overrides and precedence
+
+A static `@Suite` value can't be right in every environment. A common case: a suite backed by
+a single embedded resource (e.g. a local DynamoDB container) must run sequentially locally, but
+can use full parallelism in CI where the resource is provisioned to handle load. Because
+annotation values are compile-time constants, you can't branch on an env var inside `@Suite`.
+
+Two runtime overrides close that gap. Both `scenarioParallelism` and `featureParallelism`
+resolve through this chain, **highest precedence first**:
+
+| # | Source | How to set |
+|---|--------|------------|
+| 1 | Suite override (Scala) | `override def scenarioParallelism: Option[Int]` in the suite |
+| 2 | CLI flag | `--scenario-parallelism <n>` / `--parallelism <n>` |
+| 3 | Env var | `ZIO_BDD_SCENARIO_PARALLELISM` / `ZIO_BDD_FEATURE_PARALLELISM` |
+| 4 | `@Suite` annotation | `@Suite(scenarioParallelism = n)` (compile-time default) |
+
+The env var accepts an integer or `auto` (equivalent to `0`); an empty or unparseable value is
+ignored, deferring to the annotation. It is a JVM-wide default, shared by every suite in the fork.
+
+> **Note on CLI defaults.** The "unset" CLI sentinel is in-band: `--scenario-parallelism` defaults
+> to `0` (auto) and `--parallelism` to `1` (sequential). Passing exactly that default value on the
+> CLI is indistinguishable from omitting the flag, so it is treated as *unset* and an env var or
+> `@Suite` value can still apply. To force sequential scenarios regardless of the environment, use
+> the suite override (`override def scenarioParallelism = Some(1)`) rather than `--scenario-parallelism 1`.
+
+The suite override (`def scenarioParallelism: Option[Int] = None` / `def featureParallelism`)
+wins over everything when it returns `Some`. Returning `None` (the default) defers to the CLI
+flag, env var, and annotation as above. This lets you decide in plain Scala:
+
+```scala
+@Suite(featureDirs = Array("src/test/resources/features"))
+object LedgerSuite extends ZIOSteps[LedgerEnv, LedgerState]:
+  // Sequential locally (CI env var absent), full parallelism (auto) in CI.
+  override def scenarioParallelism: Option[Int] =
+    Option(System.getenv("CI")).map(_ => 0).orElse(Some(1))
+```
+
+Or set it CI-wide with no change to any suite:
+
+```sh
+ZIO_BDD_SCENARIO_PARALLELISM=auto sbt test   # CI: full parallelism
+sbt test                                      # local: falls back to the @Suite value
+```
+
 ---
 
 ## Step timeout


### PR DESCRIPTION
Adds two runtime override points for scenario/feature parallelism so one suite can run sequentially locally (shared embedded resource) and at full parallelism in CI — a compile-time `@Suite` constant cannot express this.

- `override def scenarioParallelism`/`featureParallelism: Option[Int]` on `ZIOSteps` (Option A, highest precedence)
- `ZIO_BDD_SCENARIO_PARALLELISM` / `ZIO_BDD_FEATURE_PARALLELISM` env vars (Option B)

Precedence: suite override > CLI flag > env var > `@Suite` annotation. Backward compatible (defaults `None` / absent → unchanged). Docs updated; 17 new unit tests.

Closes #216
Milestone: none (standalone enhancement)