### PR TITLE
assertRaises[E](effect) { inspect } — inspect the caught exception

### DIFF
--- a/core/src/main/scala/zio/bdd/core/Assertions.scala
+++ b/core/src/main/scala/zio/bdd/core/Assertions.scala
@@ -45,6 +45,21 @@ object Assertions {
       case Right(_) => throw new AssertionError(message)
     }
 
+  /**
+   * Assert that `effect` raises an exception of type `E`, then run `inspect` on
+   * the caught exception — an upgrade over [[assertThrows]] (which only checks
+   * the type) for asserting on the exception's message, cause, or fields. The
+   * exception is caught whether it surfaces as a typed failure or a defect;
+   * interruption is not treated as a raised exception and propagates.
+   *
+   * {{{
+   *   Then("charging a declined card raises PaymentError") {
+   *     assertRaises[PaymentError](chargeDeclinedCard)(e => assertTrue(e.reason == "declined"))
+   *   }
+   * }}}
+   */
+  def assertRaises[E <: Throwable](using ct: ClassTag[E]): AssertRaises[E] = new AssertRaises[E](ct)
+
   def assertZIO[A](
     actual: A,
     assertion: Assertion[A],
@@ -428,6 +443,33 @@ final class MultipleAssertionError(val failures: List[String])
     extends AssertionError(
       s"${failures.length} assertion(s) failed:\n" + failures.mkString("  - ", "\n  - ", "")
     )
+
+/**
+ * Builder returned by [[Assertions.assertRaises]] so that only the exception
+ * type `E` is named explicitly while `R`/`A` are inferred from the effect.
+ */
+final class AssertRaises[E <: Throwable](private val ct: ClassTag[E]) {
+
+  def apply[R, A](effect: ZIO[R, Throwable, A], message: String = "")(
+    inspect: E => ZIO[Any, Throwable, Unit]
+  ): ZIO[R, Throwable, Unit] = {
+    given ClassTag[E] = ct
+    val prefix        = if (message.nonEmpty) message else s"Expected ${ct.runtimeClass.getSimpleName} to be raised"
+    effect.exit.flatMap {
+      case Exit.Success(_) =>
+        ZIO.fail(new AssertionError(s"$prefix, but no exception was thrown"))
+      case Exit.Failure(cause) =>
+        if (cause.isInterruptedOnly) ZIO.failCause(cause.stripFailures)
+        else
+          cause.failureOption.orElse(cause.dieOption) match {
+            case Some(e: E) => inspect(e)
+            case Some(other) =>
+              ZIO.fail(new AssertionError(s"$prefix, but a ${other.getClass.getName} was raised: ${other.getMessage}"))
+            case None => ZIO.fail(new AssertionError(s"$prefix, but no matchable exception was raised"))
+          }
+    }
+  }
+}
 
 /**
  * A deferred before/after change assertion built by

--- a/core/src/test/scala/zio/bdd/core/AssertRaisesSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/AssertRaisesSpec.scala
@@ -1,0 +1,82 @@
+package zio.bdd.core
+
+import zio.*
+import zio.test.*
+
+/** Gate for issue #234 — `assertRaises[E](effect) { inspect }`. */
+object AssertRaisesSpec extends ZIOSpecDefault {
+
+  class PaymentError(msg: String)             extends RuntimeException(msg)
+  final class NarrowPaymentError(msg: String) extends PaymentError(msg)
+  final class OtherError(msg: String)         extends RuntimeException(msg)
+
+  private def messageOf(exit: Exit[Throwable, Unit]): String =
+    exit match
+      case Exit.Failure(cause) => cause.failureOption.flatMap(t => Option(t.getMessage)).getOrElse("")
+      case Exit.Success(_)     => ""
+
+  def spec = suite("AssertRaisesSpec")(
+    test("passes when the effect fails with E and inspect succeeds (AC1)") {
+      Assertions
+        .assertRaises[PaymentError](ZIO.fail(new PaymentError("declined")))(e =>
+          Assertions.assertTrue(e.getMessage == "declined")
+        )
+        .exit
+        .map(e => assertTrue(e.isSuccess))
+    },
+    test("inspect can assert on the caught exception's message (AC3)") {
+      Assertions
+        .assertRaises[PaymentError](ZIO.fail(new PaymentError("card declined")))(e =>
+          Assertions.assertTrue(e.getMessage.contains("declined"), "message should mention declined")
+        )
+        .exit
+        .map(e => assertTrue(e.isSuccess))
+    },
+    test("fails when the effect succeeds — no exception thrown (AC2); default message names E") {
+      Assertions.assertRaises[PaymentError](ZIO.succeed(1))(_ => ZIO.unit).exit.map { e =>
+        val msg = messageOf(e)
+        assertTrue(e.isFailure, msg.toLowerCase.contains("no exception"), msg.contains("PaymentError"))
+      }
+    },
+    test("fails when the effect raises the wrong exception type (AC2)") {
+      Assertions.assertRaises[PaymentError](ZIO.fail(new OtherError("boom")))(_ => ZIO.unit).exit.map { e =>
+        assertTrue(e.isFailure, messageOf(e).contains("OtherError"))
+      }
+    },
+    test("fails when inspect fails (AC2)") {
+      Assertions
+        .assertRaises[PaymentError](ZIO.fail(new PaymentError("declined")))(_ =>
+          Assertions.assertTrue(false, "inspect deliberately fails")
+        )
+        .exit
+        .map(e => assertTrue(e.isFailure, messageOf(e).contains("inspect deliberately fails")))
+    },
+    test("catches an exception raised as a defect (die) too") {
+      Assertions
+        .assertRaises[PaymentError](ZIO.die(new PaymentError("thrown")))(e =>
+          Assertions.assertTrue(e.getMessage == "thrown")
+        )
+        .exit
+        .map(e => assertTrue(e.isSuccess))
+    },
+    test("accepts a subtype of E") {
+      Assertions
+        .assertRaises[PaymentError](ZIO.fail(new NarrowPaymentError("narrow")))(e =>
+          Assertions.assertTrue(e.getMessage == "narrow")
+        )
+        .exit
+        .map(e => assertTrue(e.isSuccess))
+    },
+    test("honours an explicit custom message") {
+      Assertions.assertRaises[PaymentError](ZIO.succeed(1), "custom expectation")(_ => ZIO.unit).exit.map { e =>
+        assertTrue(e.isFailure, messageOf(e).contains("custom expectation"))
+      }
+    },
+    test("interruption propagates — it is not treated as a raised exception") {
+      Assertions
+        .assertRaises[PaymentError](ZIO.failCause(Cause.interrupt(zio.FiberId.None)))(_ => ZIO.unit)
+        .exit
+        .map(e => assertTrue(e.isInterrupted))
+    }
+  )
+}

--- a/docs/step-dsl.md
+++ b/docs/step-dsl.md
@@ -866,3 +866,34 @@ Assertions.assertSatisfiesZIO[R, A](actual: A, description: String)(pred: A => Z
 - On failure the message is `expected <actual> to satisfy: <description>`.
 - `assertSatisfiesZIO` takes an **effectful** predicate; if the predicate's effect fails, that
   failure propagates unchanged (it is not turned into an assertion failure).
+
+---
+
+## 17. Inspecting a raised exception with `Assertions.assertRaises`
+
+An upgrade over `assertThrows` (which only checks the exception *type*): `assertRaises[E]` catches
+the exception raised by an effect and runs an inspection block on it, so you can assert on its
+message, cause, or fields.
+
+```scala
+Then("charging a declined card raises PaymentError") {
+  Assertions.assertRaises[PaymentError](chargeDeclinedCard) { e =>
+    Assertions.assertTrue(e.reason == "declined")
+  }
+}
+```
+
+### API
+
+```scala
+Assertions.assertRaises[E <: Throwable : ClassTag, R, A](
+  effect: ZIO[R, Throwable, A],
+  message: String = s"Expected <E> to be raised"
+)(inspect: E => ZIO[Any, Throwable, Unit]): ZIO[R, Throwable, Unit]
+```
+
+- **Passes** when `effect` raises an `E` and `inspect` succeeds. **Fails** when the effect succeeds
+  (nothing raised), raises a *different* type, or when `inspect` fails.
+- The exception is caught whether it surfaces as a typed failure or a defect; **interruption** is
+  not treated as a raised exception and propagates (cancellation is honored).
+- `inspect` is a `ZIO[Any, Throwable, Unit]`, so it composes with the other `assert*` helpers.


### PR DESCRIPTION
Adds `Assertions.assertRaises[E](effect)(inspect)` — an upgrade over `assertThrows` that catches the exception raised by an effect and runs an inspection block on it (assert on message/cause/fields).

Passes when the effect raises an `E` and `inspect` succeeds; fails when it succeeds, raises a different type, or `inspect` fails. Catches both a typed failure and a defect; interruption propagates (not treated as a raised exception). A type-parameter-holder builder keeps `E` the only explicit type argument. Docs in step-dsl.md §17; 9 tests.

Closes #234
Part of #218 (combinator backlog). Milestone: none.