### PR TITLE
assertApproxEquals / shouldBeCloseTo — numeric approximate equality

### DIFF
--- a/core/src/main/scala/zio/bdd/core/Assertions.scala
+++ b/core/src/main/scala/zio/bdd/core/Assertions.scala
@@ -36,6 +36,39 @@ object Assertions {
   def assertEquals[A](actual: A, expected: A, message: String = "Values not equal"): ZIO[Any, Throwable, Unit] =
     evaluate(actual, equalTo(expected), s"$message: expected $expected, got $actual")
 
+  /**
+   * Assert that `actual` is within `delta` of `expected` — approximate equality
+   * for monetary / floating-point domains where exact `assertEquals` is the
+   * wrong tool. Passes when `abs(actual - expected) <= delta`. Works for any
+   * `Numeric` (`Double`, `BigDecimal`, …).
+   *
+   * {{{
+   *   Then("the total is about 19.99") {
+   *     ScenarioContext.get.flatMap(s => assertApproxEquals(s.total, 19.99, 0.01))
+   *   }
+   * }}}
+   */
+  def assertApproxEquals[A](actual: A, expected: A, delta: A, message: String = "")(using
+    num: Numeric[A]
+  ): ZIO[Any, Throwable, Unit] = {
+    val diff = num.abs(num.minus(actual, expected))
+    if (num.lteq(diff, delta)) ZIO.unit
+    else {
+      val prefix = if (message.nonEmpty) s"$message: " else ""
+      ZIO.fail(
+        new AssertionError(s"${prefix}expected $actual to be within $delta of $expected (difference was $diff)")
+      )
+    }
+  }
+
+  /**
+   * Fluent form of [[assertApproxEquals]]: `actual.shouldBeCloseTo(expected,
+   * delta)`.
+   */
+  extension [A: Numeric](actual: A)
+    def shouldBeCloseTo(expected: A, delta: A): ZIO[Any, Throwable, Unit] =
+      assertApproxEquals(actual, expected, delta)
+
   def assertThrows[E <: Throwable: ClassTag](
     zio: ZIO[Any, E, Any],
     message: String = "Expected exception not thrown"

--- a/core/src/test/scala/zio/bdd/core/ApproxEqualsSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/ApproxEqualsSpec.scala
@@ -1,0 +1,67 @@
+package zio.bdd.core
+
+import zio.*
+import zio.test.*
+import zio.bdd.core.Assertions.shouldBeCloseTo
+
+/** Gate for issue #236 — `assertApproxEquals` / `shouldBeCloseTo`. */
+object ApproxEqualsSpec extends ZIOSpecDefault {
+
+  private def messageOf(exit: Exit[Throwable, Unit]): String =
+    exit match
+      case Exit.Failure(cause) => cause.failureOption.flatMap(t => Option(t.getMessage)).getOrElse("")
+      case Exit.Success(_)     => ""
+
+  def spec = suite("ApproxEqualsSpec")(
+    suite("assertApproxEquals (AC1)")(
+      test("passes when the difference is within delta (Double)") {
+        Assertions.assertApproxEquals(1.0, 1.05, 0.1).exit.map(e => assertTrue(e.isSuccess))
+      },
+      test("passes at the exact boundary (diff == delta)") {
+        // 0.5 is exactly representable, so diff == delta holds precisely (avoids float boundary noise).
+        Assertions.assertApproxEquals(1.0, 1.5, 0.5).exit.map(e => assertTrue(e.isSuccess))
+      },
+      test("fails outside delta, showing actual, expected, delta and the difference") {
+        // Chosen so the difference (0.7) is a distinct string from actual/expected/delta, proving the
+        // "(difference was …)" clause is actually present.
+        Assertions.assertApproxEquals(1.0, 1.7, 0.1).exit.map { e =>
+          val msg = messageOf(e)
+          assertTrue(e.isFailure, msg.contains("1.0"), msg.contains("1.7"), msg.contains("0.1"), msg.contains("0.7"))
+        }
+      },
+      test("fails closed for NaN and for a negative delta") {
+        for
+          nan <- Assertions.assertApproxEquals(Double.NaN, 1.0, 0.1).exit
+          neg <- Assertions.assertApproxEquals(1.0, 1.0, -0.1).exit
+        yield assertTrue(nan.isFailure, neg.isFailure)
+      },
+      test("honours a custom message prefix") {
+        Assertions.assertApproxEquals(1.0, 2.0, 0.1, "balance drifted").exit.map { e =>
+          assertTrue(e.isFailure, messageOf(e).contains("balance drifted"))
+        }
+      }
+    ),
+    suite("shouldBeCloseTo (AC2)")(
+      test("fluent form passes within delta") {
+        1.0.shouldBeCloseTo(1.05, 0.1).exit.map(e => assertTrue(e.isSuccess))
+      },
+      test("fluent form fails outside delta") {
+        1.0.shouldBeCloseTo(2.0, 0.1).exit.map(e => assertTrue(e.isFailure))
+      }
+    ),
+    suite("non-Double Numeric (AC3)")(
+      test("works for BigDecimal within delta") {
+        Assertions
+          .assertApproxEquals(BigDecimal("1.00"), BigDecimal("1.02"), BigDecimal("0.05"))
+          .exit
+          .map(e => assertTrue(e.isSuccess))
+      },
+      test("works for BigDecimal outside delta") {
+        Assertions
+          .assertApproxEquals(BigDecimal("1.00"), BigDecimal("1.20"), BigDecimal("0.05"))
+          .exit
+          .map(e => assertTrue(e.isFailure))
+      }
+    )
+  )
+}

--- a/docs/step-dsl.md
+++ b/docs/step-dsl.md
@@ -930,3 +930,31 @@ Assertions.poll[R, A](
   Fail/Die caveat as `eventually`).
 - If the **probe itself** keeps failing (never yields a value), its own error is surfaced on
   timeout — there is no last-polled-value annotation, since nothing was successfully polled.
+
+---
+
+## 19. Approximate numeric equality with `Assertions.assertApproxEquals`
+
+For monetary / floating-point domains where exact `assertEquals` is the wrong tool, assert that a
+value is within a tolerance of the expected one. Works for any `Numeric` (`Double`, `BigDecimal`, …).
+
+```scala
+Then("the total is about 19.99") {
+  ScenarioContext.get.flatMap(s => Assertions.assertApproxEquals(s.total, 19.99, 0.01))
+}
+
+// fluent form (import Assertions.shouldBeCloseTo):
+Then("the rate is close to 3.5%") {
+  ScenarioContext.get.flatMap(s => s.rate.shouldBeCloseTo(0.035, 0.001))
+}
+```
+
+### API
+
+```scala
+Assertions.assertApproxEquals[A](actual: A, expected: A, delta: A, message: String = "")(using Numeric[A]): ZIO[Any, Throwable, Unit]
+extension [A: Numeric](actual: A) def shouldBeCloseTo(expected: A, delta: A): ZIO[Any, Throwable, Unit]
+```
+
+- Passes when `abs(actual - expected) <= delta` (the boundary is inclusive). On failure the message
+  shows the actual, expected, delta, and the observed difference.


### PR DESCRIPTION
Adds `Assertions.assertApproxEquals[A](actual, expected, delta, message = "")(using Numeric[A])` and a `shouldBeCloseTo` extension — approximate equality for monetary / floating-point domains.

Passes when `abs(actual - expected) <= delta` (inclusive boundary); the failure message shows actual/expected/delta/difference. Works for any `Numeric` (`Double`, `BigDecimal`); NaN and a negative delta fail closed. Docs in step-dsl.md §19; 9 tests.

Closes #236
Part of #218 (combinator backlog) — the final combinator; #218 becomes dischargeable once this merges. Milestone: none.