### PR TITLE
eventually / eventuallyAssert combinator (polling until success)

### DIFF
--- a/core/src/main/scala/zio/bdd/core/Assertions.scala
+++ b/core/src/main/scala/zio/bdd/core/Assertions.scala
@@ -148,6 +148,57 @@ object Assertions {
     )
 
   /**
+   * Retry `effect` until it succeeds or `maxTime` elapses, for asserting on
+   * eventually-consistent systems (feature-flag propagation, async consumers,
+   * mock reload) without a blind `ZIO.sleep`.
+   *
+   * On timeout the last underlying failure is surfaced — not a generic "timed
+   * out" — because `retry` re-emits the effect's final error once the schedule
+   * is exhausted. The effect stays interruptible, so an outer `stepTimeout` (or
+   * any enclosing timeout) is a hard cap; keep `maxTime` ≤ that timeout.
+   *
+   * Only typed failures are retried. A defect (an exception thrown outside a
+   * `ZIO.attempt` boundary, surfacing as `Cause.Die`) propagates on the first
+   * attempt and is NOT retried — wrap effects that may throw in `ZIO.attempt`
+   * so the throw becomes a retryable typed failure. The `assert*` helpers
+   * already do this.
+   *
+   * {{{
+   *   When("flag propagation is observed") {
+   *     eventually(
+   *       getFlagStatus.filterOrFail(_ == "ON")(RuntimeException("flag not ON yet")),
+   *       maxTime = 8.seconds
+   *     )
+   *   }
+   * }}}
+   */
+  def eventually[R, A](
+    effect: ZIO[R, Throwable, A],
+    maxTime: Duration = 10.seconds,
+    schedule: Schedule[Any, Any, Any] = Schedule.exponential(50.millis).jittered && Schedule.spaced(500.millis)
+  ): ZIO[R, Throwable, A] =
+    effect.retry(schedule && Schedule.upTo(maxTime))
+
+  /**
+   * Probe a value with `fetch`, run `assertion` against it, and retry the pair
+   * until the assertion holds or `maxTime` elapses. On timeout the last
+   * assertion failure is surfaced (see [[eventually]]).
+   *
+   * {{{
+   *   Then("the balance is eventually settled") {
+   *     eventuallyAssert(fetchBalance)(b => assertEquals(b, expected))
+   *   }
+   * }}}
+   */
+  def eventuallyAssert[R, A](
+    fetch: ZIO[R, Throwable, A]
+  )(
+    assertion: A => ZIO[Any, Throwable, Unit],
+    maxTime: Duration = 10.seconds
+  ): ZIO[R, Throwable, Unit] =
+    eventually(fetch.flatMap(assertion), maxTime)
+
+  /**
    * Run all assertions and collect every failure into a single
    * `MultipleAssertionError`.
    *

--- a/core/src/test/scala/zio/bdd/core/EventuallySpec.scala
+++ b/core/src/test/scala/zio/bdd/core/EventuallySpec.scala
@@ -1,0 +1,84 @@
+package zio.bdd.core
+
+import zio.*
+import zio.test.*
+
+/**
+ * Gate for issue #217 — `eventually` / `eventuallyAssert` polling combinators.
+ *
+ * Timing tests use `withLiveClock` because ZIOSpecDefault runs on TestClock,
+ * under which schedule delays never advance on their own. Delays are kept small
+ * (tens of ms) so the suite stays fast.
+ */
+object EventuallySpec extends ZIOSpecDefault {
+
+  private val fast: Schedule[Any, Any, Any] = Schedule.spaced(10.millis)
+
+  def spec = suite("EventuallySpec")(
+    test("eventually returns immediately when the effect already succeeds (AC1 — no Schedule import)") {
+      // Only the effect is passed: both maxTime and schedule use defaults.
+      for result <- Assertions.eventually(ZIO.succeed(42))
+      yield assertTrue(result == 42)
+    },
+    test("eventually retries until the effect succeeds (AC2 — custom schedule)") {
+      for
+        counter <- Ref.make(0)
+        effect = counter.updateAndGet(_ + 1).flatMap { n =>
+                   if (n >= 3) ZIO.succeed(n) else ZIO.fail(new RuntimeException(s"attempt $n too early"))
+                 }
+        result   <- Assertions.eventually(effect, maxTime = 2.seconds, schedule = fast)
+        attempts <- counter.get
+      yield assertTrue(result == 3, attempts == 3)
+    } @@ TestAspect.withLiveClock,
+    test("eventually retries using the default schedule when only maxTime is given (AC2 — defaults)") {
+      // schedule left at the default; only maxTime overridden to keep the suite fast.
+      for
+        counter <- Ref.make(0)
+        effect = counter.updateAndGet(_ + 1).flatMap { n =>
+                   if (n >= 2) ZIO.succeed(n) else ZIO.fail(new RuntimeException("early"))
+                 }
+        result <- Assertions.eventually(effect, maxTime = 2.seconds)
+      yield assertTrue(result == 2)
+    } @@ TestAspect.withLiveClock,
+    test("eventually surfaces the last underlying failure on timeout, not a generic timeout (AC3)") {
+      val boom = new RuntimeException("flag not ON yet")
+      for exit <- Assertions.eventually(ZIO.fail(boom), maxTime = 100.millis, schedule = fast).exit
+      yield exit match
+        case Exit.Failure(cause) =>
+          assertTrue(cause.failureOption.exists(_.getMessage == "flag not ON yet"))
+        case Exit.Success(_) =>
+          assertTrue(false)
+    } @@ TestAspect.withLiveClock,
+    test("eventually is interruptible — an outer timeout stops it well before maxTime (AC4)") {
+      val failing: ZIO[Any, Throwable, Int] = ZIO.fail(new RuntimeException("never"))
+      for
+        start   <- Clock.nanoTime
+        result  <- Assertions.eventually(failing, maxTime = 1.hour, schedule = fast).timeout(150.millis)
+        elapsed <- Clock.nanoTime.map(_ - start)
+      yield assertTrue(result.isEmpty) && assertTrue(elapsed < 5.seconds.toNanos)
+    } @@ TestAspect.withLiveClock,
+    test("eventuallyAssert retries the fetch+assert pair until the assertion holds (AC6)") {
+      for
+        counter <- Ref.make(0)
+        _ <- Assertions.eventuallyAssert(counter.updateAndGet(_ + 1))(
+               n => Assertions.assertTrue(n >= 2, s"still $n"),
+               maxTime = 2.seconds
+             )
+        attempts <- counter.get
+      yield assertTrue(attempts >= 2)
+    } @@ TestAspect.withLiveClock @@ TestAspect.timeout(30.seconds),
+    test("eventuallyAssert surfaces the assertion failure on timeout") {
+      for exit <- Assertions
+                    .eventuallyAssert(ZIO.succeed(1))(
+                      n => Assertions.assertTrue(n == 999, s"got $n, want 999"),
+                      maxTime = 100.millis
+                    )
+                    .exit
+      yield exit match
+        case Exit.Failure(cause) =>
+          assertTrue(cause.failureOption.exists(t => Option(t.getMessage).exists(_.contains("got 1, want 999"))))
+        case Exit.Success(_) =>
+          assertTrue(false)
+    } @@ TestAspect.withLiveClock
+  )
+}

--- a/docs/step-dsl.md
+++ b/docs/step-dsl.md
@@ -657,3 +657,62 @@ the step into helper methods.
 - **`withSnapshot`** — capture a state value before an action, assert after
   (see [§8 above](#8-withsnapshot-for-beforeafter-assertions))
 
+---
+
+## 12. Polling with `Assertions.eventually` / `eventuallyAssert`
+
+When the system under test is *eventually consistent* — feature-flag propagation, async
+message-queue consumers, mock reload, distributed state — a step must wait for a condition to
+become true. A blind `ZIO.sleep(worstCase)` is both slow and flaky. `eventually` retries an
+effect until it succeeds or a time budget elapses, proceeding the moment the condition holds.
+
+```scala
+// Before: fixed worst-case margin — slow when fast, flaky when slow
+When("flag propagation is observed") {
+  ScenarioContext.get.flatMap(_ => ZIO.sleep(5.seconds))
+}
+
+// After: proceeds as soon as the flag flips, up to 8s
+When("flag propagation is observed") {
+  Assertions.eventually(
+    getFlagStatus.filterOrFail(_ == "ON")(RuntimeException("flag not ON yet")),
+    maxTime = 8.seconds
+  )
+}
+```
+
+`eventuallyAssert` is a convenience overload that probes a value with `fetch`, runs an
+assertion against it, and retries the pair:
+
+```scala
+Then("the balance is eventually settled") {
+  Assertions.eventuallyAssert(fetchBalance)(b => Assertions.assertEquals(b, expected))
+}
+```
+
+### API
+
+```scala
+Assertions.eventually[R, A](
+  effect: ZIO[R, Throwable, A],
+  maxTime: Duration = 10.seconds,
+  schedule: Schedule[Any, Any, Any] = Schedule.exponential(50.millis).jittered && Schedule.spaced(500.millis)
+): ZIO[R, Throwable, A]
+
+Assertions.eventuallyAssert[R, A](
+  fetch: ZIO[R, Throwable, A]
+)(assertion: A => ZIO[Any, Throwable, Unit], maxTime: Duration = 10.seconds): ZIO[R, Throwable, Unit]
+```
+
+- **No `zio.Schedule` import needed** for the common case — the defaults live inside
+  `Assertions`. Override `schedule` only when you want a different back-off.
+- **On timeout the last underlying failure is surfaced** — not a generic "timed out". The
+  message you failed with (e.g. `"flag not ON yet"`) is what propagates, so failures stay
+  diagnosable.
+- **Interruptible.** The retry loop respects the enclosing step timeout: the outer
+  `stepTimeout` is a hard cap that interrupts the wait, so keep `maxTime` ≤ `stepTimeout`.
+- **Only typed failures are retried.** An exception thrown outside a `ZIO.attempt` boundary
+  becomes a defect (`Cause.Die`) and propagates on the first attempt without retrying. Wrap any
+  effect that may throw in `ZIO.attempt` so the throw becomes a retryable failure — the `assert*`
+  helpers already do this.
+


### PR DESCRIPTION
Adds two polling combinators to `zio.bdd.core.Assertions` for eventually-consistent assertions:

- `eventually(effect, maxTime = 10.s, schedule = exp(50ms).jittered && spaced(500ms))` — retries until the effect succeeds or `maxTime` elapses; on timeout surfaces the last underlying failure (not a generic "timed out").
- `eventuallyAssert(fetch)(assertion, maxTime = 10.s)` — retries the fetch+assert pair.

Defaults live inside `Assertions` (no `zio.Schedule` import needed); the wait is interruptible and respects an outer `stepTimeout`. Only typed failures are retried — documented, with a `ZIO.attempt` callout. Docs in step-dsl.md §12; 7 new unit tests.

Closes #217
Milestone: none (combinator #1 of the #218 backlog epic)