### PR TITLE
@expectedFailure / @failing scenario tag

### DIFF
--- a/core/src/main/scala/zio/bdd/core/Result.scala
+++ b/core/src/main/scala/zio/bdd/core/Result.scala
@@ -68,11 +68,36 @@ case class ScenarioResult(
    * How many times the scenario ran. 1 unless a retry aspect
    * (@retry/@flaky/@nonFlaky) applied.
    */
-  attempts: Int = 1
+  attempts: Int = 1,
+  /**
+   * True when the scenario carried `@expectedFailure`/`@failing`: its raw
+   * outcome is inverted — a raw failure is an expected (passing) result, and a
+   * raw pass is an "unexpectedly passing" failure.
+   */
+  expectedFailure: Boolean = false
 ):
-  def isPassed: Boolean   = stepResults.forall(r => r.isPassed || r.isSkipped) && setupError.isEmpty
+  // The scenario body outcome (every step passed or was skipped), ignoring setup.
+  private def bodyPassed: Boolean = stepResults.forall(r => r.isPassed || r.isSkipped)
+  private def rawPassed: Boolean  = bodyPassed && setupError.isEmpty
+
   def isIgnored: Boolean  = scenario.isIgnored
   def hasPending: Boolean = stepResults.exists(_.isPending)
+
+  // The @expectedFailure inversion applies only to a BODY that ran to a definitive pass/fail with
+  // setup succeeding. A setup/infra failure (a failing beforeScenario hook, bad env) is always a
+  // real failure, and a PENDING (unimplemented) step is surfaced as PENDING — neither is masked
+  // green by the tag.
+  private def inverts: Boolean = expectedFailure && setupError.isEmpty && !hasPending
+
+  def isPassed: Boolean = if (inverts) !bodyPassed else rawPassed
+
+  /**
+   * `@expectedFailure` scenario whose body failed as expected (a green result).
+   */
+  def isExpectedFailure: Boolean = inverts && !bodyPassed
+
+  /** `@expectedFailure` scenario whose body unexpectedly passed (a failure). */
+  def isUnexpectedlyPassing: Boolean = inverts && bodyPassed
 
   /**
    * A scenario is "complete" (does not block the build) if it is passed,
@@ -81,9 +106,11 @@ case class ScenarioResult(
   def isComplete: Boolean = isPassed || isIgnored || (hasPending && !hasFailure)
 
   def hasFailure: Boolean =
-    setupError.isDefined || stepResults.exists(r =>
-      r.status.isInstanceOf[StepStatus.Failed] || r.status.isInstanceOf[StepStatus.TimedOut]
-    )
+    if (inverts) isUnexpectedlyPassing
+    else
+      setupError.isDefined || stepResults.exists(r =>
+        r.status.isInstanceOf[StepStatus.Failed] || r.status.isInstanceOf[StepStatus.TimedOut]
+      )
 
   def error: Option[Throwable] =
     setupError.flatMap(_.failureOption).orElse(stepResults.find(!_.isPassed).flatMap(_.error))

--- a/core/src/main/scala/zio/bdd/core/ScenarioAspect.scala
+++ b/core/src/main/scala/zio/bdd/core/ScenarioAspect.scala
@@ -1,19 +1,22 @@
 package zio.bdd.core
 
 /**
- * A scenario-level retry policy, applied either via a Gherkin tag (`@retry(n)`
- * / `@flaky(n)` / `@nonFlaky(n)`) or the code-side `ZIOSteps.scenarioAspects`
- * override.
+ * A scenario-level aspect, applied either via a Gherkin tag or the code-side
+ * `ZIOSteps.scenarioAspects` override.
  *
  *   - [[Retry]] / [[Flaky]]: run up to `n` attempts, passing on the first
  *     success.
  *   - [[NonFlaky]]: run up to `n` attempts, failing fast on the first failure
  *     (passes only if every attempt passes).
+ *   - [[ExpectedFailure]]: the scenario is known to fail — its outcome is
+ *     inverted (a failure passes; an unexpected pass fails). Takes precedence
+ *     over the retry aspects, so the body runs once.
  */
 enum ScenarioAspect:
   case Retry(n: Int)
   case Flaky(n: Int)
   case NonFlaky(n: Int)
+  case ExpectedFailure
 
 object ScenarioAspect:
   // Matches `retry(3)` / `flaky(5)` / `nonFlaky(2)`, case-insensitive on the name.
@@ -21,18 +24,21 @@ object ScenarioAspect:
 
   /**
    * Parse a single tag (with or without a leading `@`). `n` is clamped to `>=
-   * 1`.
+   * 1`. `@expectedFailure` / `@failing` map to [[ExpectedFailure]].
    */
   def fromTag(tag: String): Option[ScenarioAspect] =
-    pattern.findFirstMatchIn(tag.trim.stripPrefix("@")).flatMap { m =>
-      m.group(2).toIntOption.map(_.max(1)).flatMap { n =>
-        m.group(1).toLowerCase match
-          case "retry"    => Some(Retry(n))
-          case "flaky"    => Some(Flaky(n))
-          case "nonflaky" => Some(NonFlaky(n))
-          case _          => None
+    val t = tag.trim.stripPrefix("@")
+    if (t.equalsIgnoreCase("expectedFailure") || t.equalsIgnoreCase("failing")) Some(ExpectedFailure)
+    else
+      pattern.findFirstMatchIn(t).flatMap { m =>
+        m.group(2).toIntOption.map(_.max(1)).flatMap { n =>
+          m.group(1).toLowerCase match
+            case "retry"    => Some(Retry(n))
+            case "flaky"    => Some(Flaky(n))
+            case "nonflaky" => Some(NonFlaky(n))
+            case _          => None
+        }
       }
-    }
 
   /** The first retry aspect found among the scenario's tags, if any. */
   def fromTags(tags: List[String]): Option[ScenarioAspect] =

--- a/core/src/main/scala/zio/bdd/core/ScenarioExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/ScenarioExecutor.scala
@@ -23,17 +23,29 @@ object ScenarioExecutor {
       ZIO.succeed(ScenarioResult(scenario, Nil, setupError = None))
     } else {
       val attempt = runAttempt[R, S](scenario, suite, dryRun, flagValues, stepTimeout)
-      resolveAspect(scenario, suite) match {
-        case None                             => attempt
-        case Some(ScenarioAspect.Retry(n))    => runUntilPass(n, attempt)
-        case Some(ScenarioAspect.Flaky(n))    => runUntilPass(n, attempt)
-        case Some(ScenarioAspect.NonFlaky(n)) => runUntilFail(n, attempt)
-      }
+      val aspects = resolveAspects(scenario, suite)
+      // In dry-run only step *wiring* is validated (every step trivially passes), so the
+      // @expectedFailure inversion must not turn that into an "unexpectedly passing" failure.
+      if (!dryRun && aspects.contains(ScenarioAspect.ExpectedFailure))
+        // @expectedFailure wins over retry: run once and invert the outcome.
+        attempt.map(_.copy(expectedFailure = true))
+      else
+        retryAspectOf(aspects) match {
+          case Some(ScenarioAspect.Retry(n))    => runUntilPass(n, attempt)
+          case Some(ScenarioAspect.Flaky(n))    => runUntilPass(n, attempt)
+          case Some(ScenarioAspect.NonFlaky(n)) => runUntilFail(n, attempt)
+          case _                                => attempt
+        }
     }
 
-  // A scenario tag wins over the code-side `scenarioAspects` map.
-  private def resolveAspect[R, S](scenario: Scenario, suite: ZIOSteps[R, S]): Option[ScenarioAspect] =
-    ScenarioAspect.fromTags(scenario.tags).orElse(suite.scenarioAspects.get(scenario.name))
+  // All aspects on the scenario: from tags plus the code-side `scenarioAspects` map.
+  private def resolveAspects[R, S](scenario: Scenario, suite: ZIOSteps[R, S]): List[ScenarioAspect] =
+    (scenario.tags.flatMap(ScenarioAspect.fromTag) ++ suite.scenarioAspects.get(scenario.name).toList).distinct
+
+  private def retryAspectOf(aspects: List[ScenarioAspect]): Option[ScenarioAspect] =
+    aspects.collectFirst { case a @ (ScenarioAspect.Retry(_) | ScenarioAspect.Flaky(_) | ScenarioAspect.NonFlaky(_)) =>
+      a
+    }
 
   // @retry / @flaky: re-run up to n times, stopping at the first passing result.
   private def runUntilPass[Env](

--- a/core/src/main/scala/zio/bdd/core/report/PrettyReporter.scala
+++ b/core/src/main/scala/zio/bdd/core/report/PrettyReporter.scala
@@ -146,6 +146,8 @@ object StatusColor:
 
   given StatusColor[ScenarioResult] = from { sc =>
     if (sc.isIgnored) Style(Color.Gray, "◑")
+    else if (sc.isUnexpectedlyPassing) Style(Color.Red, "✗") // expected to fail, but passed
+    else if (sc.isExpectedFailure) Style(Color.Gray, "✓")    // known failure — expected, not red
     else if (sc.hasPending && !sc.hasFailure) Style(Color.Orange, "◑")
     else if (sc.isPassed) Style(Color.Blue, "✓") // sky blue — scenario-level pass
     else Style(Color.Red, "✗")
@@ -291,7 +293,12 @@ object ScenarioCounts:
     if (f.isIgnored) ScenarioCounts(0, 0, f.scenarioResults.size, 0)
     else
       f.scenarioResults.foldLeft(zero) { (acc, sc) =>
+        // Mirror statusText/StatusColor ordering so the summary agrees with the tree: the
+        // expected-failure states are resolved before PENDING (an xfail scenario may also contain
+        // a pending step, but it must count as passed/failed, not pending).
         if (sc.isIgnored) acc.copy(ignored = acc.ignored + 1)
+        else if (sc.isUnexpectedlyPassing) acc.copy(failed = acc.failed + 1)
+        else if (sc.isExpectedFailure) acc.copy(passed = acc.passed + 1)
         else if (sc.hasPending && !sc.hasFailure) acc.copy(pending = acc.pending + 1)
         else if (sc.isPassed) acc.copy(passed = acc.passed + 1)
         else acc.copy(failed = acc.failed + 1)
@@ -473,6 +480,8 @@ object DocBuilder:
 
   private def statusText(sc: ScenarioResult): String =
     if (sc.isIgnored) "IGNORED"
+    else if (sc.isUnexpectedlyPassing) "UNEXPECTEDLY PASSED"
+    else if (sc.isExpectedFailure) "XFAIL (expected)"
     else if (sc.hasPending && !sc.hasFailure) "PENDING"
     else if (sc.isPassed) "PASSED"
     else "FAILED"

--- a/core/src/test/scala/zio/bdd/core/ExpectedFailureSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/ExpectedFailureSpec.scala
@@ -1,0 +1,178 @@
+package zio.bdd.core
+
+import zio.*
+import zio.test.*
+import zio.bdd.gherkin.*
+import zio.bdd.core.step.{ZIOSteps, DefaultTypedExtractor}
+import zio.bdd.core.report.*
+import zio.schema.{DeriveSchema, Schema}
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Gate for issue #232 — the `@expectedFailure` / `@failing` scenario tag, which
+ * inverts a scenario's effective outcome.
+ */
+object ExpectedFailureSpec extends ZIOSpecDefault {
+
+  case class St(x: Int = 0)
+  given Schema[St] = DeriveSchema.gen[St]
+
+  /**
+   * `When` step passes or fails per `pass`; counts executions across attempts.
+   */
+  class OutcomeSteps(pass: Boolean, val counter: AtomicInteger, val aspects: Map[String, ScenarioAspect] = Map.empty)
+      extends ZIOSteps[Any, St]
+      with DefaultTypedExtractor {
+    override def scenarioAspects: Map[String, ScenarioAspect] = aspects
+    Given("a system")(ScenarioContext.update(_ => St()))
+    When("the action runs") {
+      ZIO.succeed(counter.incrementAndGet()) *> (if (pass) ZIO.unit else ZIO.fail(new RuntimeException("boom")))
+    }
+    Then("it is done")(ZIO.unit)
+  }
+
+  /** A `beforeScenario` hook that dies — an infrastructure/setup failure. */
+  class FailingSetupSteps extends ZIOSteps[Any, St] with DefaultTypedExtractor {
+    beforeScenario((_: ScenarioMetadata) => ZIO.die(new RuntimeException("infra down")))
+    Given("a system")(ScenarioContext.update(_ => St()))
+    When("the action runs")(ZIO.unit)
+    Then("it is done")(ZIO.unit)
+  }
+
+  /** A step marked pending (unimplemented). */
+  class PendingSteps extends ZIOSteps[Any, St] with DefaultTypedExtractor {
+    Given("a system")(ScenarioContext.update(_ => St()))
+    When("the action runs")(pending("not implemented"))
+    Then("it is done")(ZIO.unit)
+  }
+
+  private def run(content: String, dryRun: Boolean = false)(using steps: ZIOSteps[Any, St]) =
+    GherkinParser.parseFeature(content, "xf.feature").flatMap { feature =>
+      FeatureExecutor.executeFeatures[Any, St](List(feature), steps.getSteps, steps, dryRun = dryRun)
+    }
+
+  private def scenario(tag: String): String =
+    s"""Feature: XF
+       |  $tag
+       |  Scenario: known bug
+       |    Given a system
+       |    When the action runs
+       |    Then it is done
+       |""".stripMargin
+
+  private def scResult(content: String)(using steps: ZIOSteps[Any, St]): ZIO[Any, Throwable, ScenarioResult] =
+    run(content).map(_.head.scenarioResults.head)
+
+  // ── Parsing (AC1) ───────────────────────────────────────────────────────────
+  private val parsing = suite("ScenarioAspect parsing (AC1)")(
+    test("parses @expectedFailure and @failing, case-insensitively") {
+      assertTrue(
+        ScenarioAspect.fromTag("expectedFailure").contains(ScenarioAspect.ExpectedFailure),
+        ScenarioAspect.fromTag("@failing").contains(ScenarioAspect.ExpectedFailure),
+        ScenarioAspect.fromTag("EXPECTEDFAILURE").contains(ScenarioAspect.ExpectedFailure),
+        ScenarioAspect.fromTag("smoke").isEmpty
+      )
+    }
+  )
+
+  // ── Outcome inversion (AC2, AC3) ────────────────────────────────────────────
+  private val inversion = suite("outcome inversion (AC2, AC3)")(
+    test("a failing body under @expectedFailure is an expected (passing) failure") {
+      given steps: ZIOSteps[Any, St] = new OutcomeSteps(pass = false, new AtomicInteger(0))
+      scResult(scenario("@expectedFailure")).map { sc =>
+        assertTrue(sc.isPassed, sc.isExpectedFailure, !sc.hasFailure, !sc.isUnexpectedlyPassing)
+      }
+    },
+    test("a passing body under @expectedFailure is an unexpectedly-passing failure") {
+      given steps: ZIOSteps[Any, St] = new OutcomeSteps(pass = true, new AtomicInteger(0))
+      scResult(scenario("@expectedFailure")).map { sc =>
+        assertTrue(!sc.isPassed, sc.isUnexpectedlyPassing, sc.hasFailure, !sc.isExpectedFailure)
+      }
+    },
+    test("@failing alias behaves the same") {
+      given steps: ZIOSteps[Any, St] = new OutcomeSteps(pass = false, new AtomicInteger(0))
+      scResult(scenario("@failing")).map(sc => assertTrue(sc.isPassed, sc.isExpectedFailure))
+    },
+    test("the inversion reaches the build gate: XFAIL → feature passes, XPASS → feature fails") {
+      for
+        xf <- run(scenario("@expectedFailure"))(using new OutcomeSteps(pass = false, new AtomicInteger(0)))
+        xp <- run(scenario("@expectedFailure"))(using new OutcomeSteps(pass = true, new AtomicInteger(0)))
+      yield assertTrue(xf.head.isPassed, xf.head.isComplete, !xp.head.isPassed, !xp.head.isComplete)
+    }
+  )
+
+  // ── Code-side + interactions (AC4) ──────────────────────────────────────────
+  private val interactions = suite("code-side + interactions (AC4)")(
+    test("code-side scenarioAspects ExpectedFailure applies without a tag") {
+      given steps: ZIOSteps[Any, St] =
+        new OutcomeSteps(
+          pass = false,
+          new AtomicInteger(0),
+          aspects = Map("known bug" -> ScenarioAspect.ExpectedFailure)
+        )
+      scResult(scenario("# none")).map(sc => assertTrue(sc.isPassed, sc.isExpectedFailure))
+    },
+    test("@ignore wins over @expectedFailure — the scenario is not run") {
+      val counter                    = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new OutcomeSteps(pass = false, counter)
+      scResult(scenario("@ignore @expectedFailure")).map(sc => assertTrue(sc.isIgnored, counter.get() == 0))
+    },
+    test("@expectedFailure takes precedence over a retry tag — the body runs once") {
+      val counter                    = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new OutcomeSteps(pass = false, counter)
+      scResult(scenario("@expectedFailure @retry(3)")).map { sc =>
+        assertTrue(sc.isExpectedFailure, sc.attempts == 1, counter.get() == 1)
+      }
+    },
+    test("@expectedFailure takes precedence over @flaky too") {
+      val counter                    = new AtomicInteger(0)
+      given steps: ZIOSteps[Any, St] = new OutcomeSteps(pass = false, counter)
+      scResult(scenario("@expectedFailure @flaky(3)")).map(sc => assertTrue(sc.isExpectedFailure, sc.attempts == 1))
+    },
+    test("a SETUP failure under @expectedFailure is a real failure, not masked green") {
+      given steps: ZIOSteps[Any, St] = new FailingSetupSteps
+      scResult(scenario("@expectedFailure")).map { sc =>
+        assertTrue(!sc.isPassed, sc.hasFailure, !sc.isExpectedFailure, !sc.isUnexpectedlyPassing)
+      }
+    },
+    test("--dry-run does not turn @expectedFailure into an unexpectedly-passing failure") {
+      given steps: ZIOSteps[Any, St] = new OutcomeSteps(pass = false, new AtomicInteger(0))
+      run(scenario("@expectedFailure"), dryRun = true).map { fr =>
+        val sc = fr.head.scenarioResults.head
+        assertTrue(sc.isPassed, !sc.isUnexpectedlyPassing, fr.head.isPassed)
+      }
+    },
+    test("a PENDING step under @expectedFailure stays PENDING, not absorbed as XFAIL") {
+      given steps: ZIOSteps[Any, St] = new PendingSteps
+      scResult(scenario("@expectedFailure")).map { sc =>
+        assertTrue(sc.hasPending, !sc.isExpectedFailure, !sc.hasFailure, sc.isComplete, !sc.isUnexpectedlyPassing)
+      }
+    }
+  )
+
+  // ── Reporter states (AC5) ───────────────────────────────────────────────────
+  private val reporter = suite("reporter surfaces the states (AC5)")(
+    test("an expected failure renders as XFAIL, not red or a plain pass") {
+      given steps: ZIOSteps[Any, St] = new OutcomeSteps(pass = false, new AtomicInteger(0))
+      scResult(scenario("@expectedFailure")).map { sc =>
+        val header = DocBuilder.scenarioBranch(sc, isLast = true, featureIgnored = false, _ => CollectedLogs()) match
+          case Doc.Branch(h, _, _) => h.text
+          case _                   => ""
+        val color = summon[StatusColor[ScenarioResult]].style(sc).color
+        assertTrue(header.toUpperCase.contains("XFAIL"), color != Color.Red)
+      }
+    },
+    test("an unexpectedly-passing scenario renders as a red failure") {
+      given steps: ZIOSteps[Any, St] = new OutcomeSteps(pass = true, new AtomicInteger(0))
+      scResult(scenario("@expectedFailure")).map { sc =>
+        val header = DocBuilder.scenarioBranch(sc, isLast = true, featureIgnored = false, _ => CollectedLogs()) match
+          case Doc.Branch(h, _, _) => h.text
+          case _                   => ""
+        val color = summon[StatusColor[ScenarioResult]].style(sc).color
+        assertTrue(header.toUpperCase.contains("UNEXPECTEDLY"), color == Color.Red)
+      }
+    }
+  )
+
+  def spec = suite("ExpectedFailureSpec")(parsing, inversion, interactions, reporter)
+}

--- a/docs/running.md
+++ b/docs/running.md
@@ -433,6 +433,38 @@ override def scenarioAspects: Map[String, ScenarioAspect] =
 
 ---
 
+## Expected-failure scenarios
+
+Mark a scenario that is *known* to fail (a pending fix, a known bug) with `@expectedFailure`
+(alias `@failing`) so CI reads it as an expected failure rather than a red build — while still
+running the body, so the tag can't silently rot.
+
+```gherkin
+@expectedFailure
+Scenario: refunds are not yet prorated
+  Given a partial refund is requested
+  When the refund is issued
+  Then the prorated amount is returned   # currently fails — tracked in #NNN
+```
+
+- If the body **fails**, the scenario is reported as **`XFAIL (expected)`** and does **not** fail
+  the build. If the body **passes**, it is reported as **`UNEXPECTEDLY PASSED`** and **does** fail
+  the build — so once the underlying bug is fixed you're told to remove the tag.
+- Distinct from `pending` (an *unimplemented* step): `@expectedFailure` expects the body to run and
+  fail.
+- Available in code via the `scenarioAspects` map: `Map("scenario name" -> ScenarioAspect.ExpectedFailure)`.
+- **Only the scenario body is inverted.** A *setup* failure (a failing `beforeScenario` hook, a
+  broken environment) is always a real failure — `@expectedFailure` never masks infrastructure
+  breakage as an expected failure.
+- **Interactions:** `@ignore` wins (an ignored scenario never runs). `@expectedFailure` takes
+  precedence over the retry tags — a scenario marked `@expectedFailure` runs **once** (retrying a
+  known failure is contradictory). Under `--dry-run` the inversion is skipped (dry-run only
+  validates step wiring). It is a scenario-level tag and is **not** applied to `@property`
+  scenarios (which have their own execution path). `ScenarioResult` exposes `isExpectedFailure` /
+  `isUnexpectedlyPassing` for custom reporters.
+
+---
+
 
 ## IDE integration
 


### PR DESCRIPTION
Adds the `@expectedFailure` (alias `@failing`) scenario tag: a scenario known to fail is reported as `XFAIL (expected)` and does not fail the build; if it *unexpectedly passes* it reports `UNEXPECTEDLY PASSED` and fails the build (so the tag can't rot).

Only the scenario **body** is inverted — a setup/infra failure or a `pending` step is never masked green — and the inversion is skipped under `--dry-run`. `@ignore` wins; `@expectedFailure` takes precedence over the retry tags (runs once). Available in code via `ScenarioAspect.ExpectedFailure`; `ScenarioResult` exposes `isExpectedFailure`/`isUnexpectedlyPassing`. Pretty reporter surfaces both states. Docs in running.md; 14 new tests.

Closes #232
Part of #218 (combinator backlog). Milestone: none.