### PR TITLE
build: bump rift to v0.11.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ import java.security.MessageDigest
 // Single source of truth for the pinned Rift release (#195). Both the FFI natives (riftNativesVersion,
 // downloaded into the embedded-natives jar) and the container image tag (Rift.DefaultImage, via the
 // generated RiftBuildInfo below) derive from it, so a version bump touches exactly one line.
-val riftVersion        = "0.10.0"
+val riftVersion        = "0.11.0"
 val riftNativesVersion = riftVersion
 
 // The (os, arch, ext) cdylibs bundled into the natives jar — linux/macOS × x86_64/aarch64 (#134).

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
@@ -14,9 +14,9 @@ object RiftBuildInfoSpec extends ZIOSpecDefault:
   def spec = suite("RiftBuildInfo")(
     test("DefaultImage is derived from the single rift-version source of truth") {
       assertTrue(
-        RiftBuildInfo.riftVersion == "0.10.0",
+        RiftBuildInfo.riftVersion == "0.11.0",
         Rift.DefaultImage == s"zainalpour/rift-proxy:v${RiftBuildInfo.riftVersion}",
-        Rift.DefaultImage == "zainalpour/rift-proxy:v0.10.0"
+        Rift.DefaultImage == "zainalpour/rift-proxy:v0.11.0"
       )
     }
   )


### PR DESCRIPTION
Bumps the pinned Rift release from v0.10.0 to v0.11.0. `riftVersion` in build.sbt is the single source of truth (#195): the FFI natives version and `Rift.DefaultImage` (via generated `RiftBuildInfo`) both derive from it. Also updates `RiftBuildInfoSpec`'s pinned expectations to 0.11.0.

Verified locally: all four v0.11.0 native assets (linux/macOS × x86_64/aarch64) match their published sha256; `RiftBuildInfoSpec` passes with 0.11.0. CI runs the full embedded-FFM + container integration test against the real v0.11.0 release.