### PR TITLE
JUnit XML and streaming reporters don't surface scenario-aspect states (retry attempts, XFAIL/XPASS)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -192,6 +192,10 @@ lazy val mimaSettings = Seq(
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.ScenarioResult.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.ScenarioResult.this"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.ScenarioResult.copy"),
+    // #238: TestCaseRecord gains an `attempts` field (retry aspect in JUnit XML) — additive, defaulted.
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.report.JUnitXMLFormatter#TestCaseRecord.apply"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.report.JUnitXMLFormatter#TestCaseRecord.this"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.report.JUnitXMLFormatter#TestCaseRecord.copy"),
     ProblemFilters.exclude[MissingFieldProblem]("zio.bdd.core.report.Color.Yellow"),
     ProblemFilters.exclude[MissingFieldProblem]("zio.bdd.core.report.Color.PaleGreen"),
     ProblemFilters.exclude[MissingFieldProblem]("zio.bdd.core.report.Color.PaleCyan"),

--- a/core/src/main/scala/zio/bdd/core/report/JUnitXMLFormatter.scala
+++ b/core/src/main/scala/zio/bdd/core/report/JUnitXMLFormatter.scala
@@ -101,7 +101,11 @@ object JUnitXMLFormatter {
     logs: CollectedLogs,
     timestamp: Instant,
     durationSecs: Double,
-    outcome: ScenarioOutcome
+    outcome: ScenarioOutcome,
+    // How many times the scenario ran (retry aspects, #225). 1 unless a retry aspect applied;
+    // carried into JUnit XML so aggregation systems can tell "passed after N attempts" from a
+    // first-try pass.
+    attempts: Int = 1
   )
 
   enum ScenarioOutcome:
@@ -109,10 +113,17 @@ object JUnitXMLFormatter {
     case Failed(message: String, stackTrace: Option[String])
     case Skipped
     case Pending(reason: String)
+    // An `@expectedFailure` scenario whose body failed as expected (#232). Rendered as <skipped>
+    // (build stays green) but distinguishable from a plain pass — CI dashboards can surface it.
+    case ExpectedFailure(reason: String)
 
   object ScenarioOutcome:
     def from(r: ScenarioResult): ScenarioOutcome =
+      // XPASS/XFAIL must be checked before `isPassed`: an expected failure has isPassed == true
+      // (the inversion), so it would otherwise be indistinguishable from a genuine pass.
       if (r.isIgnored) Skipped
+      else if (r.isUnexpectedlyPassing) Failed("expected to fail but passed — remove @expectedFailure", None)
+      else if (r.isExpectedFailure) ExpectedFailure(r.error.map(_.getMessage).getOrElse("body failed as expected"))
       else if (r.isPassed) Passed
       else if (r.hasPending && !r.hasFailure)
         Pending(
@@ -133,11 +144,12 @@ object JUnitXMLFormatter {
     timestamp: Instant,
     durationSecs: Double
   ):
-    def total: Int    = cases.length
-    def failures: Int = cases.count(_.outcome.isInstanceOf[ScenarioOutcome.Failed])
-    def skipped: Int  = cases.count(_.outcome == ScenarioOutcome.Skipped)
-    def pending: Int  = cases.count(_.outcome.isInstanceOf[ScenarioOutcome.Pending])
-    def passed: Int   = cases.count(_.outcome == ScenarioOutcome.Passed)
+    def total: Int            = cases.length
+    def failures: Int         = cases.count(_.outcome.isInstanceOf[ScenarioOutcome.Failed])
+    def skipped: Int          = cases.count(_.outcome == ScenarioOutcome.Skipped)
+    def pending: Int          = cases.count(_.outcome.isInstanceOf[ScenarioOutcome.Pending])
+    def expectedFailures: Int = cases.count(_.outcome.isInstanceOf[ScenarioOutcome.ExpectedFailure])
+    def passed: Int           = cases.count(_.outcome == ScenarioOutcome.Passed)
 
   sealed trait Format
   object Format:
@@ -168,7 +180,8 @@ object JUnitXMLFormatter {
         logs = logs.getOrElse(r.scenario.id.toString, CollectedLogs()),
         timestamp = timestamp,
         durationSecs = r.duration / 1000.0,
-        outcome = ScenarioOutcome.from(r)
+        outcome = ScenarioOutcome.from(r),
+        attempts = r.attempts
       )
     }
     TestSuiteRecord(
@@ -194,7 +207,7 @@ object JUnitXMLFormatter {
       "name"      -> suite.name,
       "tests"     -> suite.total.toString,
       "failures"  -> suite.failures.toString,
-      "skipped"   -> (suite.skipped + suite.pending).toString,
+      "skipped"   -> (suite.skipped + suite.pending + suite.expectedFailures).toString,
       "time"      -> f"${suite.durationSecs}%.3f",
       "timestamp" -> iso.format(suite.timestamp)
     ) ++
@@ -213,6 +226,7 @@ object JUnitXMLFormatter {
     ) ++
       tc.file.map("file" -> _).toSeq ++
       tc.line.map("line" -> _.toString).toSeq ++
+      (if (tc.attempts > 1) Some("attempts" -> tc.attempts.toString) else None).toSeq ++
       (if (tc.tags.nonEmpty) Some("tags" -> tc.tags.map("@" + _).mkString(" ")) else None).toSeq ++
       (if (format == Format.JUnit4) Seq("assertions" -> tc.steps.count(_.outcome == StepOutcome.Passed).toString)
        else Nil)
@@ -253,6 +267,8 @@ object JUnitXMLFormatter {
     case ScenarioOutcome.Skipped => <skipped/>
     case ScenarioOutcome.Pending(r) =>
       <skipped message={s"Pending: $r"}/>
+    case ScenarioOutcome.ExpectedFailure(reason) =>
+      <skipped message={s"expected failure: $reason"}/>
     case ScenarioOutcome.Failed(msg, trace) =>
       buildElem(
         "failure",

--- a/core/src/main/scala/zio/bdd/core/report/StreamingReporter.scala
+++ b/core/src/main/scala/zio/bdd/core/report/StreamingReporter.scala
@@ -76,16 +76,29 @@ object LiveProgressReporter extends StreamingReporter:
         Console.printLine(s"Running $n feature(s)$mode...").orDie
 
       case TestEvent.ScenarioFinished(result, featureName) =>
-        val icon = if (result.isPassed) "✓" else if (result.isIgnored) "○" else "✗"
-        val name = s"$featureName / ${result.scenario.name}"
-        Console.printLine(s"  $icon $name [${result.duration}ms]").orDie
+        // Same precedence as JUnitXMLFormatter/PrettyReporter: ignored first, then XFAIL/XPASS
+        // (which must precede isPassed — an expected failure has isPassed == true), then pass/fail.
+        val (icon, note) =
+          if (result.isIgnored) ("○", "")
+          else if (result.isExpectedFailure) ("⊗", " (expected failure)")
+          else if (result.isUnexpectedlyPassing) ("✗", " (unexpectedly passed — remove @expectedFailure)")
+          else if (result.isPassed) ("✓", "")
+          else ("✗", "")
+        val attempts = if (result.attempts > 1) s" (${result.attempts} attempts)" else ""
+        val name     = s"$featureName / ${result.scenario.name}"
+        Console.printLine(s"  $icon $name$note$attempts [${result.duration}ms]").orDie
 
       case TestEvent.SuiteFinished(results) =>
-        val total   = results.flatMap(_.scenarioResults).length
-        val passed  = results.flatMap(_.scenarioResults).count(_.isPassed)
-        val failed  = results.flatMap(_.scenarioResults).count(_.hasFailure)
-        val ignored = results.flatMap(_.scenarioResults).count(_.isIgnored)
-        Console.printLine(s"\nDone. $passed/$total passed, $failed failed, $ignored ignored").orDie
+        val scenarios = results.flatMap(_.scenarioResults)
+        val total     = scenarios.length
+        val passed    = scenarios.count(_.isPassed)
+        val failed    = scenarios.count(_.hasFailure)
+        val ignored   = scenarios.count(_.isIgnored)
+        val xfail     = scenarios.count(_.isExpectedFailure)
+        val xpass     = scenarios.count(_.isUnexpectedlyPassing)
+        val extra     = Seq(Option.when(xfail > 0)(s"$xfail xfail"), Option.when(xpass > 0)(s"$xpass xpass")).flatten
+        val suffix    = if (extra.nonEmpty) extra.mkString(" (", ", ", ")") else ""
+        Console.printLine(s"\nDone. $passed/$total passed, $failed failed, $ignored ignored$suffix").orDie
 
       case _ => ZIO.unit
     }

--- a/core/src/test/scala/zio/bdd/core/report/ReporterAspectsSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/report/ReporterAspectsSpec.scala
@@ -1,0 +1,139 @@
+package zio.bdd.core.report
+
+import zio.*
+import zio.test.*
+import zio.bdd.core.*
+import zio.bdd.gherkin.StepType
+import zio.stream.ZStream
+
+import java.time.Instant
+
+/**
+ * Gate for issue #238 — JUnit XML and the live streaming reporter must surface
+ * the scenario aspects (retry `attempts`, XFAIL/XPASS from `@expectedFailure`),
+ * not just the effective pass/fail.
+ *
+ * Note (as in JUnitXMLFormatterSpec): a scala.xml.Elem is a self-referential
+ * Seq, so every navigation is reduced to a plain String/Boolean BEFORE it
+ * reaches assertTrue.
+ */
+object ReporterAspectsSpec extends ZIOSpecDefault {
+
+  import ResultFixtures.*
+  import JUnitXMLFormatter.*
+
+  private val ts = Instant.parse("2024-01-15T10:00:00Z")
+
+  private val failingStep =
+    List((StepType.GivenStep, "does a thing", StepStatus.Failed(Cause.fail(new AssertionError("boom")))))
+  private val passingStep = List((StepType.GivenStep, "does a thing", StepStatus.Passed))
+
+  private def xfail(name: String): ScenarioResult =
+    mkScenarioResult(name, failingStep, tags = List("expectedFailure")).copy(expectedFailure = true)
+  private def xpass(name: String): ScenarioResult =
+    mkScenarioResult(name, passingStep, tags = List("expectedFailure")).copy(expectedFailure = true)
+  private def retried(name: String, n: Int): ScenarioResult =
+    mkScenarioResult(name, passingStep).copy(attempts = n)
+
+  private def renderXml(scenarios: List[ScenarioResult]): String = {
+    val fr = mkFeatureResult("F", scenarios)
+    generateXML(buildSuite(fr.feature, fr.scenarioResults, Map.empty, ts, "Suite"))
+  }
+
+  def spec = suite("ReporterAspectsSpec")(
+    suite("JUnit XML")(
+      test("XPASS emits a <failure> with an actionable message, not generic 'Scenario failed' (AC1)") {
+        val xml = renderXml(List(xpass("unexpected")))
+        assertTrue(xml.contains("<failure"), xml.contains("remove @expectedFailure"), !xml.contains("Scenario failed"))
+      },
+      test("XPASS still counts as a suite failure — build fails (AC2)") {
+        val doc      = parseXml(renderXml(List(xpass("unexpected"))))
+        val failures = (doc \ "@failures").text
+        assertTrue(failures == "1")
+      },
+      test("XFAIL emits <skipped> (distinguishable), not <failure>, and does not fail the build (AC3)") {
+        val xml      = renderXml(List(xfail("known bug")))
+        val doc      = parseXml(xml)
+        val failures = (doc \ "@failures").text
+        assertTrue(
+          xml.contains("<skipped"),
+          xml.contains("expected failure"),
+          !xml.contains("<failure"),
+          failures == "0"
+        )
+      },
+      test("attempts > 1 is carried into the testcase (AC4)") {
+        val doc      = parseXml(renderXml(List(retried("flaky", 3))))
+        val attempts = ((doc \ "testcase").head \ "@attempts").text
+        assertTrue(attempts == "3")
+      },
+      test("a first-try pass carries no attempts attribute (AC4)") {
+        val doc      = parseXml(renderXml(List(retried("clean", 1))))
+        val attempts = ((doc \ "testcase").head \ "@attempts").text
+        assertTrue(attempts == "")
+      },
+      test("a SETUP failure under @expectedFailure is a real <failure>, never masked as XFAIL-skipped") {
+        val setupFailed = mkScenarioResult("broken hook", passingStep, tags = List("expectedFailure"))
+          .copy(expectedFailure = true, setupError = Some(Cause.fail(new RuntimeException("hook exploded"))))
+        val xml      = renderXml(List(setupFailed))
+        val failures = (parseXml(xml) \ "@failures").text
+        assertTrue(xml.contains("<failure"), !xml.contains("expected failure:"), failures == "1")
+      },
+      test("mixed suite: XFAIL + XPASS + normal pass + normal fail — counts land correctly") {
+        val normalFail = mkScenarioResult("real fail", failingStep)
+        val normalPass = mkScenarioResult("real pass", passingStep)
+        val doc        = parseXml(renderXml(List(xfail("known"), xpass("surprise"), normalPass, normalFail)))
+        val tests      = (doc \ "@tests").text
+        val failures   = (doc \ "@failures").text // XPASS + normalFail
+        val skipped    = (doc \ "@skipped").text  // XFAIL
+        assertTrue(tests == "4", failures == "2", skipped == "1")
+      },
+      test("the <testsuite skipped> attribute tallies XFAIL alongside @ignore and pending") {
+        val doc =
+          parseXml(renderXml(List(xfail("known"), mkIgnoredScenarioResult("skipme"), mkPendingScenarioResult("todo"))))
+        val skipped = (doc \ "@skipped").text
+        assertTrue(skipped == "3")
+      }
+    ),
+    suite("LiveProgressReporter (streaming)")(
+      test("surfaces XFAIL, XPASS and retry attempts in the live scenario lines (AC5)") {
+        val events = List(
+          TestEvent.ScenarioFinished(xfail("known"), "F"),
+          TestEvent.ScenarioFinished(xpass("surprise"), "F"),
+          TestEvent.ScenarioFinished(retried("flaky", 3), "F")
+        )
+        for
+          _   <- LiveProgressReporter.consume(ZStream.fromIterable(events)).provide(LogCollector.live())
+          out <- TestConsole.output
+        yield
+          val text = out.mkString
+          assertTrue(
+            text.contains("expected failure"),
+            text.contains("remove @expectedFailure"),
+            text.contains("3 attempts")
+          )
+      },
+      test("SuiteFinished summary reports xfail and xpass counts") {
+        val fr = mkFeatureResult(
+          "F",
+          List(xfail("k"), xpass("s"), mkScenarioResult("p", passingStep), mkScenarioResult("f", failingStep))
+        )
+        for
+          _   <- LiveProgressReporter.consume(ZStream(TestEvent.SuiteFinished(List(fr)))).provide(LogCollector.live())
+          out <- TestConsole.output
+        yield
+          val text = out.mkString
+          assertTrue(text.contains("1 xfail"), text.contains("1 xpass"))
+      },
+      test("SuiteFinished summary suffix omits the aspect that is absent (only xfail present)") {
+        val fr = mkFeatureResult("F", List(xfail("k"), mkScenarioResult("p", passingStep)))
+        for
+          _   <- LiveProgressReporter.consume(ZStream(TestEvent.SuiteFinished(List(fr)))).provide(LogCollector.live())
+          out <- TestConsole.output
+        yield
+          val text = out.mkString
+          assertTrue(text.contains("1 xfail"), !text.contains("xpass"))
+      }
+    )
+  )
+}

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -161,6 +161,18 @@ target/test-reports/
 Both formats are compatible with Jenkins, GitLab CI, and GitHub Actions test report plugins.
 See `docs/adr/junit-report-formats.md` for a full comparison of the two XML structures.
 
+**Scenario aspects (retry, XFAIL/XPASS):**
+
+The retry (`@retry`/`@flaky`/`@nonFlaky`) and `@expectedFailure` aspects are surfaced in the XML so
+CI dashboards can distinguish tracked known-failures and flaky passes from ordinary results — build
+gating is unchanged (an expected failure never fails the build; an unexpected pass always does):
+
+| Aspect | XML representation |
+|---|---|
+| Ran more than once (retry) | `attempts="N"` attribute on the `<testcase>` (omitted when `N == 1`) |
+| `@expectedFailure` body **failed** (XFAIL) | `<skipped message="expected failure: …"/>` — counted under `skipped`, not `failures` |
+| `@expectedFailure` body **passed** (XPASS) | `<failure message="expected to fail but passed — remove @expectedFailure"/>` |
+
 **Duration:**
 
 The `time` attribute on each `<testcase>` is the real wall-clock duration of the scenario in

--- a/docs/running.md
+++ b/docs/running.md
@@ -426,7 +426,8 @@ override def scenarioAspects: Map[String, ScenarioAspect] =
 - `@ignore` wins over a retry tag: an ignored scenario never runs and is not retried. Include/
   exclude tag filtering is unaffected — the retry tags are not treated as filter labels.
 - The pretty reporter appends `(k attempts)` to a scenario that ran more than once; the count is
-  also available as `ScenarioResult.attempts` for custom reporters.
+  also available as `ScenarioResult.attempts` for custom reporters, and carried into JUnit XML as an
+  `attempts="k"` attribute on the `<testcase>` (see `docs/reporters.md`).
 - Retry tags are **scenario-level only** — a `@retry(n)` placed above `Feature:` does not apply to
   the feature's scenarios; tag each scenario (or use `scenarioAspects`). An unrecognised or
   malformed argument (e.g. `@retry(abc)`) is ignored and the scenario runs once.
@@ -462,6 +463,10 @@ Scenario: refunds are not yet prorated
   validates step wiring). It is a scenario-level tag and is **not** applied to `@property`
   scenarios (which have their own execution path). `ScenarioResult` exposes `isExpectedFailure` /
   `isUnexpectedlyPassing` for custom reporters.
+- **In JUnit XML** an XFAIL is emitted as `<skipped message="expected failure: …"/>` (distinct from a
+  plain pass, so CI dashboards can track it) and an XPASS as a `<failure>` telling you to remove the
+  tag; the live streaming reporter marks them `⊗ (expected failure)` / `(unexpectedly passed …)`.
+  See `docs/reporters.md`.
 
 ---
 


### PR DESCRIPTION
Surfaces the retry (`attempts`, #225) and `@expectedFailure` (XFAIL/XPASS, #232) scenario aspects in JUnit XML and the live streaming reporter — previously only the pretty console reporter showed them.

- **XPASS** → `<failure message="expected to fail but passed — remove @expectedFailure">` (was a generic "Scenario failed" with no trace).
- **XFAIL** → `<skipped message="expected failure: …"/>` — distinguishable from a plain pass; build stays green.
- **attempts > 1** → `attempts="N"` attribute on the `<testcase>`.
- `LiveProgressReporter` mirrors all three (per-scenario line + `SuiteFinished` xfail/xpass summary).

Build gating is unchanged and non-masking — a genuine setup failure on an `@expectedFailure` scenario is still a real `<failure>`, verified by test. Three MiMa filters added for the additive `TestCaseRecord.attempts` field. Docs in reporters.md §junitxml + running.md.

Closes #238
Milestone: none (diagnostics/observability follow-up to #225/#232).