### PR TITLE
Scenario-level retry tags: @retry(n) / @flaky(n) / @nonFlaky(n)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -188,6 +188,10 @@ lazy val mimaSettings = Seq(
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.gherkin.Scenario.copy"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.FeatureExecutor.executeFeature"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.FeatureExecutor.executeFeatures"),
+    // #225: ScenarioResult gained a trailing `attempts: Int = 1` field (retry-tag support).
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.ScenarioResult.apply"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.ScenarioResult.this"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.ScenarioResult.copy"),
     ProblemFilters.exclude[MissingFieldProblem]("zio.bdd.core.report.Color.Yellow"),
     ProblemFilters.exclude[MissingFieldProblem]("zio.bdd.core.report.Color.PaleGreen"),
     ProblemFilters.exclude[MissingFieldProblem]("zio.bdd.core.report.Color.PaleCyan"),

--- a/core/src/main/scala/zio/bdd/core/Result.scala
+++ b/core/src/main/scala/zio/bdd/core/Result.scala
@@ -63,7 +63,12 @@ case class ScenarioResult(
   scenario: Scenario,
   stepResults: List[StepResult],
   setupError: Option[Cause[Throwable]] = None,
-  duration: Long = 0L
+  duration: Long = 0L,
+  /**
+   * How many times the scenario ran. 1 unless a retry aspect
+   * (@retry/@flaky/@nonFlaky) applied.
+   */
+  attempts: Int = 1
 ):
   def isPassed: Boolean   = stepResults.forall(r => r.isPassed || r.isSkipped) && setupError.isEmpty
   def isIgnored: Boolean  = scenario.isIgnored

--- a/core/src/main/scala/zio/bdd/core/ScenarioAspect.scala
+++ b/core/src/main/scala/zio/bdd/core/ScenarioAspect.scala
@@ -1,0 +1,39 @@
+package zio.bdd.core
+
+/**
+ * A scenario-level retry policy, applied either via a Gherkin tag (`@retry(n)`
+ * / `@flaky(n)` / `@nonFlaky(n)`) or the code-side `ZIOSteps.scenarioAspects`
+ * override.
+ *
+ *   - [[Retry]] / [[Flaky]]: run up to `n` attempts, passing on the first
+ *     success.
+ *   - [[NonFlaky]]: run up to `n` attempts, failing fast on the first failure
+ *     (passes only if every attempt passes).
+ */
+enum ScenarioAspect:
+  case Retry(n: Int)
+  case Flaky(n: Int)
+  case NonFlaky(n: Int)
+
+object ScenarioAspect:
+  // Matches `retry(3)` / `flaky(5)` / `nonFlaky(2)`, case-insensitive on the name.
+  private val pattern = """(?i)^(retry|flaky|nonflaky)\((\d+)\)$""".r
+
+  /**
+   * Parse a single tag (with or without a leading `@`). `n` is clamped to `>=
+   * 1`.
+   */
+  def fromTag(tag: String): Option[ScenarioAspect] =
+    pattern.findFirstMatchIn(tag.trim.stripPrefix("@")).flatMap { m =>
+      m.group(2).toIntOption.map(_.max(1)).flatMap { n =>
+        m.group(1).toLowerCase match
+          case "retry"    => Some(Retry(n))
+          case "flaky"    => Some(Flaky(n))
+          case "nonflaky" => Some(NonFlaky(n))
+          case _          => None
+      }
+    }
+
+  /** The first retry aspect found among the scenario's tags, if any. */
+  def fromTags(tags: List[String]): Option[ScenarioAspect] =
+    tags.iterator.flatMap(fromTag).nextOption()

--- a/core/src/main/scala/zio/bdd/core/ScenarioExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/ScenarioExecutor.scala
@@ -19,49 +19,91 @@ object ScenarioExecutor {
     stepTimeout: Option[Duration] = None
   ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
     if (scenario.isIgnored) {
+      // An ignored scenario never runs — retry aspects do not apply to it.
       ZIO.succeed(ScenarioResult(scenario, Nil, setupError = None))
     } else {
-      ZIO.scoped {
-        for {
-          stateRef <- FiberRef.make(Default[S].default)
-          // Per-scenario staging is scoped to the scenario and auto-restored on scope close,
-          // so values cannot leak into the next scenario even if a step is interrupted.
-          _             <- Stage.ref.locallyScoped(Map.empty)
-          _             <- Stage.currentStepLabel.locallyScoped("")
-          scenarioScope <- ZIO.scope
-          meta           = ScenarioMetadata.from(scenario, flagValues)
-          scenarioResult <- (for {
-                              startNanos <- nowNanos
-                              // Run beforeScenario setup to completion BEFORE any step. A failing
-                              // setup is recorded as the scenario's setupError instead of running steps.
-                              beforeExit <- suite.beforeScenarioHook(meta).exit
-                              result <- beforeExit match {
-                                          case Exit.Failure(cause) =>
-                                            ZIO.succeed(ScenarioResult(scenario, Nil, setupError = Some(cause)))
-                                          case Exit.Success(_) =>
-                                            computeEffectiveStepTypes(scenario.steps).either.flatMap {
-                                              case Left(throwable) =>
-                                                ZIO.succeed(
-                                                  ScenarioResult(
-                                                    scenario,
-                                                    Nil,
-                                                    setupError = Some(Cause.fail(throwable))
-                                                  )
-                                                )
-                                              case Right(stepsWithTypes) =>
-                                                executeSteps[R, S](scenario, stepsWithTypes, suite, dryRun, stepTimeout)
-                                            }
-                                        }
-                              endNanos <- nowNanos
-                              duration  = (endNanos - startNanos) / 1_000_000L
-                            } yield result.copy(duration = duration))
-                              // afterScenario teardown always runs, even on failure or interruption.
-                              .ensuring(suite.afterScenarioHook(meta))
-                              .provideSomeLayer[StepRegistry[R, S] & R](
-                                State.layer(stateRef) ++ ZLayer.succeed(scenarioScope)
-                              )
-        } yield scenarioResult
+      val attempt = runAttempt[R, S](scenario, suite, dryRun, flagValues, stepTimeout)
+      resolveAspect(scenario, suite) match {
+        case None                             => attempt
+        case Some(ScenarioAspect.Retry(n))    => runUntilPass(n, attempt)
+        case Some(ScenarioAspect.Flaky(n))    => runUntilPass(n, attempt)
+        case Some(ScenarioAspect.NonFlaky(n)) => runUntilFail(n, attempt)
       }
+    }
+
+  // A scenario tag wins over the code-side `scenarioAspects` map.
+  private def resolveAspect[R, S](scenario: Scenario, suite: ZIOSteps[R, S]): Option[ScenarioAspect] =
+    ScenarioAspect.fromTags(scenario.tags).orElse(suite.scenarioAspects.get(scenario.name))
+
+  // @retry / @flaky: re-run up to n times, stopping at the first passing result.
+  private def runUntilPass[Env](
+    n: Int,
+    attempt: ZIO[Env, Nothing, ScenarioResult]
+  ): ZIO[Env, Nothing, ScenarioResult] = {
+    def loop(k: Int): ZIO[Env, Nothing, ScenarioResult] =
+      attempt.flatMap(r => if (r.isPassed || k >= n) ZIO.succeed(r.copy(attempts = k)) else loop(k + 1))
+    loop(1)
+  }
+
+  // @nonFlaky: re-run up to n times, stopping at the first failing result (fail fast).
+  private def runUntilFail[Env](
+    n: Int,
+    attempt: ZIO[Env, Nothing, ScenarioResult]
+  ): ZIO[Env, Nothing, ScenarioResult] = {
+    def loop(k: Int): ZIO[Env, Nothing, ScenarioResult] =
+      attempt.flatMap(r => if (!r.isPassed || k >= n) ZIO.succeed(r.copy(attempts = k)) else loop(k + 1))
+    loop(1)
+  }
+
+  // One scenario attempt: fresh per-scenario state and staging, before/after hooks included, so
+  // every retry attempt is fully independent.
+  private def runAttempt[R: Tag, S: Tag: Default](
+    scenario: Scenario,
+    suite: ZIOSteps[R, S],
+    dryRun: Boolean,
+    flagValues: Map[String, String],
+    stepTimeout: Option[Duration]
+  ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
+    ZIO.scoped {
+      for {
+        stateRef <- FiberRef.make(Default[S].default)
+        // Per-scenario staging is scoped to the scenario and auto-restored on scope close,
+        // so values cannot leak into the next scenario even if a step is interrupted.
+        _             <- Stage.ref.locallyScoped(Map.empty)
+        _             <- Stage.currentStepLabel.locallyScoped("")
+        scenarioScope <- ZIO.scope
+        meta           = ScenarioMetadata.from(scenario, flagValues)
+        scenarioResult <- (for {
+                            startNanos <- nowNanos
+                            // Run beforeScenario setup to completion BEFORE any step. A failing
+                            // setup is recorded as the scenario's setupError instead of running steps.
+                            beforeExit <- suite.beforeScenarioHook(meta).exit
+                            result <- beforeExit match {
+                                        case Exit.Failure(cause) =>
+                                          ZIO.succeed(ScenarioResult(scenario, Nil, setupError = Some(cause)))
+                                        case Exit.Success(_) =>
+                                          computeEffectiveStepTypes(scenario.steps).either.flatMap {
+                                            case Left(throwable) =>
+                                              ZIO.succeed(
+                                                ScenarioResult(
+                                                  scenario,
+                                                  Nil,
+                                                  setupError = Some(Cause.fail(throwable))
+                                                )
+                                              )
+                                            case Right(stepsWithTypes) =>
+                                              executeSteps[R, S](scenario, stepsWithTypes, suite, dryRun, stepTimeout)
+                                          }
+                                      }
+                            endNanos <- nowNanos
+                            duration  = (endNanos - startNanos) / 1_000_000L
+                          } yield result.copy(duration = duration))
+                            // afterScenario teardown always runs, even on failure or interruption.
+                            .ensuring(suite.afterScenarioHook(meta))
+                            .provideSomeLayer[StepRegistry[R, S] & R](
+                              State.layer(stateRef) ++ ZLayer.succeed(scenarioScope)
+                            )
+      } yield scenarioResult
     }
 
   private def executeSteps[R: Tag, S: Tag: Default](

--- a/core/src/main/scala/zio/bdd/core/report/PrettyReporter.scala
+++ b/core/src/main/scala/zio/bdd/core/report/PrettyReporter.scala
@@ -442,8 +442,9 @@ object DocBuilder:
     val effectiveIgnored = featureIgnored || sc.isIgnored
     val sty              = summon[StatusColor[ScenarioResult]].style(sc)
     val loc              = sc.scenario.line.map(l => s":$l").getOrElse("")
+    val attemptStr       = if (sc.attempts > 1) s" (${sc.attempts} attempts)" else ""
     val header = Doc.Leaf(
-      text = s"Scenario: ${sc.scenario.name}$loc - ${statusText(sc)}${durStr(sc.duration)}",
+      text = s"Scenario: ${sc.scenario.name}$loc - ${statusText(sc)}${durStr(sc.duration)}$attemptStr",
       style = sty
     )
     val stepDocs =

--- a/core/src/main/scala/zio/bdd/core/step/ZIOSteps.scala
+++ b/core/src/main/scala/zio/bdd/core/step/ZIOSteps.scala
@@ -527,6 +527,18 @@ trait ZIOSteps[R: Tag, S: Tag: Default]
    */
   def featureParallelism: Option[Int] = None
 
+  /**
+   * Override to apply scenario-level retry policies in code, keyed by scenario
+   * name — an alternative to the `@retry(n)` / `@flaky(n)` / `@nonFlaky(n)`
+   * Gherkin tags. A tag on the scenario takes precedence over this map.
+   *
+   * {{{
+   * override def scenarioAspects: Map[String, ScenarioAspect] =
+   *   Map("provisions a fresh tenant" -> ScenarioAspect.Retry(3))
+   * }}}
+   */
+  def scenarioAspects: Map[String, zio.bdd.core.ScenarioAspect] = Map.empty
+
   // ── Step DSL operators ──────────────────────────────────────────────────
 
   extension [Out <: Tuple](se: StepExpression[Out])

--- a/core/src/test/scala/zio/bdd/core/RetryTagsSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/RetryTagsSpec.scala
@@ -1,0 +1,234 @@
+package zio.bdd.core
+
+import zio.*
+import zio.test.*
+import zio.bdd.gherkin.*
+import zio.bdd.core.step.{ZIOSteps, DefaultTypedExtractor}
+import zio.schema.{DeriveSchema, Schema}
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Gate for issue #225 — scenario-level retry tags (@retry / @flaky / @nonFlaky)
+ * and the code-side `scenarioAspects` override.
+ */
+object RetryTagsSpec extends ZIOSpecDefault {
+
+  case class St(x: Int = 0)
+  given Schema[St] = DeriveSchema.gen[St]
+
+  /**
+   * The `When` step fails on its first `failFirst` executions (counted across
+   * retry attempts via the shared counter), then succeeds.
+   */
+  class FlakySteps(failFirst: Int, val counter: AtomicInteger, val aspects: Map[String, ScenarioAspect] = Map.empty)
+      extends ZIOSteps[Any, St]
+      with DefaultTypedExtractor {
+    override def scenarioAspects: Map[String, ScenarioAspect] = aspects
+    Given("a system")(ScenarioContext.update(_ => St()))
+    When("the flaky action runs") {
+      ZIO.succeed(counter.incrementAndGet()).flatMap { n =>
+        if (n <= failFirst) ZIO.fail(new RuntimeException(s"flaky failure #$n")) else ZIO.unit
+      }
+    }
+    Then("it is done")(ZIO.unit)
+  }
+
+  /**
+   * The `When` step fails on exactly the `failOn`-th execution, passes
+   * otherwise.
+   */
+  class FailOnNthSteps(failOn: Int, val counter: AtomicInteger) extends ZIOSteps[Any, St] with DefaultTypedExtractor {
+    Given("a system")(ScenarioContext.update(_ => St()))
+    When("the action runs") {
+      ZIO.succeed(counter.incrementAndGet()).flatMap { n =>
+        if (n == failOn) ZIO.fail(new RuntimeException(s"failure on attempt $n")) else ZIO.unit
+      }
+    }
+    Then("it is done")(ZIO.unit)
+  }
+
+  /**
+   * Does NOT reset state in `Given`, and fails the first `failFirst` attempts.
+   * A step asserts the per-scenario state starts at its default each attempt —
+   * so a leaked FiberRef is detectable.
+   */
+  class StatefulFlakySteps(failFirst: Int, val counter: AtomicInteger)
+      extends ZIOSteps[Any, St]
+      with DefaultTypedExtractor {
+    // Deliberately does NOT reset state — a fresh attempt should already start at St(x = 0) via the
+    // per-attempt FiberRef, so the `s.x != 0` check below catches a leak rather than being masked.
+    Given("a system")(ZIO.unit)
+    When("the stateful flaky action runs") {
+      ScenarioContext.get.flatMap { s =>
+        if (s.x != 0) ZIO.fail(new RuntimeException(s"state leaked across attempts: x=${s.x}"))
+        else
+          ScenarioContext.update(_.copy(x = 1)) *> ZIO.succeed(counter.incrementAndGet()).flatMap { n =>
+            if (n <= failFirst) ZIO.fail(new RuntimeException(s"flaky failure #$n")) else ZIO.unit
+          }
+      }
+    }
+    Then("it is done")(ZIO.unit)
+  }
+
+  /**
+   * `beforeScenario` hook fails (dies) every attempt → recorded as the
+   * scenario's setupError.
+   */
+  class FailingHookSteps(val counter: AtomicInteger) extends ZIOSteps[Any, St] with DefaultTypedExtractor {
+    beforeScenario { (_: ScenarioMetadata) =>
+      ZIO.succeed(counter.incrementAndGet()) *> ZIO.die(new RuntimeException("setup boom"))
+    }
+    Given("a system")(ScenarioContext.update(_ => St()))
+    When("the flaky action runs")(ZIO.unit)
+    Then("it is done")(ZIO.unit)
+  }
+
+  private val F = "retry.feature"
+
+  private def run(content: String)(using steps: ZIOSteps[Any, St]) =
+    GherkinParser.parseFeature(content, F).flatMap { feature =>
+      FeatureExecutor.executeFeatures[Any, St](List(feature), steps.getSteps, steps)
+    }
+
+  private def scenario(tag: String, when: String = "the flaky action runs"): String =
+    s"""Feature: Retry
+       |  $tag
+       |  Scenario: flaky one
+       |    Given a system
+       |    When $when
+       |    Then it is done
+       |""".stripMargin
+
+  // ── Tag parsing (AC1) ──────────────────────────────────────────────────────
+  private val parsing = suite("ScenarioAspect.fromTags (AC1)")(
+    test("parses retry / flaky / nonFlaky with an integer argument") {
+      assertTrue(
+        ScenarioAspect.fromTags(List("retry(3)")).contains(ScenarioAspect.Retry(3)),
+        ScenarioAspect.fromTags(List("flaky(5)")).contains(ScenarioAspect.Flaky(5)),
+        ScenarioAspect.fromTags(List("nonFlaky(2)")).contains(ScenarioAspect.NonFlaky(2))
+      )
+    },
+    test("tolerates a leading @ and is case-insensitive on the name") {
+      assertTrue(
+        ScenarioAspect.fromTags(List("@retry(4)")).contains(ScenarioAspect.Retry(4)),
+        ScenarioAspect.fromTags(List("NonFlaky(3)")).contains(ScenarioAspect.NonFlaky(3))
+      )
+    },
+    test("returns None for unrelated tags and the first match wins") {
+      assertTrue(
+        ScenarioAspect.fromTags(List("smoke", "wip")).isEmpty,
+        ScenarioAspect.fromTags(List("retry(2)", "flaky(9)")).contains(ScenarioAspect.Retry(2))
+      )
+    },
+    test("ignores malformed arguments and clamps a zero count to 1") {
+      assertTrue(
+        ScenarioAspect.fromTag("retry(abc)").isEmpty,
+        ScenarioAspect.fromTag("retry()").isEmpty,
+        ScenarioAspect.fromTag("retry").isEmpty,
+        ScenarioAspect.fromTag("retry(0)").contains(ScenarioAspect.Retry(1))
+      )
+    }
+  )
+
+  // ── Semantics (AC2) ─────────────────────────────────────────────────────────
+  private val semantics = suite("retry semantics (AC2)")(
+    test("@retry(n) re-runs on failure and passes on the first success") {
+      val counter                    = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new FlakySteps(failFirst = 2, counter) {}
+      run(scenario("@retry(3)")).map { r =>
+        val sc = r.head.scenarioResults.head
+        assertTrue(sc.isPassed, sc.attempts == 3, counter.get() == 3)
+      }
+    },
+    test("@retry(n) gives up after n attempts and reports failure") {
+      val counter                    = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new FlakySteps(failFirst = 99, counter) {}
+      run(scenario("@retry(2)")).map { r =>
+        val sc = r.head.scenarioResults.head
+        assertTrue(!sc.isPassed, sc.attempts == 2, counter.get() == 2)
+      }
+    },
+    test("@flaky(n) passes if any of the n runs succeeds") {
+      val counter                    = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new FlakySteps(failFirst = 1, counter) {}
+      run(scenario("@flaky(3)")).map { r =>
+        val sc = r.head.scenarioResults.head
+        assertTrue(sc.isPassed, sc.attempts == 2)
+      }
+    },
+    test("@nonFlaky(n) runs all n when they all pass") {
+      val counter                    = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new FlakySteps(failFirst = 0, counter) {}
+      run(scenario("@nonFlaky(3)")).map { r =>
+        val sc = r.head.scenarioResults.head
+        assertTrue(sc.isPassed, sc.attempts == 3, counter.get() == 3)
+      }
+    },
+    test("@nonFlaky(n) fails fast on the first failing run") {
+      val counter                    = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new FailOnNthSteps(failOn = 2, counter) {}
+      run(scenario("@nonFlaky(5)", when = "the action runs")).map { r =>
+        val sc = r.head.scenarioResults.head
+        assertTrue(!sc.isPassed, sc.attempts == 2, counter.get() == 2)
+      }
+    }
+  )
+
+  // ── Code-side override (AC3) + interactions (AC4) ───────────────────────────
+  private val overrideAndInteractions = suite("code-side override + interactions (AC3, AC4)")(
+    test("scenarioAspects code override applies when there is no tag") {
+      val counter = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] =
+        new FlakySteps(failFirst = 2, counter, aspects = Map("flaky one" -> ScenarioAspect.Retry(3))) {}
+      run(scenario("# no tag")).map { r =>
+        val sc = r.head.scenarioResults.head
+        assertTrue(sc.isPassed, sc.attempts == 3)
+      }
+    },
+    test("@ignore wins over @retry — an ignored scenario is not retried") {
+      val counter                    = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new FlakySteps(failFirst = 99, counter) {}
+      run(scenario("@ignore @retry(3)")).map { r =>
+        val sc = r.head.scenarioResults.head
+        assertTrue(sc.isIgnored, counter.get() == 0)
+      }
+    },
+    test("a scenario without any aspect runs exactly once (attempts == 1)") {
+      val counter                    = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new FlakySteps(failFirst = 0, counter) {}
+      run(scenario("# none")).map { r =>
+        val sc = r.head.scenarioResults.head
+        assertTrue(sc.isPassed, sc.attempts == 1, counter.get() == 1)
+      }
+    },
+    test("a scenario tag takes precedence over the scenarioAspects map") {
+      // Map says NonFlaky(1) (run once → would fail); tag says @retry(3) (would pass on attempt 3).
+      val counter = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] =
+        new FlakySteps(failFirst = 2, counter, aspects = Map("flaky one" -> ScenarioAspect.NonFlaky(1))) {}
+      run(scenario("@retry(3)")).map { r =>
+        val sc = r.head.scenarioResults.head
+        assertTrue(sc.isPassed, sc.attempts == 3) // tag won
+      }
+    },
+    test("each attempt gets fresh per-scenario state (no FiberRef leak)") {
+      // The step fails once then passes; it also asserts state.x == 0 at the start of every attempt.
+      val counter                    = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new StatefulFlakySteps(failFirst = 1, counter) {}
+      run(scenario("@retry(3)", when = "the stateful flaky action runs")).map { r =>
+        val sc = r.head.scenarioResults.head
+        assertTrue(sc.isPassed, sc.attempts == 2) // passed on attempt 2 without a leak failure
+      }
+    },
+    test("a failing beforeScenario hook is retried and runs the hook each attempt") {
+      val hookRuns                   = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new FailingHookSteps(hookRuns) {}
+      run(scenario("@retry(2)")).map { r =>
+        val sc = r.head.scenarioResults.head
+        assertTrue(!sc.isPassed, sc.attempts == 2, hookRuns.get() == 2)
+      }
+    }
+  )
+
+  def spec = suite("RetryTagsSpec")(parsing, semantics, overrideAndInteractions)
+}

--- a/core/src/test/scala/zio/bdd/core/report/PrettyReporterSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/report/PrettyReporterSpec.scala
@@ -174,6 +174,19 @@ object PrettyReporterSpec extends ZIOSpecDefault {
       val leaf    = DocBuilder.stepLeaf(skipped)
       assertTrue(leaf.style.color == Color.Gray, leaf.text.contains("SKIPPED"))
     },
+    test("scenarioBranch header shows the attempt count when a scenario was retried") {
+      val sc =
+        mkScenarioResult("retried scenario", List((StepType.GivenStep, "a step", StepStatus.Passed))).copy(attempts = 3)
+      DocBuilder.scenarioBranch(sc, isLast = true, featureIgnored = false, _ => emptyLogs) match
+        case Doc.Branch(header, _, _) => assertTrue(header.text.contains("3 attempts"))
+        case _                        => assertTrue(false)
+    },
+    test("scenarioBranch header omits the attempt count for a single-attempt scenario") {
+      val sc = mkScenarioResult("normal scenario", List((StepType.GivenStep, "a step", StepStatus.Passed)))
+      DocBuilder.scenarioBranch(sc, isLast = true, featureIgnored = false, _ => emptyLogs) match
+        case Doc.Branch(header, _, _) => assertTrue(!header.text.contains("attempt"))
+        case _                        => assertTrue(false)
+    },
     test("stepBranch with no logs and passed step is a Branch with no children") {
       val step = mkStep(StepType.GivenStep, "a step")
       val sr   = StepResult(step, Right(()), 0L)

--- a/docs/running.md
+++ b/docs/running.md
@@ -390,6 +390,49 @@ When("a very slow operation completes") {
 
 ---
 
+## Scenario retry tags
+
+For environmentally flaky acceptance tests, a scenario can be re-run automatically. Tag it in
+Gherkin with an integer argument, or configure it in code via `scenarioAspects`.
+
+| Tag | Semantics |
+|---|---|
+| `@retry(n)` | Re-run on failure, up to `n` attempts; pass on the first success. |
+| `@flaky(n)` | Run up to `n` attempts; pass if any succeeds (same outcome as `@retry`). |
+| `@nonFlaky(n)` | Run up to `n` attempts; pass only if **every** attempt passes (fail fast on the first failure). |
+
+```gherkin
+@retry(3)
+Scenario: provisions a fresh tenant
+  Given a clean environment
+  When a tenant is provisioned
+  Then the tenant is reachable
+```
+
+Or, without touching the feature file, override `scenarioAspects` (keyed by scenario name):
+
+```scala
+override def scenarioAspects: Map[String, ScenarioAspect] =
+  Map("provisions a fresh tenant" -> ScenarioAspect.Retry(3))
+```
+
+**Semantics & interactions**
+
+- Each attempt is fully independent: per-scenario state is reset and the `beforeScenario` /
+  `afterScenario` hooks run on every attempt.
+- A tag on the scenario takes precedence over the `scenarioAspects` map. `n` is clamped to `≥ 1`.
+- `stepTimeout` applies per step *within* each attempt, so a retried scenario's worst-case
+  wall-clock time is up to `n ×` the single-attempt time.
+- `@ignore` wins over a retry tag: an ignored scenario never runs and is not retried. Include/
+  exclude tag filtering is unaffected — the retry tags are not treated as filter labels.
+- The pretty reporter appends `(k attempts)` to a scenario that ran more than once; the count is
+  also available as `ScenarioResult.attempts` for custom reporters.
+- Retry tags are **scenario-level only** — a `@retry(n)` placed above `Feature:` does not apply to
+  the feature's scenarios; tag each scenario (or use `scenarioAspects`). An unrecognised or
+  malformed argument (e.g. `@retry(abc)`) is ignored and the scenario runs once.
+
+---
+
 
 ## IDE integration
 


### PR DESCRIPTION
Adds scenario-level retry semantics via Gherkin tags (`@retry(n)` / `@flaky(n)` / `@nonFlaky(n)`) or a code-side `scenarioAspects: Map[String, ScenarioAspect]` override.

- `@retry`/`@flaky`: run up to `n` attempts, pass on first success. `@nonFlaky`: run up to `n`, pass only if all pass (fail fast).
- Each attempt is independent: fresh per-scenario state, `beforeScenario`/`afterScenario` run every attempt. A tag wins over the map; `@ignore` wins over retry (ignored scenarios are not retried). `n` clamped to ≥1; malformed args ignored (run once). Retry tags are scenario-level only.
- Attempt count exposed as `ScenarioResult.attempts`; pretty reporter appends `(k attempts)`. Documented in running.md; 18 new unit tests + reporter tests.

Closes #225
Part of #218 (combinator backlog). Milestone: none.