### PR TITLE
assertSatisfies(actual, desc)(pred) — named-predicate assertion

### DIFF
--- a/core/src/main/scala/zio/bdd/core/Assertions.scala
+++ b/core/src/main/scala/zio/bdd/core/Assertions.scala
@@ -52,6 +52,36 @@ object Assertions {
   ): ZIO[Any, Throwable, Unit] =
     evaluate(actual, assertion, message)
 
+  /**
+   * Assert that `actual` satisfies a named predicate — a concise shorthand over
+   * `assertZIO(value, Assertion.assertion("…")(…))`. On failure the message
+   * names both the `description` and the offending `actual` value.
+   *
+   * {{{
+   *   Then("the response id is a UUID") {
+   *     ScenarioContext.get.flatMap(s => assertSatisfies(s.id, "is a valid UUID")(isUuid))
+   *   }
+   * }}}
+   */
+  def assertSatisfies[A](actual: A, description: String)(pred: A => Boolean): ZIO[Any, Throwable, Unit] =
+    ZIO.attempt {
+      if (!pred(actual)) throw new AssertionError(s"expected $actual to satisfy: $description")
+    }
+
+  /**
+   * Effectful variant of [[assertSatisfies]]: the predicate returns a `ZIO[R,
+   * Throwable, Boolean]`. A predicate whose effect fails propagates that
+   * failure unchanged.
+   */
+  def assertSatisfiesZIO[R, A](actual: A, description: String)(
+    pred: A => ZIO[R, Throwable, Boolean]
+  ): ZIO[R, Throwable, Unit] =
+    // suspend so a predicate that throws *synchronously* (before returning its effect) becomes a
+    // typed failure rather than escaping as a defect — symmetric with assertSatisfies.
+    ZIO.suspend(pred(actual)).flatMap { ok =>
+      if (ok) ZIO.unit else ZIO.fail(new AssertionError(s"expected $actual to satisfy: $description"))
+    }
+
   def assertSome[A](actual: Option[A], message: String = "Expected Some, got None"): ZIO[Any, Throwable, Unit] =
     assertZIO(actual, isSome, message)
 

--- a/core/src/test/scala/zio/bdd/core/AssertSatisfiesSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/AssertSatisfiesSpec.scala
@@ -1,0 +1,57 @@
+package zio.bdd.core
+
+import zio.*
+import zio.test.*
+
+/** Gate for issue #233 — `assertSatisfies` / `assertSatisfiesZIO`. */
+object AssertSatisfiesSpec extends ZIOSpecDefault {
+
+  private def messageOf(exit: Exit[Throwable, Unit]): String =
+    exit match
+      case Exit.Failure(cause) => cause.failureOption.flatMap(t => Option(t.getMessage)).getOrElse("")
+      case Exit.Success(_)     => ""
+
+  def spec = suite("AssertSatisfiesSpec")(
+    suite("assertSatisfies (AC1, AC3)")(
+      test("passes when the predicate is true") {
+        Assertions.assertSatisfies(42, "is even")(_ % 2 == 0).exit.map(e => assertTrue(e.isSuccess))
+      },
+      test("fails when false, naming the description and the actual value") {
+        Assertions.assertSatisfies(41, "is even")(_ % 2 == 0).exit.map { e =>
+          val msg = messageOf(e)
+          assertTrue(e.isFailure, msg.contains("41"), msg.contains("is even"))
+        }
+      },
+      test("a throwing pure predicate surfaces as a typed failure, not a defect") {
+        Assertions.assertSatisfies(1, "probe")(_ => throw new RuntimeException("pred boom")).exit.map { e =>
+          // messageOf reads failureOption (typed only), so a non-empty message proves it's a Fail, not a Die.
+          assertTrue(e.isFailure, messageOf(e).contains("pred boom"))
+        }
+      }
+    ),
+    suite("assertSatisfiesZIO (AC2, AC3)")(
+      test("passes when the effectful predicate yields true") {
+        Assertions
+          .assertSatisfiesZIO("hello", "is non-empty")(s => ZIO.succeed(s.nonEmpty))
+          .exit
+          .map(e => assertTrue(e.isSuccess))
+      },
+      test("fails when the effectful predicate yields false, naming description + actual") {
+        Assertions.assertSatisfiesZIO("bob", "is at least 5 chars")(s => ZIO.succeed(s.length >= 5)).exit.map { e =>
+          val msg = messageOf(e)
+          assertTrue(e.isFailure, msg.contains("bob"), msg.contains("is at least 5 chars"))
+        }
+      },
+      test("propagates a failing predicate effect (not swallowed)") {
+        Assertions.assertSatisfiesZIO(1, "probe")(_ => ZIO.fail(new RuntimeException("probe boom"))).exit.map { e =>
+          assertTrue(e.isFailure, messageOf(e).contains("probe boom"))
+        }
+      },
+      test("a synchronously-throwing predicate surfaces as a typed failure, not a defect") {
+        Assertions.assertSatisfiesZIO(1, "probe")(_ => throw new RuntimeException("sync boom")).exit.map { e =>
+          assertTrue(e.isFailure, messageOf(e).contains("sync boom"))
+        }
+      }
+    )
+  )
+}

--- a/docs/step-dsl.md
+++ b/docs/step-dsl.md
@@ -841,3 +841,28 @@ final class ComposedChangeAssertion[R]:
 > `R & State[S]` / `.by[B](… A =:= B)` signatures that reads the same at call sites and infers
 > reliably.
 
+
+---
+
+## 16. Named-predicate assertions with `Assertions.assertSatisfies`
+
+A concise shorthand over `assertZIO(value, Assertion.assertion("…")(…))` — assert that a value
+satisfies a named predicate, with a failure message that reports both the description and the
+offending value.
+
+```scala
+Then("the response id is a UUID") {
+  ScenarioContext.get.flatMap(s => Assertions.assertSatisfies(s.id, "is a valid UUID")(isUuid))
+}
+```
+
+### API
+
+```scala
+Assertions.assertSatisfies[A](actual: A, description: String)(pred: A => Boolean): ZIO[Any, Throwable, Unit]
+Assertions.assertSatisfiesZIO[R, A](actual: A, description: String)(pred: A => ZIO[R, Throwable, Boolean]): ZIO[R, Throwable, Unit]
+```
+
+- On failure the message is `expected <actual> to satisfy: <description>`.
+- `assertSatisfiesZIO` takes an **effectful** predicate; if the predicate's effect fails, that
+  failure propagates unchanged (it is not turned into an assertion failure).


### PR DESCRIPTION
Adds `Assertions.assertSatisfies[A](actual, description)(pred: A => Boolean)` and `assertSatisfiesZIO[R, A](actual, description)(pred: A => ZIO[R, Throwable, Boolean])` — a named-predicate shorthand over `assertZIO(value, Assertion.assertion("…")(…))`.

On failure the message is `expected <actual> to satisfy: <description>`. A throwing predicate becomes a typed failure (the effectful variant suspends the predicate, symmetric with the pure one); a failing predicate *effect* propagates unchanged. Docs in step-dsl.md §16; 7 tests.

Closes #233
Part of #218 (combinator backlog). Milestone: none.