### PR TITLE
during combinator — assert a condition holds continuously (stability assertion)

### DIFF
--- a/core/src/main/scala/zio/bdd/core/Assertions.scala
+++ b/core/src/main/scala/zio/bdd/core/Assertions.scala
@@ -199,6 +199,32 @@ object Assertions {
     eventually(fetch.flatMap(assertion), maxTime)
 
   /**
+   * The inverse of [[eventually]]: assert that `condition` *stays* true for the
+   * whole `duration`, re-probing every `interval`. Fails fast on the first
+   * violation, surfacing that underlying failure — a transient breach that
+   * recovers mid-`interval` between probes can still be missed, so pick an
+   * `interval` fine enough for the property under test.
+   *
+   * The wait stays interruptible, so an outer `stepTimeout` (or any enclosing
+   * timeout) is a hard cap; keep `duration` ≤ that timeout. As with
+   * [[eventually]], only typed failures count as a violation — a defect from
+   * `condition` (an exception thrown outside a `ZIO.attempt` boundary)
+   * propagates immediately.
+   *
+   * {{{
+   *   Then("the balance stays zero after the cancelled transaction") {
+   *     during(ScenarioContext.get.flatMap(s => assertEquals(s.balance, 0)), duration = 2.seconds)
+   *   }
+   * }}}
+   */
+  def during[R](
+    condition: ZIO[R, Throwable, Unit],
+    duration: Duration,
+    interval: Duration = 200.millis
+  ): ZIO[R, Throwable, Unit] =
+    condition.repeat(Schedule.spaced(interval) && Schedule.upTo(duration)).unit
+
+  /**
    * Run all assertions and collect every failure into a single
    * `MultipleAssertionError`.
    *

--- a/core/src/test/scala/zio/bdd/core/DuringSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/DuringSpec.scala
@@ -1,0 +1,76 @@
+package zio.bdd.core
+
+import zio.*
+import zio.test.*
+
+/**
+ * Gate for issue #222 — the `during` stability combinator (inverse of
+ * `eventually`). Timing tests use `withLiveClock` (ZIOSpecDefault runs on
+ * TestClock, under which schedule delays never advance); delays are kept small.
+ */
+object DuringSpec extends ZIOSpecDefault {
+
+  def spec = suite("DuringSpec")(
+    test("during passes when the condition holds on every probe across the window (AC1, AC3)") {
+      // Only condition + duration passed: interval defaults, no Schedule/Clock import at call site.
+      for
+        probes <- Ref.make(0)
+        _      <- Assertions.during(probes.update(_ + 1), duration = 120.millis, interval = 20.millis)
+        count  <- probes.get
+      yield assertTrue(count >= 4)
+    } @@ TestAspect.withLiveClock,
+    test("during probes repeatedly using the default interval when only duration is given (AC4 — default)") {
+      // interval left at the default (200ms); ~500ms window ⇒ a small handful of probes.
+      for
+        probes <- Ref.make(0)
+        _      <- Assertions.during(probes.update(_ + 1), duration = 500.millis)
+        count  <- probes.get
+      yield assertTrue(count >= 2, count <= 6)
+    } @@ TestAspect.withLiveClock @@ TestAspect.timeout(30.seconds),
+    test("during terminates (does not hang) when interval > duration (boundary)") {
+      for
+        start   <- Clock.nanoTime
+        result  <- Assertions.during(ZIO.unit, duration = 10.millis, interval = 100.millis).timeout(5.seconds)
+        elapsed <- Clock.nanoTime.map(_ - start)
+      yield assertTrue(result.isDefined, elapsed < 2.seconds.toNanos)
+    } @@ TestAspect.withLiveClock,
+    test("during lets a defect from the condition propagate immediately, not swallowed (AC2)") {
+      for exit <- Assertions.during(ZIO.succeed[Unit](throw new RuntimeException("boom")), duration = 1.second).exit
+      yield exit match
+        case Exit.Failure(cause) => assertTrue(cause.dieOption.exists(_.getMessage == "boom"))
+        case Exit.Success(_)     => assertTrue(false)
+    } @@ TestAspect.withLiveClock,
+    test("during fails fast on the first mid-window violation, surfacing that failure (AC2)") {
+      // Condition holds for the first two probes, then starts failing.
+      for
+        probes <- Ref.make(0)
+        condition = probes.updateAndGet(_ + 1).flatMap { n =>
+                      if (n >= 3) ZIO.fail(new RuntimeException(s"violated at probe $n")) else ZIO.unit
+                    }
+        start   <- Clock.nanoTime
+        exit    <- Assertions.during(condition, duration = 10.seconds, interval = 20.millis).exit
+        elapsed <- Clock.nanoTime.map(_ - start)
+      yield exit match
+        case Exit.Failure(cause) =>
+          assertTrue(
+            cause.failureOption.exists(_.getMessage == "violated at probe 3"),
+            elapsed < 5.seconds.toNanos // failed fast, did NOT wait the full 10s
+          )
+        case Exit.Success(_) => assertTrue(false)
+    } @@ TestAspect.withLiveClock,
+    test("during fails immediately when the condition is already false at t=0 (AC2)") {
+      for exit <- Assertions.during(ZIO.fail(new RuntimeException("false from the start")), duration = 1.second).exit
+      yield exit match
+        case Exit.Failure(cause) => assertTrue(cause.failureOption.exists(_.getMessage == "false from the start"))
+        case Exit.Success(_)     => assertTrue(false)
+    } @@ TestAspect.withLiveClock,
+    test("during is interruptible — an outer timeout stops it well before duration (AC4)") {
+      val holds: ZIO[Any, Throwable, Unit] = ZIO.unit
+      for
+        start   <- Clock.nanoTime
+        result  <- Assertions.during(holds, duration = 1.hour, interval = 20.millis).timeout(150.millis)
+        elapsed <- Clock.nanoTime.map(_ - start)
+      yield assertTrue(result.isEmpty) && assertTrue(elapsed < 5.seconds.toNanos)
+    } @@ TestAspect.withLiveClock
+  )
+}

--- a/docs/step-dsl.md
+++ b/docs/step-dsl.md
@@ -716,3 +716,40 @@ Assertions.eventuallyAssert[R, A](
   effect that may throw in `ZIO.attempt` so the throw becomes a retryable failure — the `assert*`
   helpers already do this.
 
+---
+
+## 13. Stability with `Assertions.during`
+
+The inverse of `eventually`: assert a condition *stays* true for a window rather than *becomes*
+true. Use it for negative/stability properties — "the balance must remain zero for 2s after a
+cancelled transaction", "the Rift imposter must record no new requests during a quiesce period". A
+`ZIO.sleep(d) *> assertOnce` can't catch a transient violation that recovered mid-sleep; `during`
+re-probes continuously and fails the moment the property is breached.
+
+```scala
+Then("the balance stays zero after the cancelled transaction") {
+  Assertions.during(
+    ScenarioContext.get.flatMap(s => Assertions.assertEquals(s.balance, 0)),
+    duration = 2.seconds
+  )
+}
+```
+
+### API
+
+```scala
+Assertions.during[R](
+  condition: ZIO[R, Throwable, Unit],
+  duration: Duration,
+  interval: Duration = 200.millis
+): ZIO[R, Throwable, Unit]
+```
+
+- **Fails fast** on the first probe that fails, surfacing that underlying failure (not a generic
+  "stability check failed"). Passes only if `condition` holds on every probe across `duration`.
+- **Sampling, not continuous.** A breach that appears and recovers entirely between two probes can
+  be missed — choose an `interval` fine enough for the property under test.
+- **No `zio.Schedule`/`Clock` import** needed at the call site; the defaults live in `Assertions`.
+- **Interruptible**, and respects the enclosing `stepTimeout` — keep `duration` ≤ `stepTimeout`.
+  Only typed failures count as a violation (same Fail/Die caveat as `eventually`).
+


### PR DESCRIPTION
Adds `Assertions.during(condition, duration, interval = 200.millis)` — the inverse of `eventually` (#217). Re-probes the condition every `interval` for the whole `duration`, failing fast on the first violation and surfacing that underlying failure (not a generic "stability check failed").

Interruptible; respects the outer `stepTimeout`. Sampling (not continuous) — documented, with the same Fail/Die caveat as `eventually`. Docs in step-dsl.md §13; 7 new unit tests.

Closes #222
Part of #218 (combinator backlog). Milestone: none.