### PR TITLE
assertChange with .by / .from().to() — composable before/after change assertion

### DIFF
--- a/core/src/main/scala/zio/bdd/core/Assertions.scala
+++ b/core/src/main/scala/zio/bdd/core/Assertions.scala
@@ -364,6 +364,29 @@ object Assertions {
       else ZIO.fail(new MultipleAssertionError(failures))
     }
 
+  /**
+   * A composable before/after change assertion — the deferred, readable upgrade
+   * over `withSnapshot` for "after a deposit of 100, the balance increased by
+   * 100." Captures `probe` before running `action`, re-probes after, and defers
+   * evaluation until a terminal: `.by(delta)`, `.from(x).to(y)`, `.toAnything`,
+   * or `.and(...)` composition.
+   *
+   * `R` is the probe's environment (typically containing `State[S]`), threaded
+   * through unchanged.
+   *
+   * {{{
+   *   Then("the deposit increases the balance by 100") {
+   *     assertChange(ScenarioContext.get.map(_.balance)) {
+   *       When("a deposit of 100 is made") { ... }
+   *     }.by(100)
+   *   }
+   * }}}
+   */
+  def assertChange[R, A](
+    probe: ZIO[R, Throwable, A]
+  )(action: ZIO[R, Throwable, Unit]): ChangeAssertion[R, A] =
+    new ChangeAssertion(probe, action)
+
   private def containsAllElements[A](expected: Iterable[A]): Assertion[Iterable[A]] =
     Assertion.assertion("containsAllElements") { actual =>
       expected.forall(e => actual.exists(_ == e))
@@ -375,3 +398,110 @@ final class MultipleAssertionError(val failures: List[String])
     extends AssertionError(
       s"${failures.length} assertion(s) failed:\n" + failures.mkString("  - ", "\n  - ", "")
     )
+
+/**
+ * A deferred before/after change assertion built by
+ * [[Assertions.assertChange]]. Terminals (`by` / `from().to()` / `toAnything`)
+ * run `action` once, capturing the probe before and after; `and` composes
+ * several probes over that single action.
+ */
+final class ChangeAssertion[R, A] private[core] (
+  private[core] val probe: ZIO[R, Throwable, A],
+  private[core] val action: ZIO[R, Throwable, Unit]
+) {
+  import ChangeAssertion.*
+
+  /** Assert the probed value changed by exactly `delta`. */
+  def by(delta: A)(using num: Numeric[A]): ZIO[R, Throwable, Unit] =
+    runAll(action, List(probeCheck(probe, byCheck(delta))))
+
+  /** Begin a `from(before).to(after)` exact before/after assertion. */
+  def from(before: A): ChangeAssertion.From[R, A] =
+    new ChangeAssertion.From(probe, action, before)
+
+  /** Assert the probed value changed at all (before != after). */
+  def toAnything: ZIO[R, Throwable, Unit] =
+    runAll(action, List(probeCheck(probe, changedCheck)))
+
+  /**
+   * Compose with another `probe` over the *same* action: the receiver's
+   * `action` is run once and both this probe and `otherProbe` must change.
+   * Taking a bare probe (rather than a second `assertChange`) makes the
+   * single-action contract unrepresentable-to-violate — there is no way to
+   * smuggle in a second action.
+   */
+  def and[B](otherProbe: ZIO[R, Throwable, B]): ComposedChangeAssertion[R] =
+    new ComposedChangeAssertion(
+      action,
+      List(probeCheck(probe, changedCheck[A]), probeCheck(otherProbe, changedCheck[B]))
+    )
+}
+
+object ChangeAssertion {
+  // A capture unit: running it snapshots the "before"; the effect it returns —
+  // run after the action — snapshots the "after" and yields a failure message,
+  // or None when the observed change is as expected. The element type is hidden
+  // in the closure so heterogeneous probes compose in one list.
+  private[core] type ProbeCheck[R] = ZIO[R, Throwable, ZIO[R, Throwable, Option[String]]]
+
+  private[core] def probeCheck[R, A](probe: ZIO[R, Throwable, A], check: (A, A) => Option[String]): ProbeCheck[R] =
+    probe.map(before => probe.map(after => check(before, after)))
+
+  private[core] def runAll[R](action: ZIO[R, Throwable, Unit], checks: List[ProbeCheck[R]]): ZIO[R, Throwable, Unit] =
+    for {
+      afters  <- ZIO.foreach(checks)(identity) // snapshot every "before", in order
+      _       <- action                        // one action for the whole assertion
+      results <- ZIO.foreach(afters)(identity) // snapshot every "after" and evaluate
+      failures = results.flatten
+      _ <- if (failures.isEmpty) ZIO.unit
+           else ZIO.fail(new AssertionError("assertChange failed:\n" + failures.mkString("  - ", "\n  - ", "")))
+    } yield ()
+
+  private[core] def byCheck[A](delta: A)(using num: Numeric[A]): (A, A) => Option[String] =
+    (before, after) => {
+      val actual = num.minus(after, before)
+      Option.unless(num.equiv(actual, delta))(
+        s"expected a change of $delta, but changed by $actual (before=$before, after=$after)"
+      )
+    }
+
+  private[core] def changedCheck[A]: (A, A) => Option[String] =
+    (before, after) => Option.when(before == after)(s"expected the value to change, but it stayed $before")
+
+  private[core] def fromToCheck[A](expectedBefore: A, expectedAfter: A): (A, A) => Option[String] =
+    (before, after) => {
+      val errs = List(
+        Option.when(before != expectedBefore)(s"expected before=$expectedBefore, got before=$before"),
+        Option.when(after != expectedAfter)(s"expected after=$expectedAfter, got after=$after")
+      ).flatten
+      Option.unless(errs.isEmpty)(errs.mkString("; "))
+    }
+
+  /** Intermediate builder for `from(before).to(after)`. */
+  final class From[R, A] private[core] (
+    probe: ZIO[R, Throwable, A],
+    action: ZIO[R, Throwable, Unit],
+    before: A
+  ) {
+    def to(after: A): ZIO[R, Throwable, Unit] =
+      runAll(action, List(probeCheck(probe, fromToCheck(before, after))))
+  }
+}
+
+/**
+ * Several change assertions composed over a single action (see
+ * [[ChangeAssertion.and]]). Every probe must change; `assert` runs the action
+ * once and evaluates them all.
+ */
+final class ComposedChangeAssertion[R] private[core] (
+  action: ZIO[R, Throwable, Unit],
+  checks: List[ChangeAssertion.ProbeCheck[R]]
+) {
+  import ChangeAssertion.*
+
+  def and[B](otherProbe: ZIO[R, Throwable, B]): ComposedChangeAssertion[R] =
+    new ComposedChangeAssertion(action, checks :+ probeCheck(otherProbe, changedCheck[B]))
+
+  def assert: ZIO[R, Throwable, Unit] =
+    runAll(action, checks)
+}

--- a/core/src/test/scala/zio/bdd/core/AssertChangeSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/AssertChangeSpec.scala
@@ -1,0 +1,119 @@
+package zio.bdd.core
+
+import zio.*
+import zio.test.*
+import zio.bdd.core.step.State
+
+/**
+ * Gate for issue #224 — the `assertChange` before/after change builder (.by /
+ * .from().to() / .toAnything / .and). Each test gets a fresh `Ref`-backed
+ * `State[Counters]` so state never leaks between tests.
+ */
+object AssertChangeSpec extends ZIOSpecDefault {
+
+  final case class Counters(a: Int = 0, b: Int = 0, c: Int = 0, money: BigDecimal = BigDecimal(0))
+
+  private def withState[A](z: ZIO[State[Counters], Throwable, A]): ZIO[Any, Throwable, Exit[Throwable, A]] =
+    Ref.make(Counters()).flatMap { ref =>
+      val st = new State[Counters]:
+        def get: UIO[Counters]                         = ref.get
+        def update(f: Counters => Counters): UIO[Unit] = ref.update(f)
+      z.exit.provideEnvironment(ZEnvironment(st))
+    }
+
+  private val probeA: ZIO[State[Counters], Nothing, Int]            = State.get[Counters].map(_.a)
+  private val probeB: ZIO[State[Counters], Nothing, Int]            = State.get[Counters].map(_.b)
+  private val probeC: ZIO[State[Counters], Nothing, Int]            = State.get[Counters].map(_.c)
+  private val probeMoney: ZIO[State[Counters], Nothing, BigDecimal] = State.get[Counters].map(_.money)
+  private def bumpA(by: Int): ZIO[State[Counters], Nothing, Unit]   = State.update[Counters](c => c.copy(a = c.a + by))
+  private def bumpB(by: Int): ZIO[State[Counters], Nothing, Unit]   = State.update[Counters](c => c.copy(b = c.b + by))
+  private def bumpC(by: Int): ZIO[State[Counters], Nothing, Unit]   = State.update[Counters](c => c.copy(c = c.c + by))
+  private def bumpMoney(by: BigDecimal): ZIO[State[Counters], Nothing, Unit] =
+    State.update[Counters](c => c.copy(money = c.money + by))
+
+  private def messageOf(exit: Exit[Throwable, Unit]): String =
+    exit match
+      case Exit.Failure(cause) => cause.failureOption.flatMap(t => Option(t.getMessage)).getOrElse("")
+      case Exit.Success(_)     => ""
+
+  def spec = suite("AssertChangeSpec")(
+    // ── .by ───────────────────────────────────────────────────────────────
+    suite(".by")(
+      test("passes when the value changes by exactly the delta (AC1)") {
+        withState(Assertions.assertChange(probeA)(bumpA(100)).by(100)).map(e => assertTrue(e.isSuccess))
+      },
+      test("fails when the change differs, showing before/after/expected (AC1, AC5)") {
+        withState(Assertions.assertChange(probeA)(bumpA(70)).by(100)).map { exit =>
+          val msg = messageOf(exit)
+          assertTrue(exit.isFailure, msg.contains("100"), msg.contains("70"), msg.contains("before=0"))
+        }
+      },
+      test("works for a non-Int Numeric (BigDecimal), including a negative delta (AC1)") {
+        for
+          up   <- withState(Assertions.assertChange(probeMoney)(bumpMoney(BigDecimal("1.25"))).by(BigDecimal("1.25")))
+          down <- withState(Assertions.assertChange(probeMoney)(bumpMoney(BigDecimal("-2.50"))).by(BigDecimal("-2.50")))
+        yield assertTrue(up.isSuccess, down.isSuccess)
+      }
+    ),
+    // ── .from().to() ──────────────────────────────────────────────────────
+    suite(".from.to")(
+      test("passes on exact before and after values (AC2)") {
+        withState(Assertions.assertChange(probeA)(bumpA(5)).from(0).to(5)).map(e => assertTrue(e.isSuccess))
+      },
+      test("fails when the before value does not match (AC2, AC5)") {
+        withState(Assertions.assertChange(probeA)(bumpA(5)).from(1).to(6)).map(e =>
+          assertTrue(e.isFailure, messageOf(e).contains("before"))
+        )
+      },
+      test("fails when the after value does not match (AC2, AC5)") {
+        withState(Assertions.assertChange(probeA)(bumpA(5)).from(0).to(99)).map(e =>
+          assertTrue(e.isFailure, messageOf(e).contains("99"))
+        )
+      }
+    ),
+    // ── .toAnything ───────────────────────────────────────────────────────
+    suite(".toAnything")(
+      test("passes when the value changed at all (AC3)") {
+        withState(Assertions.assertChange(probeA)(bumpA(1)).toAnything).map(e => assertTrue(e.isSuccess))
+      },
+      test("fails when the value did not change (AC3, AC5)") {
+        withState(Assertions.assertChange(probeA)(bumpA(0)).toAnything).map(e =>
+          assertTrue(e.isFailure, messageOf(e).toLowerCase.contains("change"))
+        )
+      }
+    ),
+    // ── .and composition ──────────────────────────────────────────────────
+    suite(".and")(
+      test("passes when both probes change over a single action (AC4)") {
+        val action = bumpA(1) *> bumpB(2)
+        withState(Assertions.assertChange(probeA)(action).and(probeB).assert).map(e => assertTrue(e.isSuccess))
+      },
+      test("chains 3+ probes and passes when all change (AC4)") {
+        val action = bumpA(1) *> bumpB(1) *> bumpC(1)
+        withState(Assertions.assertChange(probeA)(action).and(probeB).and(probeC).assert)
+          .map(e => assertTrue(e.isSuccess))
+      },
+      test("fails when one composed probe does not change, naming it in the message (AC4, AC5)") {
+        val action = bumpA(1) // b untouched
+        withState(Assertions.assertChange(probeA)(action).and(probeB).assert).map { e =>
+          assertTrue(e.isFailure, messageOf(e).toLowerCase.contains("change"))
+        }
+      },
+      test("runs the action exactly once for the whole composition") {
+        for
+          runs  <- Ref.make(0)
+          action = bumpA(1) *> bumpB(1) *> runs.update(_ + 1)
+          exit  <- withState(Assertions.assertChange(probeA)(action).and(probeB).assert)
+          count <- runs.get
+        yield assertTrue(exit.isSuccess, count == 1)
+      }
+    ),
+    // ── action failure propagates (not swallowed as "no change") ──────────
+    test("a failing action propagates its error, it is not coerced into an assertion failure") {
+      val boom: ZIO[State[Counters], Throwable, Unit] = ZIO.fail(new RuntimeException("action boom"))
+      withState(Assertions.assertChange(probeA)(boom).by(1)).map(e =>
+        assertTrue(e.isFailure, messageOf(e).contains("action boom"))
+      )
+    }
+  )
+}

--- a/docs/step-dsl.md
+++ b/docs/step-dsl.md
@@ -794,3 +794,50 @@ Assertions.assertBetween[A]    (min: Int, max: Int, collection: Iterable[A], lab
   `ZIO.attempt` boundary — still propagates, same Fail/Die caveat as `eventually`.) If a predicate
   can raise a typed error you do *not* want treated as an unsatisfied element, handle it first.
 
+---
+
+## 15. Change assertions with `Assertions.assertChange`
+
+A composable, readable upgrade over [`withSnapshot`](#8-withsnapshot-for-beforeafter-assertions)
+for "after a deposit of 100, the balance increased by 100." `assertChange(probe)(action)` captures
+`probe` before running `action`, re-probes after, and defers the check to a terminal:
+
+```scala
+Then("the deposit increases the balance by 100") {
+  Assertions.assertChange(ScenarioContext.get.map(_.balance)) {
+    When("a deposit of 100 is made") { ... }
+  }.by(100)
+}
+```
+
+### API
+
+```scala
+Assertions.assertChange[R, A](probe: ZIO[R, Throwable, A])(action: ZIO[R, Throwable, Unit]): ChangeAssertion[R, A]
+
+final class ChangeAssertion[R, A]:
+  def by(delta: A)(using Numeric[A]): ZIO[R, Throwable, Unit]  // changed by exactly delta
+  def from(before: A): ChangeAssertion.From[R, A]              // .from(x).to(y): exact before AND after
+  def toAnything: ZIO[R, Throwable, Unit]                      // changed at all (before != after)
+  def and[B](otherProbe: ZIO[R, Throwable, B]): ComposedChangeAssertion[R]
+
+final class ComposedChangeAssertion[R]:
+  def and[B](otherProbe: ZIO[R, Throwable, B]): ComposedChangeAssertion[R]
+  def assert: ZIO[R, Throwable, Unit]                          // run the shared action once; every probe must change
+```
+
+- **`.by(delta)`** requires a `Numeric[A]` and asserts `after - before == delta` (exact equality —
+  for approximate numeric comparison use a dedicated tolerance check).
+- **`.from(x).to(y)`** asserts the exact before *and* after values.
+- **`.toAnything`** asserts the value changed without pinning the delta.
+- **`.and(otherProbe)`** composes several probes over a **single** action — the action runs once
+  and every probe must change. It takes a bare *probe* (not a second `assertChange`), so there is
+  no way to supply a second action; chain more with `.and` and terminate with `.assert`:
+  `assertChange(a)(action).and(b).and(c).assert`.
+- Failure messages show the observed **before**, **after**, and **expected** values.
+
+> **Design note.** The environment is threaded as a single `R` (typically containing `State[S]`),
+> and `.by` takes `delta: A` directly — a simplification of the issue's sketched
+> `R & State[S]` / `.by[B](… A =:= B)` signatures that reads the same at call sites and infers
+> reliably.
+


### PR DESCRIPTION
Adds `Assertions.assertChange(probe)(action)` — a deferred before/after change assertion (RSpec `change { }.by`-style), a readable upgrade over `withSnapshot`.

Terminals: `.by(delta)` (Numeric, exact), `.from(x).to(y)` (exact before AND after), `.toAnything` (changed at all), and `.and(otherProbe)…​.assert` to compose several probes over a **single** action. `.and` takes a bare probe so a second action can't be smuggled in. Failure messages show before/after/expected. Docs in step-dsl.md §15; 13 unit tests.

Note: the environment is threaded as a single `R` and `.by` takes `delta: A` — a deliberate simplification of the issue's sketched `R & State[S]` / `.by[B](… A =:= B)` signatures (design note licensed this) that reads the same and infers reliably.

Closes #224
Part of #218 (combinator backlog). Milestone: none.