### PR TITLE
Embedded adapter: go entirely FFI — drop the loopback admin plane for scenario state + correlated spaces (rift#411)

### DIFF
--- a/rift-embedded/src/main/java/zio/bdd/mock/rift/embedded/RiftFfiBridge.java
+++ b/rift-embedded/src/main/java/zio/bdd/mock/rift/embedded/RiftFfiBridge.java
@@ -25,12 +25,14 @@ import java.nio.file.Path;
  * the identical source compiles and runs against both generations. Every variant needs
  * {@code --enable-native-access}.
  *
- * <p>Requires the C-ABI v2 (rift#343, first shipped in {@code librift_ffi} v0.9.0): the data plane
- * ({@code rift_start/stop/create_imposter/replace_stubs/recorded/free}) plus the in-process admin
- * plane ({@code rift_serve_admin}), per-imposter delete ({@code rift_delete_imposter}), build
- * identity ({@code rift_build_info}), and thread-local error text ({@code rift_last_error}). All
- * symbols are bound at {@link #start}, so a pre-v2 library fails fast there with a missing-symbol
- * error rather than degrading silently — zio-bdd pins the v2 natives and does not support older Rift.
+ * <p>Requires {@code librift_ffi} ≥ v0.11.0: the v2 data plane
+ * ({@code rift_start/stop/create_imposter/replace_stubs/recorded/free}) + in-process admin plane
+ * ({@code rift_serve_admin}) + per-imposter delete + build identity + thread-local error text
+ * (rift#343, v0.9.0), plus the admin long tail over direct C-ABI (rift#411, v0.11.0):
+ * {@code rift_flow_state_get/put} and {@code rift_space_add_stub/delete/recorded}, which let the
+ * adapter drive scenario state and correlated spaces with no loopback HTTP. All symbols are bound at
+ * {@link #start}, so a pre-v0.11.0 library fails fast there with a missing-symbol error rather than
+ * degrading silently — zio-bdd pins the matching natives and does not support older Rift.
  *
  * <p>Boundary discipline mirrors the crate: memory is created and freed on the same side (returned
  * {@code *mut c_char} buffers are handed straight back to {@code rift_free}; {@code rift_build_info}
@@ -88,6 +90,14 @@ public final class RiftFfiBridge implements AutoCloseable {
   private final MethodHandle buildInfo;
   private final MethodHandle lastError;
 
+  // v0.11.0 (rift#411): the admin long tail over direct C-ABI — scenario/flow state + correlated
+  // spaces — so the embedded adapter drives them with no loopback HTTP admin plane.
+  private final MethodHandle flowStateGet;
+  private final MethodHandle flowStatePut;
+  private final MethodHandle spaceAddStub;
+  private final MethodHandle spaceDelete;
+  private final MethodHandle spaceRecorded;
+
   private RiftFfiBridge(Arena arena, SymbolLookup lookup, MemorySegment handle) {
     this.arena = arena;
     this.handle = handle;
@@ -107,6 +117,19 @@ public final class RiftFfiBridge implements AutoCloseable {
     this.deleteImposter = downcall(lookup, "rift_delete_imposter",
         FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_SHORT));
     this.lastError = downcall(lookup, "rift_last_error", FunctionDescriptor.of(ValueLayout.ADDRESS));
+    // v0.11.0 symbols are mandatory too: binding them makes a pre-0.11.0 library fail fast at start
+    // (zio-bdd pins the matching natives, so the floor is honest).
+    this.flowStateGet = downcall(lookup, "rift_flow_state_get", FunctionDescriptor.of(
+        ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_SHORT, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+    this.flowStatePut = downcall(lookup, "rift_flow_state_put", FunctionDescriptor.of(
+        ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_SHORT, ValueLayout.ADDRESS, ValueLayout.ADDRESS,
+        ValueLayout.ADDRESS));
+    this.spaceAddStub = downcall(lookup, "rift_space_add_stub", FunctionDescriptor.of(
+        ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_SHORT, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+    this.spaceDelete = downcall(lookup, "rift_space_delete", FunctionDescriptor.of(
+        ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_SHORT, ValueLayout.ADDRESS));
+    this.spaceRecorded = downcall(lookup, "rift_space_recorded", FunctionDescriptor.of(
+        ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_SHORT, ValueLayout.ADDRESS));
   }
 
   /**
@@ -200,6 +223,64 @@ public final class RiftFfiBridge implements AutoCloseable {
       return (int) deleteImposter.invoke(handle, (short) port);
     } catch (Throwable t) {
       throw failure("rift_delete_imposter", t);
+    }
+  }
+
+  /**
+   * Get a scenario/flow-state value as JSON {@code {"flowId","key","value"}}, or {@code null} when
+   * the key is absent OR on error (the crate's {@code rift_last_error} distinguishes them). The native
+   * buffer is freed via {@code rift_free} before return.
+   */
+  public String flowStateGet(int port, String flowId, String key) {
+    try (Arena call = Arena.ofConfined()) {
+      MemorySegment result = (MemorySegment) flowStateGet.invoke(handle, (short) port,
+          (MemorySegment) ALLOC_STRING.invoke(call, flowId), (MemorySegment) ALLOC_STRING.invoke(call, key));
+      return readAndFree(result);
+    } catch (Throwable t) {
+      throw failure("rift_flow_state_get", t);
+    }
+  }
+
+  /** Set a scenario/flow-state value from a bare JSON value. Returns {@code 0} on success, {@code -1} on error. */
+  public int flowStatePut(int port, String flowId, String key, String valueJson) {
+    try (Arena call = Arena.ofConfined()) {
+      return (int) flowStatePut.invoke(handle, (short) port, (MemorySegment) ALLOC_STRING.invoke(call, flowId),
+          (MemorySegment) ALLOC_STRING.invoke(call, key), (MemorySegment) ALLOC_STRING.invoke(call, valueJson));
+    } catch (Throwable t) {
+      throw failure("rift_flow_state_put", t);
+    }
+  }
+
+  /** Register a stub scoped to {@code flowId} (its {@code space} is set from {@code flowId}). Returns {@code 0}/{@code -1}. */
+  public int spaceAddStub(int port, String flowId, String stubJson) {
+    try (Arena call = Arena.ofConfined()) {
+      return (int) spaceAddStub.invoke(handle, (short) port, (MemorySegment) ALLOC_STRING.invoke(call, flowId),
+          (MemorySegment) ALLOC_STRING.invoke(call, stubJson));
+    } catch (Throwable t) {
+      throw failure("rift_space_add_stub", t);
+    }
+  }
+
+  /** Tear down a space (its scoped stubs, recorded requests, scenario state). Returns {@code 0}/{@code -1}. */
+  public int spaceDelete(int port, String flowId) {
+    try (Arena call = Arena.ofConfined()) {
+      return (int) spaceDelete.invoke(handle, (short) port, (MemorySegment) ALLOC_STRING.invoke(call, flowId));
+    } catch (Throwable t) {
+      throw failure("rift_space_delete", t);
+    }
+  }
+
+  /**
+   * The requests recorded under {@code flowId} (header-filtered by the space's resolved flow id) as a
+   * JSON array string, or {@code null} on error. The native buffer is freed via {@code rift_free}.
+   */
+  public String spaceRecorded(int port, String flowId) {
+    try (Arena call = Arena.ofConfined()) {
+      MemorySegment result =
+          (MemorySegment) spaceRecorded.invoke(handle, (short) port, (MemorySegment) ALLOC_STRING.invoke(call, flowId));
+      return readAndFree(result);
+    } catch (Throwable t) {
+      throw failure("rift_space_recorded", t);
     }
   }
 

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedCorrelatedSpace.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedCorrelatedSpace.scala
@@ -1,0 +1,108 @@
+package zio.bdd.mock.rift.embedded
+
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.rift.RiftProtocol
+import zio.json.*
+import zio.json.ast.Json
+
+/**
+ * The Correlated-space wire ops (rift#223) over the embedded engine's direct
+ * C-ABI (rift#411) — the FFI-transport mirror of
+ * [[zio.bdd.mock.rift.RiftCorrelatedSpace]] (which the container adapter drives
+ * over HTTP). It builds the byte-identical Mountebank stub JSON via
+ * [[RiftProtocol]] and registers / tears it down through the space FFI
+ * downcalls, so wire fidelity is the same as the container adapter; only the
+ * transport differs (no loopback HTTP admin plane, #244).
+ *
+ * Pure functions of `(engine, port, flowId, …)` — no adapter state — mirroring
+ * `RiftCorrelatedSpace`'s shared-primitives pattern. Stub tracking (which
+ * rules/faults/extras are registered under a space) stays in
+ * [[EmbeddedRiftMockControl]]; only the wire calls live here.
+ */
+private[embedded] object EmbeddedCorrelatedSpace:
+
+  /** Add one portable rule's stub under `(port, flowId)`. */
+  def postStub(engine: EmbeddedEngine, port: Int, flowId: String, rule: MockRule): IO[MockError, Unit] =
+    engine.spaceAddStub(port, flowId, RiftProtocol.stub(rule).toJson)
+
+  /**
+   * Add one pre-built stub (a capability stub: script/proxy/template) under
+   * `(port, flowId)`.
+   */
+  def postRawStub(engine: EmbeddedEngine, port: Int, flowId: String, stub: Json): IO[MockError, Unit] =
+    engine.spaceAddStub(port, flowId, stub.toJson)
+
+  /** Add one fault stub under `(port, flowId)`. */
+  def postFaultStub(
+    engine: EmbeddedEngine,
+    port: Int,
+    flowId: String,
+    m: RequestMatch,
+    fault: FaultKind,
+    id: RuleId
+  ): IO[MockError, Unit] =
+    engine.spaceAddStub(port, flowId, RiftProtocol.faultStub(m, fault, id).toJson)
+
+  /** Register the tracked portable rules under `(port, flowId)`, in order. */
+  def registerStubs(
+    engine: EmbeddedEngine,
+    port: Int,
+    flowId: String,
+    rules: Vector[(RuleId, MockRule)]
+  ): IO[MockError, Unit] =
+    ZIO.foreachDiscard(rules)((rid, rule) => postStub(engine, port, flowId, rule.copy(id = Some(rid))))
+
+  /** Register the tracked capability stubs under `(port, flowId)`, in order. */
+  def registerRawStubs(
+    engine: EmbeddedEngine,
+    port: Int,
+    flowId: String,
+    extras: Vector[(RuleId, Json)]
+  ): IO[MockError, Unit] =
+    ZIO.foreachDiscard(extras)((_, stub) => postRawStub(engine, port, flowId, stub))
+
+  /** Register the tracked fault stubs under `(port, flowId)`, in order. */
+  def registerFaultStubs(
+    engine: EmbeddedEngine,
+    port: Int,
+    flowId: String,
+    faults: Vector[(RuleId, RequestMatch, FaultKind)]
+  ): IO[MockError, Unit] =
+    ZIO.foreachDiscard(faults)((rid, m, fault) => postFaultStub(engine, port, flowId, m, fault, rid))
+
+  /**
+   * Tear down the whole space — also clears its recorded requests + flow state.
+   * Idempotent.
+   */
+  def deleteSpace(engine: EmbeddedEngine, port: Int, flowId: String): IO[MockError, Unit] =
+    engine.spaceDelete(port, flowId)
+
+  /**
+   * rift#223 has no per-stub-in-space delete: tear the whole space down and
+   * re-register `extras` (capability stubs) → `faults` → `rules`, in that
+   * first-match order (capability stubs and faults must win first-match over a
+   * normal rule).
+   */
+  def rebuild(
+    engine: EmbeddedEngine,
+    port: Int,
+    flowId: String,
+    extras: Vector[(RuleId, Json)],
+    faults: Vector[(RuleId, RequestMatch, FaultKind)],
+    rules: Vector[(RuleId, MockRule)]
+  ): IO[MockError, Unit] =
+    deleteSpace(engine, port, flowId) *>
+      registerRawStubs(engine, port, flowId, extras) *>
+      registerFaultStubs(engine, port, flowId, faults) *>
+      registerStubs(engine, port, flowId, rules)
+
+  /**
+   * The requests recorded under `flowId` on the shared imposter, filtered by
+   * the space's resolved flow id (the header-filtered `received`, rift#201 —
+   * parity with the container adapter).
+   */
+  def received(engine: EmbeddedEngine, port: Int, flowId: String): IO[MockError, List[RecordedRequest]] =
+    engine
+      .spaceRecorded(port, flowId)
+      .flatMap(json => ZIO.fromEither(RiftProtocol.parseRequestsArray(json)).mapError(MockError.CommunicationError(_)))

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
@@ -3,8 +3,6 @@ package zio.bdd.mock.rift.embedded
 import zio.*
 import zio.bdd.mock.{MockControl, MockError, Provisioning}
 import zio.bdd.mock.rift.RiftMode
-import zio.http.Client
-import zio.json.ast.Json
 
 import java.nio.file.{Files, Path, StandardCopyOption}
 
@@ -25,14 +23,12 @@ import java.nio.file.{Files, Path, StandardCopyOption}
  * (`--enable-native-access` to silence the restricted-method warning).
  * Published as two variants from this one source: `zio-bdd-rift-embedded` for
  * **JDK 22+** (stable FFM, JEP 454) and `zio-bdd-rift-embedded-jdk21` for **JDK
- * 21** (preview FFM — also needs `--enable-preview`). Requires the C-ABI v2
- * (rift#343, `librift_ffi` ≥ v0.9.0) — a pre-v2 library fails fast at start
- * with a missing-symbol error.
+ * 21** (preview FFM — also needs `--enable-preview`). Requires `librift_ffi` ≥
+ * v0.11.0: the adapter drives Rift entirely over FFI, including the admin long
+ * tail (rift#411) — a pre-v0.11.0 library fails fast at start with a
+ * missing-symbol error when the bridge binds those mandatory symbols.
  */
 object EmbeddedRift:
-
-  // The engine binds the in-process admin API on loopback with an OS-assigned port (rift#343).
-  private val serveAdminOptions: String = Json.Obj("host" -> Json.Str("127.0.0.1"), "port" -> Json.Num(0)).toString
 
   /**
    * True iff a `librift_ffi` resolves for the host (a bundled native resource,
@@ -51,31 +47,18 @@ object EmbeddedRift:
    * A scoped [[MockControl]] backed by the in-process Rift engine, in the given
    * isolation `mode` (#203 adds Correlated — mirroring the container adapter,
    * but the shared imposter is FFI-created/-destroyed rather than
-   * HTTP-managed): `rift_start` plus `rift_serve_admin` (the in-process admin
-   * plane) on layer construction, `rift_stop` (and, in Correlated mode, the
-   * shared imposter's teardown) on close. Self-contained — it builds its own
-   * loopback HTTP client for the admin plane, so the public requirement stays
-   * just [[Provisioning]]. Fails with [[MockError.ProvisionFailed]] when no
-   * native library resolves for the host, or it cannot be loaded.
+   * HTTP-managed): `rift_start` on layer construction, `rift_stop` (and, in
+   * Correlated mode, the shared imposter's teardown) on close. Entirely FFI
+   * (#244) — no loopback HTTP admin plane, so the public requirement stays just
+   * [[Provisioning]]. Fails with [[MockError.ProvisionFailed]] when no native
+   * library resolves for the host, or it cannot be loaded.
    */
   def layer(mode: RiftMode): ZLayer[Provisioning, MockError, MockControl] =
     ZLayer.scoped {
       for
-        prov   <- ZIO.service[Provisioning]
-        engine <- startEngine
-        // Standing up the admin plane is part of constructing the backend, so a failure here is a
-        // ProvisionFailed (matching this layer's contract), not the raw CommunicationError.
-        adminInfo <-
-          engine
-            .serveAdmin(serveAdminOptions)
-            .mapError(e => MockError.ProvisionFailed(s"starting the embedded Rift admin plane: $e"))
-        client <- adminClient
-        control <- EmbeddedRiftMockControl.make(
-                     engine,
-                     prov,
-                     EmbeddedRiftMockControl.Admin(adminInfo.adminUrl, client),
-                     mode
-                   )
+        prov    <- ZIO.service[Provisioning]
+        engine  <- startEngine
+        control <- EmbeddedRiftMockControl.make(engine, prov, mode)
       yield control
     }
 
@@ -87,14 +70,6 @@ object EmbeddedRift:
       path   <- loadablePath(source)
       engine <- RiftFfi.start(path.toString)
     yield engine
-
-  // The loopback HTTP client for the in-process admin plane, owned by the layer's scope so the
-  // embedded adapter needs nothing from the environment but Provisioning (mirrors the container
-  // adapter's Client, but self-provided).
-  private def adminClient: ZIO[Scope, MockError, Client] =
-    Client.default.build
-      .map(_.get[Client])
-      .mapError(t => MockError.ProvisionFailed(s"building embedded Rift admin HTTP client: ${message(t)}"))
 
   // An override is already a real path; a bundled resource is extracted to a temp file (removed when
   // the JVM exits — the engine keeps the loaded library mapped, so the file is no longer needed).
@@ -116,6 +91,3 @@ object EmbeddedRift:
           val msg = Option(t.getMessage).filter(_.nonEmpty).fold("")(m => s": $m")
           MockError.ProvisionFailed(s"extracting bundled native '$resource': ${t.getClass.getSimpleName}$msg")
         }
-
-  private def message(t: Throwable): String =
-    Option(t.getMessage).getOrElse(t.getClass.getSimpleName)

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
@@ -2,8 +2,7 @@ package zio.bdd.mock.rift.embedded
 
 import zio.*
 import zio.bdd.mock.*
-import zio.bdd.mock.rift.{Correlation, RiftCorrelatedSpace, RiftMode, RiftProtocol, RiftScenarioAdmin}
-import zio.http.Client
+import zio.bdd.mock.rift.{Correlation, RiftMode, RiftProtocol}
 import zio.json.*
 import zio.json.ast.Json
 
@@ -16,17 +15,16 @@ import zio.json.ast.Json
  * container adapter — the FFI consumes the same imposter/stub model the admin
  * API does — so the wire fidelity is identical; only the transport differs.
  *
- * Requires the C-ABI v2 (rift#343, `librift_ffi` ≥ v0.9.0): the engine starts
- * the '''real''' admin API in-process on loopback
- * ([[EmbeddedEngine.serveAdmin]]) over the same manager the FFI downcalls
- * drive. So the adapter is "the container adapter minus Docker": the hot-path
- * data plane stays FFI downcalls (`create_imposter`/`replace_stubs`/`recorded`,
- * no HTTP hop), while the admin long tail — scenario pin/read/reset, and (in
- * Correlated mode) the whole per-space stub plane — routes over the loopback
- * admin URL, exactly as the container adapter does. `destroy` frees the port
- * via `rift_delete_imposter`. All six capabilities are advertised. (Older Rift
- * is unsupported — a pre-v2 library fails fast at load, so there is no legacy
- * tier.)
+ * Requires the C-ABI v0.11.0 (rift#411): the adapter drives Rift '''entirely
+ * over FFI''' — no loopback HTTP admin plane (#244). The hot-path data plane is
+ * `create_imposter`/`replace_stubs`/`recorded`; the admin long tail —
+ * scenario/flow state (`rift_flow_state_get`/`put`) and, in Correlated mode,
+ * the whole per-space stub plane (`rift_space_add_stub`/`delete`/`recorded`) —
+ * are direct downcalls too, over the same manager, so there is no TCP + HTTP
+ * round trip for an in-process engine. `destroy` frees the port via
+ * `rift_delete_imposter`. All six capabilities are advertised. (Older Rift is
+ * unsupported — a pre-v0.11.0 library fails fast at load when the bridge binds
+ * the mandatory symbols, so there is no legacy tier.)
  *
  * Two isolation modes ([[RiftMode]]), mirroring the container adapter:
  *
@@ -41,12 +39,13 @@ import zio.json.ast.Json
  *   - Correlated: all spaces share ONE imposter (created via
  *     `rift_create_imposter` on an allocator-issued port, guarded by
  *     `sharedPort` so it is created at most once), whose `flowIdSource` is
- *     `header:<correlation>`. Since the FFI has no per-space stub surface, the
- *     shared imposter's spaces are driven entirely over the loopback admin
- *     plane through [[RiftCorrelatedSpace]] — the same wire calls the container
- *     adapter issues (`POST/DELETE .../spaces/:flowId/...`, the header-filtered
- *     `received`) — so isolation semantics are byte-identical, only the shared
- *     imposter's own creation/teardown goes through the FFI instead of HTTP.
+ *     `header:<correlation>`. The shared imposter's spaces are driven over the
+ *     space FFI downcalls through [[EmbeddedCorrelatedSpace]] — the
+ *     FFI-transport mirror of the container adapter's `RiftCorrelatedSpace`,
+ *     building the byte-identical stub JSON via [[RiftProtocol]] and
+ *     registering/tearing it down via `rift_space_add_stub`/`delete`/`recorded`
+ *     — so isolation semantics are byte-identical to the container, with no
+ *     HTTP hop.
  *
  * A native imposter ([[provisionNative]]) always gets its own port regardless
  * of mode, so the two space kinds coexist; per-space operations dispatch by
@@ -59,8 +58,7 @@ private[embedded] final case class EmbeddedRiftMockControl(
   spaces: Ref[Map[SpaceId, EmbeddedRiftMockControl.Imposter]],
   correlated: Ref[Map[SpaceId, EmbeddedRiftMockControl.CorrSpace]],
   sharedPort: Ref.Synchronized[Option[Int]],
-  ids: Ref[Int],
-  admin: EmbeddedRiftMockControl.Admin
+  ids: Ref[Int]
 ) extends MockControl:
 
   import EmbeddedRiftMockControl.{CorrSpace, Imposter}
@@ -296,7 +294,7 @@ private[embedded] final case class EmbeddedRiftMockControl(
     for
       _ <- ZIO.foreachDiscard(sc.rules) { r =>
              val stub = RiftProtocol.statefulStub(sc.name, r.whenState, r.thenState, MockRule(r.request, r.respond))
-             RiftCorrelatedSpace.postRawStub(admin.client, admin.url, cs.port, cs.flowId, stub)
+             EmbeddedCorrelatedSpace.postRawStub(engine, cs.port, cs.flowId, stub)
            }
       _ <- putScenarioState(cs.port, cs.flowId, sc.name, sc.initial)
       _ <- cs.scenarios.update(_ + (sc.name -> sc.initial))
@@ -309,35 +307,46 @@ private[embedded] final case class EmbeddedRiftMockControl(
     )
 
   private val embeddedStateInspection: StateInspection = new StateInspection:
+    // Guard `currentState` on the locally-tracked scenarios (like `setState`/`reset`) so an undeclared
+    // name is an accurate InvalidDefinition from the Ref — not inferred from a `flow_state_get` null,
+    // which the crate also returns on a genuine engine error (rift#415: null conflates absent-key and
+    // error).
     def currentState(space: MockSpace, name: String): IO[MockError, ScenarioState] =
-      dispatch(space)(cs => readState(cs.port, cs.flowId, space.id, name))(imp =>
-        readState(imp.port, imp.port.toString, space.id, name)
+      dispatch(space)(cs => guardDefined(cs.scenarios, space.id, name)(readState(cs.port, cs.flowId, space.id, name)))(
+        imp => guardDefined(imp.scenarios, space.id, name)(readState(imp.port, imp.port.toString, space.id, name))
       )
     def setState(space: MockSpace, name: String, to: ScenarioState): IO[MockError, Unit] =
       dispatch(space)(cs => guardDefined(cs.scenarios, space.id, name)(putScenarioState(cs.port, cs.flowId, name, to)))(
         imp => guardDefined(imp.scenarios, space.id, name)(putScenarioState(imp.port, imp.port.toString, name, to))
       )
 
-  private def guardDefined(
+  private def guardDefined[A](
     scenarios: Ref[Map[String, ScenarioState]],
     spaceId: SpaceId,
     name: String
-  )(action: => IO[MockError, Unit]): IO[MockError, Unit] =
+  )(action: => IO[MockError, A]): IO[MockError, A] =
     scenarios.get.flatMap(s =>
       if s.contains(name) then action
       else ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${spaceId.value}"))
     )
 
+  // Reached only for a scenario the guard confirmed is declared (so `define` has pinned its state):
+  // a `Some` is its current state. A `None` here is anomalous — a declared scenario whose flow-state
+  // key vanished, or a genuine engine error the null-return can't distinguish — surfaced as a
+  // CommunicationError rather than masked as "no scenario" (which the guard already rules out).
   private def readState(port: Int, flowId: String, spaceId: SpaceId, name: String): IO[MockError, ScenarioState] =
-    RiftScenarioAdmin.readState(admin.client, admin.url, port, flowId, name).flatMap {
+    engine.flowStateGet(port, flowId, name).flatMap {
       case Some(s) => ZIO.succeed(ScenarioState(s))
-      case None    => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${spaceId.value}"))
+      case None =>
+        ZIO.fail(MockError.CommunicationError(s"scenario '$name' on space ${spaceId.value} has no readable state"))
     }
 
   // flowId = the imposter port (PerInstance) / the correlation value (Correlated): the slice a
-  // request resolves its scenario state to.
+  // request resolves its scenario state to. Scenario state is flow-state keyed by the scenario name,
+  // stored as a JSON string — the same slice `set_scenario_state` writes (rift-core), so pinning via
+  // `rift_flow_state_put(name, "\"state\"")` is byte-identical to the admin `/scenarios/:name/state`.
   private def putScenarioState(port: Int, flowId: String, name: String, state: ScenarioState): IO[MockError, Unit] =
-    RiftScenarioAdmin.putState(admin.client, admin.url, port, flowId, name, state)
+    engine.flowStatePut(port, flowId, name, Json.Str(state.value).toJson)
 
   // ---------------------------------------------------------------------------
 
@@ -393,15 +402,19 @@ private[embedded] final case class EmbeddedRiftMockControl(
       tagged <- tagRules(rules)
       // Mirror serveImposter's release-on-error: if a stub POST fails partway, tear the half-built
       // space down so it can't orphan stubs on the shared imposter.
-      _ <- RiftCorrelatedSpace
-             .registerStubs(admin.client, admin.url, port, flowId, tagged)
-             .onError(_ => RiftCorrelatedSpace.deleteSpace(admin.client, admin.url, port, flowId).ignore)
+      _ <- EmbeddedCorrelatedSpace
+             .registerStubs(engine, port, flowId, tagged)
+             .onError(_ =>
+               EmbeddedCorrelatedSpace
+                 .deleteSpace(engine, port, flowId)
+                 .catchAllCause(c => ZIO.logWarningCause(s"rollback: teardown of half-built space $flowId failed", c))
+             )
       rulesRef  <- Ref.make(tagged)
       faultsRef <- Ref.make(Vector.empty[(RuleId, RequestMatch, FaultKind)])
       extrasRef <- Ref.make(Vector.empty[(RuleId, Json)])
       scen      <- Ref.make(Map.empty[String, ScenarioState])
       _ <- correlated.update(
-             _.updated(id, CorrSpace(port, flowId, corr.header, rulesRef, faultsRef, extrasRef, scen))
+             _.updated(id, CorrSpace(port, flowId, rulesRef, faultsRef, extrasRef, scen))
            )
     yield MockSpace(s"http://localhost:$port", req => req.copy(headers = req.headers.add(corr.header, flowId)), id)
 
@@ -429,7 +442,7 @@ private[embedded] final case class EmbeddedRiftMockControl(
       val act = priority match
         // Base appends (Rift's space POST appends).
         case Priority.Base =>
-          RiftCorrelatedSpace.postStub(admin.client, admin.url, cs.port, cs.flowId, rule.copy(id = Some(ruleId))) *>
+          EmbeddedCorrelatedSpace.postStub(engine, cs.port, cs.flowId, rule.copy(id = Some(ruleId))) *>
             cs.rules.update(_ :+ tagged)
         // Overlay must be first-match — rebuild with the prepended set.
         case Priority.Overlay =>
@@ -460,14 +473,14 @@ private[embedded] final case class EmbeddedRiftMockControl(
     tagRules(rules).flatMap(next => rebuildSpaceWith(cs, next) *> cs.rules.set(next))
 
   private def corrDestroy(spaceId: SpaceId, cs: CorrSpace): IO[MockError, Unit] =
-    RiftCorrelatedSpace.deleteSpace(admin.client, admin.url, cs.port, cs.flowId) *> correlated.update(_ - spaceId)
+    EmbeddedCorrelatedSpace.deleteSpace(engine, cs.port, cs.flowId) *> correlated.update(_ - spaceId)
 
   // Space-scoped recorded requests: the header-filtered admin query (rift#201) returns everything
   // recorded under this space's flowId — identical to the container adapter, so a cross-space
   // request (a different flowId) is excluded, while this space's own traffic (matched or not) is
   // returned. Parity with `RiftMockControl`; no client-side re-filtering.
   private def corrReceived(cs: CorrSpace): IO[MockError, List[RecordedRequest]] =
-    RiftCorrelatedSpace.received(admin.client, admin.url, cs.port, cs.flowId, cs.header)
+    EmbeddedCorrelatedSpace.received(engine, cs.port, cs.flowId)
 
   // rift#223 has no per-stub-in-space delete: re-register the space's stubs after a whole-space
   // teardown. Server-first — the caller commits tracking only on success. Re-register with the
@@ -488,7 +501,7 @@ private[embedded] final case class EmbeddedRiftMockControl(
     faults: Vector[(RuleId, RequestMatch, FaultKind)],
     rules: Vector[(RuleId, MockRule)]
   ): IO[MockError, Unit] =
-    RiftCorrelatedSpace.rebuild(admin.client, admin.url, cs.port, cs.flowId, extras, faults, rules)
+    EmbeddedCorrelatedSpace.rebuild(engine, cs.port, cs.flowId, extras, faults, rules)
 
   private def rulesOf(src: NormalizedSource): IO[MockError, List[MockRule]] =
     src.payload match
@@ -573,12 +586,6 @@ private[embedded] final case class EmbeddedRiftMockControl(
 private[embedded] object EmbeddedRiftMockControl:
 
   /**
-   * Where the v2 in-process admin plane is reachable, plus the HTTP client to
-   * reach it.
-   */
-  final case class Admin(url: String, client: Client)
-
-  /**
    * A live imposter: its bound port, the ordered portable rules tracked for
    * `rift_replace_stubs`, the pre-built capability stubs (#132/#185) and
    * scenario stubs (#193) re-registered ahead of the rules on every rebuild,
@@ -597,16 +604,17 @@ private[embedded] object EmbeddedRiftMockControl:
 
   /**
    * A Correlated space (rift#223): its shared imposter's port, its `flowId` on
-   * that imposter, the correlation `header` `received` filters by, the space's
-   * tracked portable rules, faults, and pre-built capability stubs (each
-   * re-registered ahead of the rules on a rebuild — rift#223 has no
-   * per-stub-in-space delete), and its defined scenarios' initial states (for
-   * reset). Mirrors the container adapter's `CorrSpace`.
+   * that imposter, the space's tracked portable rules, faults, and pre-built
+   * capability stubs (each re-registered ahead of the rules on a rebuild —
+   * rift#223 has no per-stub-in-space delete), and its defined scenarios'
+   * initial states (for reset). Mirrors the container adapter's `CorrSpace`
+   * (minus the correlation header: the space FFI filters `recorded` by the
+   * resolved flow id itself, so the adapter never re-filters). `flowId`
+   * addresses the space.
    */
   final case class CorrSpace(
     port: Int,
     flowId: String,
-    header: String,
     rules: Ref[Vector[(RuleId, MockRule)]],
     faults: Ref[Vector[(RuleId, RequestMatch, FaultKind)]],
     extras: Ref[Vector[(RuleId, Json)]],
@@ -627,7 +635,6 @@ private[embedded] object EmbeddedRiftMockControl:
   def make(
     engine: EmbeddedEngine,
     provisioning: Provisioning,
-    admin: Admin,
     mode: RiftMode = RiftMode.PerInstance
   ): URIO[Scope, MockControl] =
     for
@@ -635,6 +642,6 @@ private[embedded] object EmbeddedRiftMockControl:
       correlated <- Ref.make(Map.empty[SpaceId, CorrSpace])
       sharedPort <- Ref.Synchronized.make(Option.empty[Int])
       ids        <- Ref.make(0)
-      control     = EmbeddedRiftMockControl(engine, provisioning, mode, spaces, correlated, sharedPort, ids, admin)
+      control     = EmbeddedRiftMockControl(engine, provisioning, mode, spaces, correlated, sharedPort, ids)
       _          <- ZIO.addFinalizer(control.teardownShared)
     yield control

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/RiftFfi.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/RiftFfi.scala
@@ -5,12 +5,15 @@ import zio.bdd.mock.MockError
 import zio.json.*
 
 /**
- * The ZIO-facing surface over the Rift engine's C-ABI v2 (rift#343,
- * `librift_ffi` ≥ v0.9.0): the data plane (create an imposter, replace all of
- * its stubs, read its recorded requests) plus the in-process admin plane
- * ([[serveAdmin]]), per-imposter delete ([[deleteImposter]]), and build
- * identity ([[buildInfo]]). A pre-v2 library fails fast at load
- * ([[RiftFfiBridge.start]]), so this surface always assumes v2.
+ * The ZIO-facing surface over the Rift engine's C-ABI (`librift_ffi` ≥
+ * v0.11.0): the data plane (create an imposter, replace all of its stubs, read
+ * its recorded requests) plus the in-process admin plane ([[serveAdmin]]),
+ * per-imposter delete ([[deleteImposter]]), build identity ([[buildInfo]]), and
+ * — the admin long tail over direct C-ABI (rift#411) — scenario/flow state
+ * ([[flowStateGet]]/[[flowStatePut]]) and the correlated space plane
+ * ([[spaceAddStub]]/[[spaceDelete]]/[[spaceRecorded]]), so the adapter needs no
+ * loopback HTTP. A pre-v0.11.0 library fails fast at load
+ * ([[RiftFfiBridge.start]]) when the bridge binds those mandatory symbols.
  *
  * A trait (not just the live wrapper) so the adapter can be unit-tested against
  * a recording double without the native library.
@@ -43,6 +46,40 @@ private[embedded] trait EmbeddedEngine:
   /** The engine's build identity (version/commit/features). */
   def buildInfo: IO[MockError, EmbeddedEngine.BuildInfo]
 
+  // The admin long tail over direct C-ABI (rift#411, librift_ffi ≥ v0.11.0): scenario/flow state +
+  // correlated spaces, so the adapter drives them with no loopback HTTP admin plane.
+
+  /**
+   * The scenario/flow-state value for `(flowId, key)` as its string form
+   * (scenario state is stored as a JSON string), or `None` if the key is
+   * absent.
+   */
+  def flowStateGet(port: Int, flowId: String, key: String): IO[MockError, Option[String]]
+
+  /**
+   * Set the scenario/flow-state value for `(flowId, key)` from a bare JSON
+   * value.
+   */
+  def flowStatePut(port: Int, flowId: String, key: String, valueJson: String): IO[MockError, Unit]
+
+  /**
+   * Register a stub scoped to `flowId` on the shared imposter (its `space` is
+   * set from `flowId`).
+   */
+  def spaceAddStub(port: Int, flowId: String, stubJson: String): IO[MockError, Unit]
+
+  /**
+   * Tear down a space in one call (its scoped stubs, recorded requests, and
+   * scenario state).
+   */
+  def spaceDelete(port: Int, flowId: String): IO[MockError, Unit]
+
+  /**
+   * The requests recorded under `flowId` (header-filtered by the space's
+   * resolved flow id) as a JSON array string (`[]` when none).
+   */
+  def spaceRecorded(port: Int, flowId: String): IO[MockError, String]
+
 private[embedded] object EmbeddedEngine:
 
   /**
@@ -65,6 +102,15 @@ private[embedded] object EmbeddedEngine:
   )
   object BuildInfo:
     given JsonDecoder[BuildInfo] = DeriveJsonDecoder.gen[BuildInfo]
+
+  /**
+   * The `value` field of a `rift_flow_state_get` result
+   * (`{"flowId","key","value"}`), decoded as its string form — scenario state
+   * (the sole reader) is stored as a JSON string. Extra fields ignored.
+   */
+  private[embedded] final case class FlowStateValue(value: String)
+  private[embedded] object FlowStateValue:
+    given JsonDecoder[FlowStateValue] = DeriveJsonDecoder.gen[FlowStateValue]
 
   /**
    * The live engine over [[RiftFfiBridge]] — the Panama FFM bindings to
@@ -136,6 +182,55 @@ private[embedded] object EmbeddedEngine:
           ZIO
             .fromEither(json.fromJson[BuildInfo])
             .mapError(e => MockError.CommunicationError(s"rift_build_info returned unparseable build info: $e ($json)"))
+      }
+
+    // A null return is "key absent" (mapped to None) — the crate also returns null on a genuine
+    // error, but the adapter only reads a scenario it defined on a live imposter, so absence is the
+    // meaningful case (mirrors the HTTP path's `Option[String]`). rift's null conflates the two.
+    def flowStateGet(port: Int, flowId: String, key: String): IO[MockError, Option[String]] =
+      blocking("rift_flow_state_get")(Option(bridge.flowStateGet(port, flowId, key))).flatMap {
+        case None => ZIO.none
+        case Some(json) =>
+          ZIO
+            .fromEither(json.fromJson[FlowStateValue])
+            .mapError(e => MockError.CommunicationError(s"rift_flow_state_get returned unparseable JSON: $e ($json)"))
+            .map(v => Some(v.value))
+      }
+
+    def flowStatePut(port: Int, flowId: String, key: String, valueJson: String): IO[MockError, Unit] =
+      blocking("rift_flow_state_put") {
+        val rc = bridge.flowStatePut(port, flowId, key, valueJson)
+        if rc == 0 then None else Some(withReason(s"rift_flow_state_put returned $rc for port $port"))
+      }.flatMap {
+        case None      => ZIO.unit
+        case Some(msg) => ZIO.fail(MockError.CommunicationError(msg))
+      }
+
+    def spaceAddStub(port: Int, flowId: String, stubJson: String): IO[MockError, Unit] =
+      blocking("rift_space_add_stub") {
+        val rc = bridge.spaceAddStub(port, flowId, stubJson)
+        if rc == 0 then None else Some(withReason(s"rift_space_add_stub returned $rc for port $port"))
+      }.flatMap {
+        case None      => ZIO.unit
+        case Some(msg) => ZIO.fail(MockError.CommunicationError(msg))
+      }
+
+    def spaceDelete(port: Int, flowId: String): IO[MockError, Unit] =
+      blocking("rift_space_delete") {
+        val rc = bridge.spaceDelete(port, flowId)
+        if rc == 0 then None else Some(withReason(s"rift_space_delete returned $rc for port $port"))
+      }.flatMap {
+        case None      => ZIO.unit
+        case Some(msg) => ZIO.fail(MockError.CommunicationError(msg))
+      }
+
+    def spaceRecorded(port: Int, flowId: String): IO[MockError, String] =
+      blocking("rift_space_recorded") {
+        val json = bridge.spaceRecorded(port, flowId)
+        if json == null then Left(withReason(s"rift_space_recorded returned null for port $port")) else Right(json)
+      }.flatMap {
+        case Right(json) => ZIO.succeed(json)
+        case Left(msg)   => ZIO.fail(MockError.CommunicationError(msg))
       }
 
     private def blocking[A](op: String)(thunk: => A): IO[MockError, A] =

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
@@ -2,25 +2,19 @@ package zio.bdd.mock.rift.embedded
 
 import zio.*
 import zio.bdd.mock.*
-import zio.bdd.mock.rift.FakeRift
-import zio.http.Client
+import zio.bdd.mock.rift.RiftMode
 import zio.json.*
-import zio.json.ast.Json
 import zio.test.*
 
 /**
- * Unit gate for the embedded (FFI) adapter's v2 wiring (#193) — no native
- * library. The data plane is a recording [[EmbeddedEngine]] double (echoes the
- * requested port, captures the latest replace-stubs JSON per port, records
- * `deleteImposter` calls), and the in-process admin plane is stood in for by
- * [[FakeRift]] (the same fake the container adapter's unit spec uses), so the
- * scenario/state control-plane calls the v2 adapter routes over the admin URL
- * can be asserted with no Docker and no engine.
- *
- * With the v2 admin plane up the adapter is capability-complete: all six
- * capabilities are advertised; the stub-based four are realised as
- * whole-imposter `rift_replace_stubs`, the stateful two route to the admin
- * client, and `destroy` frees the port via `rift_delete_imposter`.
+ * Unit gate for the embedded (FFI) adapter — no native library, and no loopback
+ * HTTP admin plane (#244). The engine is a recording [[EmbeddedEngine]] double
+ * that captures every downcall: the data plane (echoes the requested port,
+ * keeps the latest replace-stubs JSON per port, records `deleteImposter`), the
+ * scenario/flow-state plane (`rift_flow_state_get`/`put`), and the correlated
+ * space plane (`rift_space_add_stub`/`delete`/`recorded`). So the whole SPI —
+ * including the admin long tail that used to route over the in-process admin
+ * URL — is asserted with no Docker, no engine, and no HTTP client.
  */
 object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
 
@@ -30,13 +24,16 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
   )
   private val pingSource = MockSource.Dsl(MockSpec(List(pingRule)))
 
-  // A recording engine that echoes the requested port (parsed from the config, like the real
-  // engine), keeps the latest replace-stubs JSON per port, and records deleteImposter calls. The v2
-  // admin-plane methods aren't exercised here (the adapter is built directly with a FakeRift-backed
-  // Admin), so they return canned values.
-  private final class RecordingEngine(replaced: Ref[Map[Int, String]], deleted: Ref[Chunk[Int]]) extends EmbeddedEngine:
-    def createImposter(configJson: String): IO[MockError, Int] =
-      ZIO.succeed(portOf(configJson))
+  // A recording engine that echoes the requested port (parsed from the config, like the real engine),
+  // keeps the latest replace-stubs JSON per port, records deleteImposter calls, and — for #244 —
+  // captures the scenario/flow-state map and the per-space stub lists the adapter drives over FFI.
+  private final class RecordingEngine(
+    val replaced: Ref[Map[Int, String]],
+    val deleted: Ref[Chunk[Int]],
+    val flowState: Ref[Map[(Int, String, String), String]],
+    val spaceStubs: Ref[Map[(Int, String), Vector[String]]]
+  ) extends EmbeddedEngine:
+    def createImposter(configJson: String): IO[MockError, Int] = ZIO.succeed(portOf(configJson))
     def replaceStubs(port: Int, stubsJson: String): IO[MockError, Unit] =
       replaced.update(_.updated(port, stubsJson))
     def recorded(port: Int): IO[MockError, String] = ZIO.succeed("[]")
@@ -45,52 +42,60 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
     def deleteImposter(port: Int): IO[MockError, Unit]     = deleted.update(_ :+ port)
     def buildInfo: IO[MockError, EmbeddedEngine.BuildInfo] = ZIO.succeed(EmbeddedEngine.BuildInfo("test"))
 
+    // Admin long tail over the recorded FFI (#244): flow-state is keyed (port, flowId, key) -> the
+    // stored valueJson; `get` decodes it back to the string form the adapter reads (scenario state is
+    // a JSON string). The space plane appends/clears the per-(port, flowId) stub list.
+    def flowStateGet(port: Int, flowId: String, key: String): IO[MockError, Option[String]] =
+      flowState.get.map(_.get((port, flowId, key)).flatMap(_.fromJson[String].toOption))
+    def flowStatePut(port: Int, flowId: String, key: String, valueJson: String): IO[MockError, Unit] =
+      flowState.update(_.updated((port, flowId, key), valueJson))
+    def spaceAddStub(port: Int, flowId: String, stubJson: String): IO[MockError, Unit] =
+      spaceStubs.update(m => m.updated((port, flowId), m.getOrElse((port, flowId), Vector.empty) :+ stubJson))
+    def spaceDelete(port: Int, flowId: String): IO[MockError, Unit] =
+      spaceStubs.update(_ - ((port, flowId)))
+    def spaceRecorded(port: Int, flowId: String): IO[MockError, String] = ZIO.succeed("[]")
+
     private def portOf(cfg: String): Int =
       cfg
-        .fromJson[Json]
+        .fromJson[zio.json.ast.Json]
         .toOption
-        .collect { case o: Json.Obj => o }
-        .flatMap(_.fields.collectFirst { case ("port", Json.Num(n)) => n.intValue })
+        .collect { case o: zio.json.ast.Json.Obj => o }
+        .flatMap(_.fields.collectFirst { case ("port", zio.json.ast.Json.Num(n)) => n.intValue })
         .getOrElse(0)
 
   private def portFromUri(baseUri: String): Int = baseUri.substring(baseUri.lastIndexOf(':') + 1).toInt
 
-  private def withControl(
-    use: (MockControl, Ref[Map[Int, String]], Ref[Chunk[Int]], FakeRift) => IO[Any, TestResult]
-  ): ZIO[Client & Provisioning, Any, TestResult] =
+  private def withControl(mode: RiftMode = RiftMode.PerInstance)(
+    use: (MockControl, RecordingEngine) => IO[Any, TestResult]
+  ): ZIO[Provisioning, Any, TestResult] =
     ZIO.scoped {
       for
-        prov            <- ZIO.service[Provisioning]
-        client          <- ZIO.service[Client]
-        replaced        <- Ref.make(Map.empty[Int, String])
-        deleted         <- Ref.make(Chunk.empty[Int])
-        adminAndFake    <- FakeRift.started
-        (adminUrl, fake) = adminAndFake
-        control <- EmbeddedRiftMockControl.make(
-                     RecordingEngine(replaced, deleted),
-                     prov,
-                     EmbeddedRiftMockControl.Admin(adminUrl, client)
-                   )
-        result <- use(control, replaced, deleted, fake)
+        prov       <- ZIO.service[Provisioning]
+        replaced   <- Ref.make(Map.empty[Int, String])
+        deleted    <- Ref.make(Chunk.empty[Int])
+        flowState  <- Ref.make(Map.empty[(Int, String, String), String])
+        spaceStubs <- Ref.make(Map.empty[(Int, String), Vector[String]])
+        engine      = RecordingEngine(replaced, deleted, flowState, spaceStubs)
+        control    <- EmbeddedRiftMockControl.make(engine, prov, mode)
+        result     <- use(control, engine)
       yield result
     }
 
   def spec = suite("EmbeddedRiftCapabilities")(
     test("#211: an authored port is honoured — the imposter binds on it and baseUri reflects it") {
-      withControl { (control, _, _, _) =>
-        for
-          space <- control.provision(MockSource.Dsl(MockSpec(List(pingRule), port = Some(9998)))).map(_.head)
+      withControl() { (control, _) =>
+        for space <- control.provision(MockSource.Dsl(MockSpec(List(pingRule), port = Some(9998)))).map(_.head)
         yield assertTrue(portFromUri(space.baseUri) == 9998, space.baseUri == "http://localhost:9998")
       }
     },
     test("#211: omitting the port keeps the auto-assigned default (a nonzero free port, not 9998)") {
-      withControl { (control, _, _, _) =>
+      withControl() { (control, _) =>
         for space <- control.provision(pingSource).map(_.head)
         yield assertTrue(portFromUri(space.baseUri) > 0, portFromUri(space.baseUri) != 9998)
       }
     },
     test("advertises all six capabilities and every accessor succeeds") {
-      withControl { (control, _, _, _) =>
+      withControl() { (control, _) =>
         for
           faultsE   <- control.faults.either
           scriptE   <- control.scripting.either
@@ -117,23 +122,23 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
       }
     },
     test("faults.inject rebuilds the imposter with a first-match _rift.fault stub ahead of the rules") {
-      withControl { (control, replaced, _, _) =>
+      withControl() { (control, engine) =>
         for
           space  <- control.provision(pingSource).map(_.head)
           port    = portFromUri(space.baseUri)
           faults <- control.faults
           _      <- faults.inject(space, RequestMatch(path = PathMatch.Exact("/boom")), FaultKind.ConnectionReset)
-          json   <- replaced.get.map(_.getOrElse(port, ""))
+          json   <- engine.replaced.get.map(_.getOrElse(port, ""))
         yield assertTrue(
           json.contains("CONNECTION_RESET_BY_PEER"),
           json.contains("/boom"),
           json.contains("_rift"),
-          json.indexOf("/boom") < json.indexOf("/ping") // fault wins first-match over the normal rule
+          json.indexOf("/boom") < json.indexOf("/ping")
         )
       }
     },
     test("scripting/proxyRecord/templating each rebuild with a first-match capability stub ahead of the rules") {
-      withControl { (control, replaced, _, _) =>
+      withControl() { (control, engine) =>
         for
           space    <- control.provision(pingSource).map(_.head)
           port      = portFromUri(space.baseUri)
@@ -147,7 +152,7 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
                  RequestMatch(path = PathMatch.Exact("/t")),
                  ResponseTemplate(body = "x${V}", captures = List(TemplateCapture("${V}", TemplateSource.Body, ".*")))
                )
-          json <- replaced.get.map(_.getOrElse(port, ""))
+          json <- engine.replaced.get.map(_.getOrElse(port, ""))
         yield assertTrue(
           json.contains("rhai") && json.contains("/s"),
           json.contains("proxyOnce") && json.contains("http://up") && json.contains("/p"),
@@ -159,14 +164,14 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
       }
     },
     test("an injected capability rule is tracked and removable; the rebuild drops the stub, unknown ids fail") {
-      withControl { (control, replaced, _, _) =>
+      withControl() { (control, engine) =>
         for
           space  <- control.provision(pingSource).map(_.head)
           port    = portFromUri(space.baseUri)
           faults <- control.faults
           ruleId <- faults.inject(space, RequestMatch(path = PathMatch.Exact("/boom")), FaultKind.ConnectionReset)
           rmE    <- control.removeRule(space, ruleId).either
-          json   <- replaced.get.map(_.getOrElse(port, ""))
+          json   <- engine.replaced.get.map(_.getOrElse(port, ""))
           ghostE <- control.removeRule(space, RuleId("ghost")).either
         yield assertTrue(
           rmE.isRight,
@@ -178,7 +183,7 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
       }
     },
     test("an injected extra survives a later addRule/replaceRules and stays first-match ahead of the new rules") {
-      withControl { (control, replaced, _, _) =>
+      withControl() { (control, engine) =>
         val addedRule = MockRule(RequestMatch(path = PathMatch.Exact("/added")), ResponseDef(status = 200))
         val replRule  = MockRule(RequestMatch(path = PathMatch.Exact("/replaced")), ResponseDef(status = 200))
         for
@@ -187,9 +192,9 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
           faults    <- control.faults
           _         <- faults.inject(space, RequestMatch(path = PathMatch.Exact("/boom")), FaultKind.ConnectionReset)
           _         <- control.addRule(space, addedRule, Priority.Base)
-          afterAdd  <- replaced.get.map(_.getOrElse(port, ""))
+          afterAdd  <- engine.replaced.get.map(_.getOrElse(port, ""))
           _         <- control.replaceRules(space, List(replRule))
-          afterRepl <- replaced.get.map(_.getOrElse(port, ""))
+          afterRepl <- engine.replaced.get.map(_.getOrElse(port, ""))
         yield assertTrue(
           afterAdd.contains("CONNECTION_RESET_BY_PEER") && afterAdd.contains("/added"),
           afterAdd.indexOf("/boom") < afterAdd.indexOf("/added"),
@@ -199,8 +204,8 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
         )
       }
     },
-    test("scenarios: define registers the stateful stubs (FFI) and pins the initial state (admin plane)") {
-      withControl { (control, replaced, _, fake) =>
+    test("scenarios: define registers the stateful stubs (replace_stubs) and pins the initial state (flow_state_put)") {
+      withControl() { (control, engine) =>
         val invoice = ScenarioDef(
           "invoice",
           List(
@@ -218,56 +223,51 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
           port   = portFromUri(space.baseUri)
           ss    <- control.scenarios
           _     <- ss.define(space, invoice)
-          stubs <- replaced.get.map(_.getOrElse(port, ""))
-          puts  <- fake.scenarioPuts.get
+          stubs <- engine.replaced.get.map(_.getOrElse(port, ""))
+          flow  <- engine.flowState.get
         yield assertTrue(
-          // the stateful stub is registered via rift_replace_stubs, ahead of the /ping rule
           stubs.contains("\"scenarioName\":\"invoice\""),
           stubs.contains("\"requiredScenarioState\":\"Unpaid\""),
           stubs.contains("\"newScenarioState\":\"Paid\""),
           stubs.indexOf("/pay") < stubs.indexOf("/ping"),
-          // define pins the initial state via PUT …/scenarios/invoice/state {state, flowId=port}
-          puts.exists(p =>
-            p.startsWith(s"$port/invoice") && p.contains("\"state\":\"Unpaid\"") && p.contains(s"\"flowId\":\"$port\"")
-          )
+          // define pins the initial state via rift_flow_state_put(port, flowId=port, "invoice", "\"Unpaid\"")
+          flow.get((port, port.toString, "invoice")).contains("\"Unpaid\"")
         )
       }
     },
-    test("stateInspection: currentState reads the admin view; setState/reset pin; unknown scenarios fail") {
-      withControl { (control, _, _, fake) =>
+    test("stateInspection: currentState reads flow state (FFI); setState/reset pin; unknown scenarios fail") {
+      withControl() { (control, engine) =>
         val sc = ScenarioDef("s", List.empty, initial = ScenarioState("A"))
         for
-          space  <- control.provision(pingSource).map(_.head)
-          port    = portFromUri(space.baseUri)
-          ss     <- control.scenarios
-          si     <- control.stateInspection
-          _      <- ss.define(space, sc)
-          _      <- fake.setScenarios(s"""{"flowId":"$port","scenarios":[{"name":"s","state":"B"}]}""")
-          cur    <- si.currentState(space, "s")
-          gets   <- fake.scenarioGets.get
-          _      <- si.setState(space, "s", ScenarioState("C"))
-          _      <- ss.reset(space, "s")
-          puts   <- fake.scenarioPuts.get
-          ghostS <- si.currentState(space, "ghost").either
-          ghostR <- ss.reset(space, "ghost").either
-          // setState guards on the locally-tracked scenarios (a distinct path from currentState's
-          // admin-view check and reset's map lookup) — an unknown name must fail before any PUT.
+          space      <- control.provision(pingSource).map(_.head)
+          port        = portFromUri(space.baseUri)
+          ss         <- control.scenarios
+          si         <- control.stateInspection
+          _          <- ss.define(space, sc)                                                    // pins "A"
+          _          <- engine.flowState.update(_.updated((port, port.toString, "s"), "\"B\"")) // simulate a transition
+          cur        <- si.currentState(space, "s")
+          _          <- si.setState(space, "s", ScenarioState("C"))
+          afterSet   <- engine.flowState.get.map(_.get((port, port.toString, "s")))
+          _          <- ss.reset(space, "s")
+          afterReset <- engine.flowState.get.map(_.get((port, port.toString, "s")))
+          ghostS     <- si.currentState(space, "ghost").either
+          ghostR     <- ss.reset(space, "ghost").either
+          // setState guards on the locally-tracked scenarios — an unknown name must fail before any put.
           ghostSet  <- si.setState(space, "ghost", ScenarioState("Z")).either
-          putsAfter <- fake.scenarioPuts.get
+          flowAfter <- engine.flowState.get
         yield assertTrue(
           cur == ScenarioState("B"),
-          gets.exists(_ == s"$port?$port"),                                            // GET …/scenarios?flowId=port
-          puts.exists(p => p.startsWith(s"$port/s") && p.contains("\"state\":\"C\"")), // setState
-          puts.exists(p => p.startsWith(s"$port/s") && p.contains("\"state\":\"A\"")), // reset → initial
+          afterSet.contains("\"C\""),
+          afterReset.contains("\"A\""), // reset → initial
           ghostS == Left(MockError.InvalidDefinition(s"no scenario 'ghost' on space ${space.id.value}")),
           ghostR == Left(MockError.InvalidDefinition(s"no scenario 'ghost' on space ${space.id.value}")),
           ghostSet == Left(MockError.InvalidDefinition(s"no scenario 'ghost' on space ${space.id.value}")),
-          !putsAfter.exists(_.startsWith(s"$port/ghost")) // the guard rejects before issuing any PUT
+          !flowAfter.contains((port, port.toString, "ghost")) // the guard rejects before issuing any put
         )
       }
     },
     test("a defined scenario's stubs survive a later addRule/replaceRules, staying ahead of the new rules") {
-      withControl { (control, replaced, _, _) =>
+      withControl() { (control, engine) =>
         val invoice = ScenarioDef(
           "invoice",
           List(
@@ -288,27 +288,72 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
           ss        <- control.scenarios
           _         <- ss.define(space, invoice)
           _         <- control.addRule(space, addedRule, Priority.Base)
-          afterAdd  <- replaced.get.map(_.getOrElse(port, ""))
+          afterAdd  <- engine.replaced.get.map(_.getOrElse(port, ""))
           _         <- control.replaceRules(space, List(replRule))
-          afterRepl <- replaced.get.map(_.getOrElse(port, ""))
+          afterRepl <- engine.replaced.get.map(_.getOrElse(port, ""))
         yield assertTrue(
-          // the whole-imposter rebuild threads scenarioStubs through addRule, still ahead of the new rule
           afterAdd.contains("\"scenarioName\":\"invoice\"") && afterAdd.contains("/added"),
           afterAdd.indexOf("/pay") < afterAdd.indexOf("/added"),
-          // replaceRules swaps the ruleset but preserves the scenario stub, still first-match
           afterRepl.contains("\"scenarioName\":\"invoice\"") && afterRepl.contains("/replaced"),
           !afterRepl.contains("/added"),
           afterRepl.indexOf("/pay") < afterRepl.indexOf("/replaced")
         )
       }
     },
+    test("correlated: a space registers via rift_space_add_stub and destroy tears it down via rift_space_delete") {
+      withControl(RiftMode.correlated) { (control, engine) =>
+        val srcA =
+          MockSource.Dsl(
+            MockSpec(List(MockRule(RequestMatch(path = PathMatch.Exact("/a")), ResponseDef(status = 200))))
+          )
+        for
+          a         <- control.provision(srcA).map(_.head)
+          afterProv <- engine.spaceStubs.get
+          recA      <- control.received(a) // routes over rift_space_recorded (→ [])
+          _         <- control.destroy(a)
+          afterDel  <- engine.spaceStubs.get
+        yield assertTrue(
+          control.isolation == Isolation.Correlated,
+          afterProv.exists { case (_, stubs) => stubs.exists(_.contains("/a")) }, // registered via the space FFI
+          recA.isEmpty, // received via the space FFI
+          afterDel.forall { case (_, stubs) => !stubs.exists(_.contains("/a")) } // torn down via the space FFI
+        )
+      }
+    },
+    test("correlated: a fault + overlay rule rebuild the space via the FFI, first-match ahead of the base rule") {
+      withControl(RiftMode.correlated) { (control, engine) =>
+        val base =
+          MockSource.Dsl(
+            MockSpec(List(MockRule(RequestMatch(path = PathMatch.Exact("/base")), ResponseDef(status = 200))))
+          )
+        for
+          space  <- control.provision(base).map(_.head)
+          faults <- control.faults
+          // corrInjectFault → rebuild (fault ahead of the base rule)
+          _ <- faults.inject(space, RequestMatch(path = PathMatch.Exact("/boom")), FaultKind.ConnectionReset)
+          // corrAddRule(Overlay) → rebuild (overlay ahead of the base rule, behind the fault)
+          _ <- control.addRule(
+                 space,
+                 MockRule(RequestMatch(path = PathMatch.Exact("/over")), ResponseDef(status = 200)),
+                 Priority.Overlay
+               )
+          // one shared imposter, one flow → the last rebuild's registration order is the stub list
+          stubs <- engine.spaceStubs.get.map(_.values.headOption.getOrElse(Vector.empty).mkString("\n"))
+        yield assertTrue(
+          stubs.contains("CONNECTION_RESET_BY_PEER") && stubs.contains("/boom"),
+          stubs.contains("/over") && stubs.contains("/base"),
+          stubs.indexOf("/boom") < stubs.indexOf("/over"), // fault registered ahead of the rules
+          stubs.indexOf("/over") < stubs.indexOf("/base")  // overlay first-match over the base rule
+        )
+      }
+    },
     test("destroy frees the port via rift_delete_imposter; later ops on the space fail SpaceNotFound") {
-      withControl { (control, _, deleted, _) =>
+      withControl() { (control, engine) =>
         for
           space   <- control.provision(pingSource).map(_.head)
           port     = portFromUri(space.baseUri)
           _       <- control.destroy(space)
-          deletes <- deleted.get
+          deletes <- engine.deleted.get
           goneE   <- control.received(space).either
         yield assertTrue(
           deletes == Chunk(port),
@@ -316,4 +361,4 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
         )
       }
     }
-  ).provide(Provisioning.live, Client.default) @@ TestAspect.withLiveClock
+  ).provide(Provisioning.live) @@ TestAspect.withLiveClock


### PR DESCRIPTION
The embedded Rift adapter now drives scenario/flow state and correlated spaces directly over the C-ABI instead of a loopback HTTP admin plane. This eliminates the TCP/HTTP hop for in-process engine control, leveraging rift v0.11.0's C-ABI exposure of those endpoints (rift#411).

Also adds EmbeddedCorrelatedSpace as the FFI mirror of RiftCorrelatedSpace and raises the librift_ffi floor to v0.11.0.

Closes #244

**Dependencies:** rift v0.11.0 (already pinned); also surfaced rift#415 (filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)