### PR TITLE
poll(probe)(assertion) — retry with a foregrounded last-polled value

### DIFF
--- a/core/src/main/scala/zio/bdd/core/Assertions.scala
+++ b/core/src/main/scala/zio/bdd/core/Assertions.scala
@@ -244,6 +244,35 @@ object Assertions {
     eventually(fetch.flatMap(assertion), maxTime)
 
   /**
+   * Companion to [[eventually]] that separates the `probe` (run once per
+   * attempt) from the `assertion` (retried), re-probing every `interval` until
+   * the assertion holds or `maxTime` elapses. On timeout the last assertion
+   * failure is surfaced — annotated with the last polled value — rather than a
+   * generic "timed out".
+   *
+   * The wait stays interruptible, so an outer `stepTimeout` (or any enclosing
+   * timeout) is a hard cap; keep `maxTime` ≤ that timeout. Only typed failures
+   * are retried (same Fail/Die caveat as [[eventually]]).
+   *
+   * {{{
+   *   Then("the job eventually reports DONE") {
+   *     poll(fetchJobStatus)(status => assertEquals(status, "DONE"))
+   *   }
+   * }}}
+   */
+  def poll[R, A](
+    probe: ZIO[R, Throwable, A],
+    maxTime: Duration = 10.seconds,
+    interval: Duration = 200.millis
+  )(assertion: A => ZIO[Any, Throwable, Unit]): ZIO[R, Throwable, Unit] =
+    probe.flatMap { value =>
+      assertion(value).mapError { err =>
+        val detail = Option(err.getMessage).getOrElse(err.getClass.getName)
+        new AssertionError(s"poll assertion did not hold (last polled value: $value): $detail", err)
+      }
+    }.retry(Schedule.spaced(interval) && Schedule.upTo(maxTime))
+
+  /**
    * The inverse of [[eventually]]: assert that `condition` *stays* true for the
    * whole `duration`, re-probing every `interval`. Fails fast on the first
    * violation, surfacing that underlying failure — a transient breach that

--- a/core/src/test/scala/zio/bdd/core/PollSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/PollSpec.scala
@@ -1,0 +1,84 @@
+package zio.bdd.core
+
+import zio.*
+import zio.test.*
+
+/**
+ * Gate for issue #235 — the `poll` combinator. Timing tests use `withLiveClock`
+ * (ZIOSpecDefault runs on TestClock, under which schedule delays never
+ * advance); delays are kept small.
+ */
+object PollSpec extends ZIOSpecDefault {
+
+  private val fast: Duration = 10.millis
+
+  def spec = suite("PollSpec")(
+    test("retries probe + assertion until the assertion holds (AC1)") {
+      for
+        counter <- Ref.make(0)
+        probe    = counter.updateAndGet(_ + 1)
+        result <- Assertions.poll(probe, maxTime = 2.seconds, interval = fast)(n =>
+                    Assertions.assertTrue(n >= 3, s"only $n so far")
+                  )
+        got <- counter.get
+      yield assertTrue(got >= 3)
+    } @@ TestAspect.withLiveClock,
+    test("on timeout, surfaces the last assertion failure and the last polled value (AC2)") {
+      for exit <- Assertions
+                    .poll(ZIO.succeed("PENDING"), maxTime = 100.millis, interval = fast)(status =>
+                      Assertions.assertTrue(status == "DONE", s"status was $status")
+                    )
+                    .exit
+      yield exit match
+        case Exit.Failure(cause) =>
+          val msg = cause.failureOption.flatMap(t => Option(t.getMessage)).getOrElse("")
+          // last polled value + the assertion's own message, not a generic "timed out".
+          assertTrue(msg.contains("PENDING"), msg.contains("status was PENDING"))
+        case Exit.Success(_) => assertTrue(false)
+    } @@ TestAspect.withLiveClock,
+    test("retries using the default interval when only the probe + assertion are given (AC3)") {
+      for
+        counter <- Ref.make(0)
+        probe    = counter.updateAndGet(_ + 1)
+        _       <- Assertions.poll(probe, maxTime = 2.seconds)(n => Assertions.assertTrue(n >= 2, s"only $n"))
+        got     <- counter.get
+      yield assertTrue(got >= 2)
+    } @@ TestAspect.withLiveClock @@ TestAspect.timeout(30.seconds),
+    test("the surfaced message shows the LAST polled value, not a stale earlier one (AC2)") {
+      for
+        counter <- Ref.make(0)
+        probe    = counter.updateAndGet(_ + 1).map(n => s"v$n") // v1, v2, v3, …
+        exit <- Assertions
+                  .poll(probe, maxTime = 80.millis, interval = fast)(v => Assertions.assertTrue(v == "done", s"got $v"))
+                  .exit
+      yield exit match
+        case Exit.Failure(cause) =>
+          val msg = cause.failureOption.flatMap(t => Option(t.getMessage)).getOrElse("")
+          // the value keeps changing; the message must not still say v1.
+          assertTrue(msg.contains("last polled value"), !msg.contains("v1)"))
+        case Exit.Success(_) => assertTrue(false)
+    } @@ TestAspect.withLiveClock,
+    test("a probe that itself fails surfaces its own error on timeout (no last-value annotation)") {
+      for exit <-
+          Assertions
+            .poll(ZIO.fail(new RuntimeException("probe unavailable")), maxTime = 80.millis, interval = fast)(_ =>
+              ZIO.unit
+            )
+            .exit
+      yield exit match
+        case Exit.Failure(cause) =>
+          val msg = cause.failureOption.flatMap(t => Option(t.getMessage)).getOrElse("")
+          assertTrue(msg.contains("probe unavailable"), !msg.contains("last polled value"))
+        case Exit.Success(_) => assertTrue(false)
+    } @@ TestAspect.withLiveClock,
+    test("is interruptible — an outer timeout stops it well before maxTime (AC3)") {
+      for
+        start <- Clock.nanoTime
+        result <- Assertions
+                    .poll(ZIO.succeed(0), maxTime = 1.hour, interval = fast)(_ => Assertions.assertTrue(false, "never"))
+                    .timeout(150.millis)
+        elapsed <- Clock.nanoTime.map(_ - start)
+      yield assertTrue(result.isEmpty) && assertTrue(elapsed < 5.seconds.toNanos)
+    } @@ TestAspect.withLiveClock
+  )
+}

--- a/docs/step-dsl.md
+++ b/docs/step-dsl.md
@@ -897,3 +897,36 @@ Assertions.assertRaises[E <: Throwable : ClassTag, R, A](
 - The exception is caught whether it surfaces as a typed failure or a defect; **interruption** is
   not treated as a raised exception and propagates (cancellation is honored).
 - `inspect` is a `ZIO[Any, Throwable, Unit]`, so it composes with the other `assert*` helpers.
+
+---
+
+## 18. Polling a probe with `Assertions.poll`
+
+A companion to [`eventually`](#12-polling-with-assertionseventually--eventuallyassert) that
+separates the **probe** (run once per attempt) from the **assertion** (retried) — useful when the
+probe is expensive and you want the failure message to foreground the *last polled value*.
+
+```scala
+Then("the job eventually reports DONE") {
+  Assertions.poll(fetchJobStatus)(status => Assertions.assertEquals(status, "DONE"))
+}
+```
+
+### API
+
+```scala
+Assertions.poll[R, A](
+  probe: ZIO[R, Throwable, A],
+  maxTime: Duration = 10.seconds,
+  interval: Duration = 200.millis
+)(assertion: A => ZIO[Any, Throwable, Unit]): ZIO[R, Throwable, Unit]
+```
+
+- Re-probes every `interval` until the `assertion` holds or `maxTime` elapses.
+- **On timeout the last assertion failure is surfaced**, annotated with the last polled value
+  (`poll assertion did not hold (last polled value: …): …`) — not a generic "timed out".
+- Configurable `maxTime` and `interval` with sensible defaults. **Interruptible**, and respects the
+  enclosing `stepTimeout` — keep `maxTime` ≤ `stepTimeout`. Only typed failures are retried (same
+  Fail/Die caveat as `eventually`).
+- If the **probe itself** keeps failing (never yields a value), its own error is surfaced on
+  timeout — there is no last-polled-value annotation, since nothing was successfully polled.


### PR DESCRIPTION
Adds `Assertions.poll(probe, maxTime = 10.s, interval = 200.millis)(assertion)` — a companion to `eventually` that separates the probe (once per attempt) from the assertion (retried).

On timeout the last assertion failure is surfaced, annotated with the last polled value (`poll assertion did not hold (last polled value: …): …`), not a generic "timed out". A probe that itself keeps failing surfaces its own error. Interruptible; respects `stepTimeout`. Docs in step-dsl.md §18; 6 tests.

Closes #235
Part of #218 (combinator backlog). Milestone: none.