### PR TITLE
Distinguish step interruption from failure in retry loops

### DIFF
--- a/core/src/main/scala/zio/bdd/core/ScenarioExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/ScenarioExecutor.scala
@@ -79,6 +79,10 @@ object ScenarioExecutor {
                             // setup is recorded as the scenario's setupError instead of running steps.
                             beforeExit <- suite.beforeScenarioHook(meta).exit
                             result <- beforeExit match {
+                                        // Cancellation of the setup hook must propagate, not be recorded as a
+                                        // retryable setup error (see the step-body note below).
+                                        case Exit.Failure(cause) if cause.isInterruptedOnly =>
+                                          ZIO.failCause(cause.stripFailures)
                                         case Exit.Failure(cause) =>
                                           ZIO.succeed(ScenarioResult(scenario, Nil, setupError = Some(cause)))
                                         case Exit.Success(_) =>
@@ -141,6 +145,9 @@ object ScenarioExecutor {
         startNanos  <- nowNanos
         beforeCause <- suite.beforeStepHook(stepMeta).foldCause[Option[Cause[Throwable]]](c => Some(c), _ => None)
         result <- beforeCause match {
+                    // Cancellation of a beforeStep hook propagates rather than becoming a retryable failure.
+                    case Some(cause) if cause.isInterruptedOnly =>
+                      ZIO.failCause(cause.stripFailures)
                     case Some(cause) =>
                       // A failing beforeStep hook fails the step; the step body is not run.
                       ZIO.succeed(StepResult(step, Left(cause)))
@@ -162,19 +169,31 @@ object ScenarioExecutor {
                                              effect
                                          }
                                          timedEffect.foldCauseZIO(
-                                           cause => ZIO.succeed(StepResult(step, Left(cause))),
+                                           cause =>
+                                             // A genuine external interruption (cancellation / shutdown) must
+                                             // propagate, not be recorded as a retryable step failure —
+                                             // otherwise retry tags would re-run a cancelled scenario. A per-step
+                                             // timeout surfaces as a StepTimeoutException (a typed failure), so it
+                                             // is not interrupt-only and stays a normal failed step.
+                                             if (cause.isInterruptedOnly) ZIO.failCause(cause.stripFailures)
+                                             else ZIO.succeed(StepResult(step, Left(cause))),
                                            _ => ZIO.succeed(StepResult(step, Right(())))
                                          )
                                        }
                                    )
                         afterCause <-
                           suite.afterStepHook(stepMeta).foldCause[Option[Cause[Throwable]]](c => Some(c), _ => None)
-                      } yield afterCause match {
-                        // A failing afterStep hook fails an otherwise-passed step; a step that has
-                        // already failed keeps its original cause.
-                        case Some(cause) if stepRes.outcome.isRight => StepResult(step, Left(cause))
-                        case _                                      => stepRes
-                      }
+                        merged <- afterCause match {
+                                    // Cancellation of an afterStep hook propagates rather than turning a
+                                    // (possibly passed) step into a retryable failure.
+                                    case Some(cause) if cause.isInterruptedOnly => ZIO.failCause(cause.stripFailures)
+                                    // A failing afterStep hook fails an otherwise-passed step; a step that has
+                                    // already failed keeps its original cause.
+                                    case Some(cause) if stepRes.outcome.isRight =>
+                                      ZIO.succeed(StepResult(step, Left(cause)))
+                                    case _ => ZIO.succeed(stepRes)
+                                  }
+                      } yield merged
                   }
         endNanos <- nowNanos
         duration  = (endNanos - startNanos) / 1_000_000L

--- a/core/src/test/scala/zio/bdd/core/RetryTagsSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/RetryTagsSpec.scala
@@ -83,6 +83,54 @@ object RetryTagsSpec extends ZIOSpecDefault {
     Then("it is done")(ZIO.unit)
   }
 
+  /**
+   * The `When` step raises an interrupt-only `Cause` (the shape produced when a
+   * step is cancelled), without globally interrupting the run fiber — so the
+   * executor's handling of `Cause.Interrupt` is exercised deterministically.
+   */
+  class InterruptRaisingSteps(val attempts: AtomicInteger) extends ZIOSteps[Any, St] with DefaultTypedExtractor {
+    Given("a system")(ScenarioContext.update(_ => St()))
+    When("the interrupted action runs") {
+      ZIO.succeed(attempts.incrementAndGet()) *> ZIO.failCause(Cause.interrupt(zio.FiberId.None))
+    }
+    Then("it is done")(ZIO.unit)
+  }
+
+  /** A `beforeScenario` hook that raises an interrupt-only cause. */
+  class InterruptBeforeScenarioSteps(val hookRuns: AtomicInteger) extends ZIOSteps[Any, St] with DefaultTypedExtractor {
+    beforeScenario { (_: ScenarioMetadata) =>
+      ZIO.succeed(hookRuns.incrementAndGet()) *> ZIO.failCause(Cause.interrupt(zio.FiberId.None))
+    }
+    Given("a system")(ScenarioContext.update(_ => St()))
+    When("a step")(ZIO.unit)
+    Then("it is done")(ZIO.unit)
+  }
+
+  /**
+   * A `beforeStep` hook that raises an interrupt-only cause on the first step.
+   */
+  class InterruptBeforeStepSteps(val hookRuns: AtomicInteger) extends ZIOSteps[Any, St] with DefaultTypedExtractor {
+    beforeStep { (_: StepMetadata) =>
+      ZIO.succeed(hookRuns.incrementAndGet()) *> ZIO.failCause(Cause.interrupt(zio.FiberId.None))
+    }
+    Given("a system")(ScenarioContext.update(_ => St()))
+    When("a step")(ZIO.unit)
+    Then("it is done")(ZIO.unit)
+  }
+
+  /**
+   * An `afterStep` hook that raises an interrupt-only cause after the first
+   * (passing) step.
+   */
+  class InterruptAfterStepSteps(val hookRuns: AtomicInteger) extends ZIOSteps[Any, St] with DefaultTypedExtractor {
+    afterStep { (_: StepMetadata) =>
+      ZIO.succeed(hookRuns.incrementAndGet()) *> ZIO.failCause(Cause.interrupt(zio.FiberId.None))
+    }
+    Given("a system")(ScenarioContext.update(_ => St()))
+    When("a step")(ZIO.unit)
+    Then("it is done")(ZIO.unit)
+  }
+
   private val F = "retry.feature"
 
   private def run(content: String)(using steps: ZIOSteps[Any, St]) =
@@ -230,5 +278,46 @@ object RetryTagsSpec extends ZIOSpecDefault {
     }
   )
 
-  def spec = suite("RetryTagsSpec")(parsing, semantics, overrideAndInteractions)
+  // ── Interruption (issue #230) ───────────────────────────────────────────────
+  private val interruption = suite("interruption vs failure (#230)")(
+    test("an interrupted step propagates interruption instead of completing as a failed scenario (AC1)") {
+      val attempts                   = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new InterruptRaisingSteps(attempts)
+      run(scenario("# no tag", when = "the interrupted action runs")).exit.map { exit =>
+        // Unfixed: the interrupt is recorded as a failed step, so the run completes (Success).
+        assertTrue(exit.isInterrupted, attempts.get() == 1)
+      }
+    },
+    test("@retry(n) does NOT re-run an interrupted scenario — cancellation is honored (AC2)") {
+      val attempts                   = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new InterruptRaisingSteps(attempts)
+      run(scenario("@retry(3)", when = "the interrupted action runs")).exit.map { exit =>
+        // Unfixed: interrupt → failed attempt → retried 3×. Fixed: propagates on the first attempt.
+        assertTrue(exit.isInterrupted, attempts.get() == 1)
+      }
+    },
+    test("an interrupted beforeScenario hook propagates and is not retried") {
+      val hookRuns                   = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new InterruptBeforeScenarioSteps(hookRuns)
+      run(scenario("@retry(3)", when = "a step")).exit.map { exit =>
+        assertTrue(exit.isInterrupted, hookRuns.get() == 1)
+      }
+    },
+    test("an interrupted beforeStep hook propagates and is not retried") {
+      val hookRuns                   = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new InterruptBeforeStepSteps(hookRuns)
+      run(scenario("@retry(3)", when = "a step")).exit.map { exit =>
+        assertTrue(exit.isInterrupted, hookRuns.get() == 1)
+      }
+    },
+    test("an interrupted afterStep hook propagates and is not retried") {
+      val hookRuns                   = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new InterruptAfterStepSteps(hookRuns)
+      run(scenario("@retry(3)", when = "a step")).exit.map { exit =>
+        assertTrue(exit.isInterrupted, hookRuns.get() == 1)
+      }
+    }
+  )
+
+  def spec = suite("RetryTagsSpec")(parsing, semantics, overrideAndInteractions, interruption)
 }


### PR DESCRIPTION
ScenarioExecutor converted any Cause — including a pure interruption — into a failed StepResult/setupError, so with the retry tags (@retry/@flaky/@nonFlaky) a cancelled scenario was re-run up to n times instead of honoring cancellation.

Fix: at the step body and all three hook sites (beforeScenario, beforeStep, afterStep), an interrupt-only Cause (cause.isInterruptedOnly) now re-raises via ZIO.failCause(cause.stripFailures), propagating interruption through the retry loop's flatMap so it stops. A per-step stepTimeout surfaces as a StepTimeoutException (typed failure), so it stays a normal retryable failed step. afterScenario teardown still runs on interruption via .ensuring. 5 new interruption tests.

Closes #230