### PR TITLE
Collection quantifiers: assertForAll / assertExists / assertNoneSatisfy / assertExactly / assertBetween

### DIFF
--- a/core/src/main/scala/zio/bdd/core/Assertions.scala
+++ b/core/src/main/scala/zio/bdd/core/Assertions.scala
@@ -224,6 +224,118 @@ object Assertions {
   ): ZIO[R, Throwable, Unit] =
     condition.repeat(Schedule.spaced(interval) && Schedule.upTo(duration)).unit
 
+  // ── Collection quantifiers ─────────────────────────────────────────────────
+  // Assert a predicate over the elements of a collection (every / some / no /
+  // exactly-n / between). The predicate is soft-evaluated against every element
+  // so a single failure message can list all offenders with their indices.
+
+  private def labelTag(label: String): String = if (label.nonEmpty) s"[$label] " else ""
+
+  // Run `pred` against every element, recording (index, element, failure message
+  // when the predicate failed — None when it satisfied).
+  private def probeAll[A](
+    collection: Iterable[A],
+    pred: A => ZIO[Any, Throwable, Unit]
+  ): ZIO[Any, Nothing, List[(Int, A, Option[String])]] =
+    ZIO.foreach(collection.toList.zipWithIndex) { case (a, i) =>
+      pred(a).either.map {
+        case Right(_) => (i, a, None)
+        case Left(t)  => (i, a, Some(Option(t.getMessage).getOrElse(t.getClass.getName)))
+      }
+    }
+
+  private def renderElems[A](elems: List[(Int, A, Option[String])]): String =
+    elems.map { case (i, a, msg) => s"  - [index $i] $a" + msg.fold("")(m => s" ($m)") }.mkString("\n")
+
+  /**
+   * Assert every element of `collection` satisfies `pred`. An empty collection
+   * passes vacuously.
+   */
+  def assertForAll[A](collection: Iterable[A], label: String = "")(
+    pred: A => ZIO[Any, Throwable, Unit]
+  ): ZIO[Any, Throwable, Unit] =
+    probeAll(collection, pred).flatMap { probed =>
+      val offenders = probed.filter(_._3.isDefined)
+      if (offenders.isEmpty) ZIO.unit
+      else
+        ZIO.fail(
+          new AssertionError(
+            s"${labelTag(label)}assertForAll failed: ${offenders.size} of ${probed.size} element(s) did not satisfy the predicate:\n${renderElems(offenders)}"
+          )
+        )
+    }
+
+  /** Assert at least one element of `collection` satisfies `pred`. */
+  def assertExists[A](collection: Iterable[A], label: String = "")(
+    pred: A => ZIO[Any, Throwable, Unit]
+  ): ZIO[Any, Throwable, Unit] =
+    probeAll(collection, pred).flatMap { probed =>
+      if (probed.exists(_._3.isEmpty)) ZIO.unit
+      else {
+        val detail = if (probed.nonEmpty) s":\n${renderElems(probed)}" else ""
+        ZIO.fail(
+          new AssertionError(
+            s"${labelTag(label)}assertExists failed: no element of ${probed.size} satisfied the predicate$detail"
+          )
+        )
+      }
+    }
+
+  /**
+   * Assert no element of `collection` satisfies `pred`. Named to avoid a clash
+   * with `assertNone[A](actual: Option[A])`, which asserts an `Option` is
+   * empty.
+   */
+  def assertNoneSatisfy[A](collection: Iterable[A], label: String = "")(
+    pred: A => ZIO[Any, Throwable, Unit]
+  ): ZIO[Any, Throwable, Unit] =
+    probeAll(collection, pred).flatMap { probed =>
+      val satisfying = probed.filter(_._3.isEmpty)
+      if (satisfying.isEmpty) ZIO.unit
+      else
+        ZIO.fail(
+          new AssertionError(
+            s"${labelTag(label)}assertNoneSatisfy failed: ${satisfying.size} element(s) satisfied the predicate:\n${renderElems(satisfying)}"
+          )
+        )
+    }
+
+  /** Assert exactly `n` elements of `collection` satisfy `pred`. */
+  def assertExactly[A](n: Int, collection: Iterable[A], label: String = "")(
+    pred: A => ZIO[Any, Throwable, Unit]
+  ): ZIO[Any, Throwable, Unit] =
+    probeAll(collection, pred).flatMap { probed =>
+      val satisfying = probed.filter(_._3.isEmpty)
+      if (satisfying.size == n) ZIO.unit
+      else
+        ZIO.fail(
+          new AssertionError(
+            s"${labelTag(label)}assertExactly($n) failed: ${satisfying.size} of ${probed.size} element(s) satisfied the predicate:\n${renderElems(satisfying)}"
+          )
+        )
+    }
+
+  /**
+   * Assert between `min` and `max` (inclusive) elements of `collection` satisfy
+   * `pred`.
+   */
+  def assertBetween[A](min: Int, max: Int, collection: Iterable[A], label: String = "")(
+    pred: A => ZIO[Any, Throwable, Unit]
+  ): ZIO[Any, Throwable, Unit] =
+    probeAll(collection, pred).flatMap { probed =>
+      val satisfying = probed.filter(_._3.isEmpty)
+      val count      = satisfying.size
+      if (count >= min && count <= max) ZIO.unit
+      else {
+        val detail = if (satisfying.nonEmpty) s":\n${renderElems(satisfying)}" else ""
+        ZIO.fail(
+          new AssertionError(
+            s"${labelTag(label)}assertBetween($min, $max) failed: $count of ${probed.size} element(s) satisfied the predicate$detail"
+          )
+        )
+      }
+    }
+
   /**
    * Run all assertions and collect every failure into a single
    * `MultipleAssertionError`.

--- a/core/src/test/scala/zio/bdd/core/CollectionQuantifiersSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/CollectionQuantifiersSpec.scala
@@ -1,0 +1,120 @@
+package zio.bdd.core
+
+import zio.*
+import zio.test.*
+
+/**
+ * Gate for issue #223 — collection quantifiers (assertForAll / assertExists /
+ * assertNoneSatisfy / assertExactly / assertBetween). "Satisfies" means the
+ * predicate succeeds.
+ */
+object CollectionQuantifiersSpec extends ZIOSpecDefault {
+
+  // pred: element is even
+  private def isEven(n: Int): ZIO[Any, Throwable, Unit] =
+    Assertions.assertTrue(n % 2 == 0, s"$n is odd")
+
+  private def messageOf(exit: Exit[Throwable, Unit]): String =
+    exit match
+      case Exit.Failure(cause) => cause.failureOption.flatMap(t => Option(t.getMessage)).getOrElse("")
+      case Exit.Success(_)     => ""
+
+  def spec = suite("CollectionQuantifiersSpec")(
+    // ── assertForAll ──────────────────────────────────────────────
+    suite("assertForAll")(
+      test("passes when every element satisfies the predicate") {
+        Assertions.assertForAll(List(2, 4, 6))(isEven).exit.map(e => assertTrue(e.isSuccess))
+      },
+      test("passes vacuously on an empty collection") {
+        Assertions.assertForAll(List.empty[Int])(isEven).exit.map(e => assertTrue(e.isSuccess))
+      },
+      test("fails and lists offending elements with indices and label (AC3)") {
+        for exit <- Assertions.assertForAll(List(2, 3, 4, 5), label = "evens")(isEven).exit
+        yield
+          val msg = messageOf(exit)
+          assertTrue(
+            exit.isFailure,
+            msg.contains("evens"),
+            msg.contains("index 1"), // the value 3
+            msg.contains("index 3"), // the value 5
+            !msg.contains("index 0") // 2 satisfied, not an offender
+          )
+      }
+    ),
+    // ── assertExists ──────────────────────────────────────────────
+    suite("assertExists")(
+      test("passes when at least one element satisfies") {
+        Assertions.assertExists(List(1, 3, 4))(isEven).exit.map(e => assertTrue(e.isSuccess))
+      },
+      test("fails when none satisfy") {
+        Assertions.assertExists(List(1, 3, 5), label = "evens")(isEven).exit.map { e =>
+          assertTrue(e.isFailure, messageOf(e).contains("evens"))
+        }
+      },
+      test("fails on an empty collection") {
+        Assertions.assertExists(List.empty[Int])(isEven).exit.map(e => assertTrue(e.isFailure))
+      }
+    ),
+    // ── assertNoneSatisfy ─────────────────────────────────────────
+    suite("assertNoneSatisfy")(
+      test("passes when no element satisfies") {
+        Assertions.assertNoneSatisfy(List(1, 3, 5))(isEven).exit.map(e => assertTrue(e.isSuccess))
+      },
+      test("passes on an empty collection") {
+        Assertions.assertNoneSatisfy(List.empty[Int])(isEven).exit.map(e => assertTrue(e.isSuccess))
+      },
+      test("fails and lists the offending (satisfying) elements with indices") {
+        for exit <- Assertions.assertNoneSatisfy(List(1, 2, 3, 4))(isEven).exit
+        yield
+          val msg = messageOf(exit)
+          assertTrue(exit.isFailure, msg.contains("index 1"), msg.contains("index 3"))
+      }
+    ),
+    // ── assertExactly ─────────────────────────────────────────────
+    suite("assertExactly")(
+      test("passes when exactly n satisfy") {
+        Assertions.assertExactly(2, List(1, 2, 3, 4))(isEven).exit.map(e => assertTrue(e.isSuccess))
+      },
+      test("fails when the count differs from n, listing the satisfying indices") {
+        Assertions.assertExactly(3, List(1, 2, 3, 4), label = "evens")(isEven).exit.map { e =>
+          val msg = messageOf(e)
+          // 2 and 4 satisfy at indices 1 and 3; the message must name them (not a bare count).
+          assertTrue(e.isFailure, msg.contains("evens"), msg.contains("index 1"), msg.contains("index 3"))
+        }
+      },
+      test("assertExactly(0) passes on an empty collection") {
+        Assertions.assertExactly(0, List.empty[Int])(isEven).exit.map(e => assertTrue(e.isSuccess))
+      }
+    ),
+    // ── assertBetween ─────────────────────────────────────────────
+    suite("assertBetween")(
+      test("passes when the satisfying count is within [min, max]") {
+        Assertions.assertBetween(1, 3, List(1, 2, 3, 4, 6))(isEven).exit.map(e => assertTrue(e.isSuccess))
+      },
+      test("passes at the min boundary exactly") {
+        // exactly 1 even (2) with min=1
+        Assertions.assertBetween(1, 3, List(1, 2, 3))(isEven).exit.map(e => assertTrue(e.isSuccess))
+      },
+      test("fails when the count is below min") {
+        Assertions.assertBetween(3, 5, List(1, 2, 3))(isEven).exit.map(e => assertTrue(e.isFailure))
+      },
+      test("fails when the count is above max, listing the satisfying indices and label (AC3)") {
+        for exit <- Assertions.assertBetween(0, 1, List(2, 4, 6), label = "evens")(isEven).exit
+        yield
+          val msg = messageOf(exit)
+          // 2,4,6 all satisfy at indices 0,1,2; count 3 > max 1.
+          assertTrue(exit.isFailure, msg.contains("evens"), msg.contains("index 0"), msg.contains("index 2"))
+      },
+      test("empty collection: passes when min=0, fails when min>0") {
+        for
+          ok  <- Assertions.assertBetween(0, 2, List.empty[Int])(isEven).exit
+          bad <- Assertions.assertBetween(1, 2, List.empty[Int])(isEven).exit
+        yield assertTrue(ok.isSuccess, bad.isFailure)
+      }
+    ),
+    // ── naming collision (AC2): the existing Option assertNone still resolves ──
+    test("the pre-existing assertNone(Option) is unaffected") {
+      Assertions.assertNone(Option.empty[Int]).exit.map(e => assertTrue(e.isSuccess))
+    }
+  )
+}

--- a/docs/step-dsl.md
+++ b/docs/step-dsl.md
@@ -753,3 +753,44 @@ Assertions.during[R](
 - **Interruptible**, and respects the enclosing `stepTimeout` — keep `duration` ≤ `stepTimeout`.
   Only typed failures count as a violation (same Fail/Die caveat as `eventually`).
 
+---
+
+## 14. Collection quantifiers
+
+`assertContainsAll` / `assertContainsSubset` check *membership*, but not a *predicate* over the
+elements. These quantifiers assert a predicate holds for every / some / no / exactly-n / a range
+of elements, and on failure list the offending elements **with their indices** (and the optional
+`label`) so you see *which* elements broke the rule, not just a count.
+
+```scala
+Then("every settled order has a positive total") {
+  ScenarioContext.get.flatMap { s =>
+    Assertions.assertForAll(s.orders, label = "orders")(o => Assertions.assertTrue(o.total > 0, s"${o.id} is non-positive"))
+  }
+}
+```
+
+### API
+
+```scala
+Assertions.assertForAll[A]     (collection: Iterable[A], label: String = "")(pred: A => ZIO[Any, Throwable, Unit]): ZIO[Any, Throwable, Unit]
+Assertions.assertExists[A]     (collection: Iterable[A], label: String = "")(pred: A => ZIO[Any, Throwable, Unit]): ZIO[Any, Throwable, Unit]
+Assertions.assertNoneSatisfy[A](collection: Iterable[A], label: String = "")(pred: A => ZIO[Any, Throwable, Unit]): ZIO[Any, Throwable, Unit]
+Assertions.assertExactly[A]    (n: Int, collection: Iterable[A], label: String = "")(pred: A => ZIO[Any, Throwable, Unit]): ZIO[Any, Throwable, Unit]
+Assertions.assertBetween[A]    (min: Int, max: Int, collection: Iterable[A], label: String = "")(pred: A => ZIO[Any, Throwable, Unit]): ZIO[Any, Throwable, Unit]
+```
+
+- **"Satisfies" = the predicate succeeds.** The predicate is any `ZIO[Any, Throwable, Unit]` — the
+  existing `assert*` helpers compose directly.
+- **`assertForAll`** fails if any element fails (empty collection passes vacuously); **`assertExists`**
+  fails if none satisfy (empty fails); **`assertNoneSatisfy`** fails if any satisfies (empty passes) —
+  named to avoid a clash with `assertNone[A](Option[A])`, which asserts an `Option` is empty;
+  **`assertExactly(n)`** / **`assertBetween(min, max)`** fail when the satisfying count is off /
+  outside `[min, max]`.
+- **Every element is probed** (soft, `collectAll`-style), so the failure message reports *all*
+  offenders with their indices — not just the first.
+- **A predicate that fails with a typed error counts as "did not satisfy"** — a genuine error in
+  the typed channel is indistinguishable from a legitimate `false`. (A defect — thrown outside a
+  `ZIO.attempt` boundary — still propagates, same Fail/Die caveat as `eventually`.) If a predicate
+  can raise a typed error you do *not* want treated as an unsatisfied element, handle it first.
+


### PR DESCRIPTION
Adds five predicate-over-collection quantifiers to `zio.bdd.core.Assertions`: `assertForAll`, `assertExists`, `assertNoneSatisfy`, `assertExactly(n)`, `assertBetween(min, max)`.

Each soft-evaluates the predicate against every element and, on failure, lists the offending elements with their indices and the optional label (not just a count). `assertNoneSatisfy` avoids a name clash with the existing `assertNone(Option)`. Empty-collection semantics follow ScalaTest Inspectors (forAll vacuous-pass, exists fails, noneSatisfy passes). Docs in step-dsl.md §14; 18 new unit tests.

Closes #223
Part of #218 (combinator backlog). Milestone: none.