### PR TITLE
MockControl Intercept capability + DSL — built-in HTTPS intercept via Rift (drop mitmproxy)

### DIFF
--- a/conformance/src/main/scala/zio/bdd/mock/conformance/NegotiationErrorScenarios.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/NegotiationErrorScenarios.scala
@@ -42,7 +42,8 @@ object NegotiationErrorScenarios:
         Capability.StateInspection   -> control.stateInspection,
         Capability.Scripting         -> control.scripting,
         Capability.ProxyRecord       -> control.proxyRecord,
-        Capability.Templating        -> control.templating
+        Capability.Templating        -> control.templating,
+        Capability.Intercept         -> control.intercept
       )
       for
         outcomes <- ZIO.foreach(accessors)((cap, acc) => acc.either.map(cap -> _))

--- a/conformance/src/test/jdk22/zio/bdd/mock/conformance/EmbeddedConformanceSpec.scala
+++ b/conformance/src/test/jdk22/zio/bdd/mock/conformance/EmbeddedConformanceSpec.scala
@@ -41,7 +41,8 @@ object EmbeddedConformanceSpec extends ZIOSpecDefault:
         Capability.ProxyRecord,
         Capability.Templating,
         Capability.StatefulScenarios,
-        Capability.StateInspection
+        Capability.StateInspection,
+        Capability.Intercept
       ),
       Isolation.PerInstance,
       available = EmbeddedRift.available

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ConformanceMatrixSpec.scala
@@ -97,7 +97,7 @@ object ConformanceMatrixSpec extends ZIOSpecDefault:
     MockBackendUnderTest(
       "rift",
       (Client.default ++ Provisioning.live) >>> Rift.managed().mapError(asT),
-      Capability.values.toSet, // Rift advertises every capability (#132)
+      Capability.values.toSet - Capability.Intercept, // the container advertises all but Intercept (#219, embedded-only)
       Isolation.PerInstance,
       available = riftEnabled
     )

--- a/docs/mock-advanced.md
+++ b/docs/mock-advanced.md
@@ -30,11 +30,15 @@ _  <- sc.define(space, defineRetry(path))
 | `Capability.Scripting` | `scripting: IO[Unsupported, Scripting]` | yes | yes | no |
 | `Capability.ProxyRecord` | `proxyRecord: IO[Unsupported, ProxyRecord]` | yes | yes | no |
 | `Capability.Templating` | `templating: IO[Unsupported, Templating]` | yes | yes | no |
+| `Capability.Intercept` | `intercept: IO[Unsupported, Intercept]` | no | yes | no |
 
 Faults, StatefulScenarios, and StateInspection are portable across all three
 adapters. Scripting, ProxyRecord, and Templating are Rift-only (container or
 embedded — embedded is capability-complete, a pure backend swap for the
-container, not a reduced subset); WireMock does not advertise them. See
+container, not a reduced subset); WireMock does not advertise them. `Intercept`
+(built-in HTTPS intercept, §9) is **embedded-only**: it runs the TLS-MITM
+listener in-process over the FFI; the container and WireMock adapters inherit
+the `Unsupported` fallback. See
 [Adapters](mock-adapters.md) for the full per-adapter breakdown and
 [Mocking overview](mocking.md) for the `MockControl` port these accessors sit
 on.
@@ -376,3 +380,75 @@ Next: [Cookbook](mock-cookbook.md)
 
 See also: [Mocking overview](mocking.md) · [the DSL](mock-dsl.md) ·
 [Adapters](mock-adapters.md)
+
+---
+
+## 9. HTTPS intercept — drop the mitmproxy container (`Capability.Intercept`)
+
+When a SUT **hard-codes** an external HTTPS host you cannot change
+(`https://cdn.example.com/…`), the usual trick is to stand up a separate
+**mitmproxy** container that TLS-MITMs that host and redirects it to a mock. The
+embedded Rift provider does this **in-process, with no extra container**: it runs
+a TLS-MITM forward-proxy, mints a per-host leaf cert signed by its own CA, and
+either forwards the intercepted host to a mock space or answers it inline.
+
+The MITM constraint is intrinsic — the SUT must trust the intercept CA — so the
+goal is to *provision* that trust, not eliminate it: `trustStore` hands you a
+ready-to-use JVM truststore (JKS by default) + password, and `proxyPort` is the
+loopback port the SUT proxies through. Starting the listener is lazy and opt-in:
+a suite that never calls `mc.intercept` pays nothing.
+
+Build rules with the DSL — `intercept(host).redirectTo(space)` or
+`.respondWith(stub)` — and apply them through the capability:
+
+```scala
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.dsl.*
+import zio.bdd.mock.rift.embedded.EmbeddedRift
+
+// A layer for the in-process engine — no Docker, no mitmproxy.
+val mock = Provisioning.live >>> EmbeddedRift.layer
+
+val setUp: ZIO[MockControl, Throwable, TrustStore] =
+  for
+    mc     <- ZIO.service[MockControl]
+    // the imposter that will answer the intercepted host
+    spaces <- mc.provision(MockSource.Resource("cdn-config.json")).mapError(e => new RuntimeException(e.toString))
+    ic     <- mc.intercept.mapError(u => new RuntimeException(u.message))
+    // redirect the hard-coded external host to that mock space
+    _      <- ic.add(intercept("cdn.example.com").redirectTo(spaces.head))
+              .mapError(e => new RuntimeException(e.toString))
+    // (or answer inline, no imposter needed:)
+    //   _ <- ic.add(intercept("cdn.example.com").respondWith(InterceptStub(200, body = Some("""{"cdn":"mocked"}"""))))
+    ts     <- ic.trustStore().mapError(e => new RuntimeException(e.toString)) // JKS path + password
+    port   <- ic.proxyPort.mapError(e => new RuntimeException(e.toString))    // the loopback proxy port
+  yield ts
+```
+
+Wire the JVM SUT in one line each — trust the CA and route HTTPS through the
+intercept port:
+
+```
+-Djavax.net.ssl.trustStore=<ts.path> -Djavax.net.ssl.trustStorePassword=<ts.password>
+-Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=<port>
+```
+
+The SUT's call to `https://cdn.example.com/config.json` is intercepted, its TLS
+terminated with a leaf cert the truststore trusts, and the request forwarded to
+your mock imposter (or answered by the inline stub) — the mitmproxy container is
+gone. See `EmbeddedInterceptSpec` for the runnable end-to-end version (a real
+`java.net.http.HttpClient` driving the intercept).
+
+**Isolation semantics.** `redirectTo` forwards to the target space's imposter
+**port**; under PerInstance (the embedded default) each space has its own port,
+so the redirect lands on exactly that space. `respondWith` is
+isolation-independent. Because a Correlated space shares one imposter port and is
+separated by a correlation header the intercepted request does not carry, use
+PerInstance (the default) for host redirects.
+
+> **Truststore format.** `trustStore` defaults to **JKS**, which the JVM's
+> default `TrustManagerFactory` loads as a `trustedCertEntry` out of the box.
+> `TrustStoreFormat.Pkcs12` is selectable, but rift's PKCS#12 export is not yet
+> surfaced as a trust anchor by the JVM `KeyStore` (rift#417) — prefer JKS for a
+> JVM SUT.

--- a/mock/src/main/scala/zio/bdd/mock/Capability.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Capability.scala
@@ -9,7 +9,7 @@ import zio.IO
  * un-advertised one the accessor fails fast with [[Unsupported]].
  */
 enum Capability:
-  case Faults, StatefulScenarios, StateInspection, Scripting, ProxyRecord, Templating
+  case Faults, StatefulScenarios, StateInspection, Scripting, ProxyRecord, Templating, Intercept
 
 /**
  * How a backend keeps mock spaces isolated under parallel features/scenarios.
@@ -96,6 +96,60 @@ trait ProxyRecord:
    * mutate rules after the first recorded call.
    */
   def proxy(space: MockSpace, m: RequestMatch, upstream: String): IO[MockError, RuleId]
+
+/**
+ * Built-in HTTPS intercept (#219): a TLS-MITM forward-proxy that intercepts
+ * matched hosts and either forwards them to a mock space or answers them inline
+ * — so a SUT that hard-codes an external HTTPS host (whose address you cannot
+ * change) can be redirected to a mock without an external mitmproxy container.
+ * Capability: [[Capability.Intercept]].
+ *
+ * The SUT is wired in two steps (both automated by this port): it trusts the
+ * intercept CA (via the [[trustStore]] file + password) and points its HTTPS
+ * proxy at [[proxyPort]] on loopback. The MITM constraint is intrinsic — the
+ * SUT must trust the CA — so the goal is to *provision* that trust, not
+ * eliminate it.
+ *
+ * Starting the intercept listener is opt-in and lazy: it happens on the first
+ * call to any method here, so a suite that never intercepts pays nothing.
+ */
+trait Intercept:
+  /**
+   * The loopback port the SUT points its HTTPS proxy at. Starts the intercept
+   * listener on first use (memoized), so repeat calls return the same port.
+   */
+  def proxyPort: IO[MockError, Int]
+
+  /**
+   * Install an intercept `rule` — build it with
+   * `dsl.intercept(host).redirectTo(space)` / `.respondWith(stub)`. Rules are
+   * first-match in installation order.
+   */
+  def add(rule: InterceptRule): IO[MockError, Unit]
+
+  /**
+   * Export a truststore containing the intercept CA to a fresh temp file,
+   * returning its path + password — hand both to the SUT's JVM so it trusts the
+   * intercept's per-host leaf certificates. Defaults to JKS: it loads as a JVM
+   * truststore out of the box (a `trustedCertEntry` the default
+   * `TrustManagerFactory` reads); PKCS#12 is selectable but see rift#417 —
+   * rift's PKCS#12 export is not yet exposed as a trust anchor by the JVM's
+   * `KeyStore`.
+   */
+  def trustStore(format: TrustStoreFormat = TrustStoreFormat.Jks): IO[MockError, TrustStore]
+
+  /**
+   * Convenience: intercept `host` and forward its requests to `space`'s
+   * imposter.
+   */
+  final def redirectTo(host: String, space: MockSpace): IO[MockError, Unit] =
+    add(InterceptRule.Redirect(host, space))
+
+  /**
+   * Convenience: intercept `host` and answer its requests inline with `stub`.
+   */
+  final def respondWith(host: String, stub: InterceptStub): IO[MockError, Unit] =
+    add(InterceptRule.Serve(host, stub))
 
 /** Response templating. Capability: [[Capability.Templating]]. */
 trait Templating:

--- a/mock/src/main/scala/zio/bdd/mock/Dsl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Dsl.scala
@@ -169,3 +169,21 @@ object dsl:
 
     private def add(thenState: Option[ScenarioState]): ScenarioBuilder =
       sb.copy(rules = sb.rules :+ StatefulRule(whenState, request, response, thenState))
+
+  // --- intercept (HTTPS intercept capability, #219) -------------------------
+
+  /**
+   * Begin an intercept rule for HTTPS `host`:
+   * `intercept("cdn.example.com").redirectTo(space)` or `.respondWith(stub)`.
+   * Produces a portable [[InterceptRule]] applied via the [[Intercept]]
+   * capability
+   * (`mc.intercept.flatMap(_.add(intercept(host).redirectTo(space)))`).
+   */
+  def intercept(host: String): InterceptBuilder = InterceptBuilder(host)
+
+  final case class InterceptBuilder private[dsl] (host: String):
+    /** Forward the intercepted host's requests to `space`'s imposter. */
+    def redirectTo(space: MockSpace): InterceptRule = InterceptRule.Redirect(host, space)
+
+    /** Answer the intercepted host's requests inline with `stub`. */
+    def respondWith(stub: InterceptStub): InterceptRule = InterceptRule.Serve(host, stub)

--- a/mock/src/main/scala/zio/bdd/mock/Intercept.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Intercept.scala
@@ -1,0 +1,55 @@
+package zio.bdd.mock
+
+import java.nio.file.Path
+
+/**
+ * Portable value types for the [[Capability.Intercept]] capability (#219): a
+ * built-in HTTPS intercept / TLS-MITM forward-proxy that redirects a hard-coded
+ * external host to a mock, so a suite can drop an external mitmproxy container.
+ * Backend-neutral — no rift (or any adapter) types leak in, so a different
+ * backend could implement `Intercept` over its own proxy features.
+ */
+
+/**
+ * The truststore format the SUT's JVM consumes
+ * (`-Djavax.net.ssl.trustStoreType`).
+ */
+enum TrustStoreFormat:
+  case Pkcs12, Jks
+
+  /** The lowercase wire token an adapter passes to its backend. */
+  def wire: String = this match
+    case Pkcs12 => "pkcs12"
+    case Jks    => "jks"
+
+/**
+ * A ready-to-use truststore file containing the intercept CA, plus the password
+ * that opens it. Hand both to the SUT's JVM so it trusts the intercept's
+ * per-host leaf certificates: `-Djavax.net.ssl.trustStore=<path>
+ * -Djavax.net.ssl.trustStorePassword=<password>`.
+ */
+final case class TrustStore(path: Path, password: String, format: TrustStoreFormat)
+
+/**
+ * An inline response served for an intercepted host (the `respondWith` action).
+ */
+final case class InterceptStub(
+  status: Int = 200,
+  headers: Map[String, String] = Map.empty,
+  body: Option[String] = None
+)
+
+/**
+ * A portable intercept rule: match an intercepted HTTPS `host` and either
+ * forward it to a mock [[MockSpace]] or answer it inline with a
+ * [[InterceptStub]]. Build one with the DSL —
+ * `dsl.intercept(host).redirectTo(space)` / `.respondWith(stub)` — and apply it
+ * via [[Intercept.add]] (or the `redirectTo`/`respondWith` convenience
+ * methods).
+ */
+enum InterceptRule:
+  /** Intercept `host` and forward its requests to `to`'s imposter. */
+  case Redirect(host: String, to: MockSpace)
+
+  /** Intercept `host` and answer its requests inline with `stub`. */
+  case Serve(host: String, stub: InterceptStub)

--- a/mock/src/main/scala/zio/bdd/mock/MockControl.scala
+++ b/mock/src/main/scala/zio/bdd/mock/MockControl.scala
@@ -111,3 +111,11 @@ trait MockControl:
   def scripting: IO[Unsupported, Scripting]
   def proxyRecord: IO[Unsupported, ProxyRecord]
   def templating: IO[Unsupported, Templating]
+
+  /**
+   * Built-in HTTPS intercept (#219). Defaults to the [[Unsupported]] fallback
+   * so only an adapter that actually runs an intercept listener (the embedded
+   * Rift provider) overrides it — the container/WireMock adapters inherit the
+   * fallback, keeping the capability backend-neutral.
+   */
+  def intercept: IO[Unsupported, Intercept] = ZIO.fail(Unsupported(Capability.Intercept, backendName))

--- a/mock/src/test/scala/zio/bdd/mock/CapabilityNegotiationSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/CapabilityNegotiationSpec.scala
@@ -95,6 +95,13 @@ object CapabilityNegotiationSpec extends ZIOSpecDefault:
         noneRequired == Right(())
       )
     },
+    test("intercept defaults to the Unsupported fallback for an adapter that doesn't override it (#219)") {
+      // AC1: Capability.Intercept is backend-neutral — the accessor is a default `Unsupported` on
+      // MockControl, so an adapter that doesn't run an intercept listener (here the stub) inherits it.
+      val backend = StubMockControl("rift", Set.empty)
+      for either <- backend.intercept.either
+      yield assertTrue(either == Left(Unsupported(Capability.Intercept, "rift")))
+    },
     test("advertised accessors and require both succeed for every capability") {
       // AC2: for an advertised capability the accessor never returns Unsupported,
       // and require for that capability succeeds — the two sides of the honesty

--- a/mock/src/test/scala/zio/bdd/mock/InterceptDslSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/InterceptDslSpec.scala
@@ -1,0 +1,31 @@
+package zio.bdd.mock
+
+import zio.test.*
+
+/**
+ * The portable Intercept DSL + value types (#219, AC1/AC2): pure builders that
+ * produce the neutral [[InterceptRule]] a suite applies via the [[Intercept]]
+ * capability. No backend needed.
+ */
+object InterceptDslSpec extends ZIOSpecDefault:
+
+  import dsl.*
+
+  private val space = MockSpace("http://localhost:4545", identity, SpaceId("s1"))
+
+  def spec = suite("Intercept DSL (#219)")(
+    test("intercept(host).redirectTo(space) builds a Redirect rule") {
+      assertTrue(
+        intercept("cdn.example.com").redirectTo(space) == InterceptRule.Redirect("cdn.example.com", space)
+      )
+    },
+    test("intercept(host).respondWith(stub) builds a Serve rule") {
+      val stub = InterceptStub(status = 418, headers = Map("X-Teapot" -> "1"), body = Some("teapot"))
+      assertTrue(
+        intercept("cdn.example.com").respondWith(stub) == InterceptRule.Serve("cdn.example.com", stub)
+      )
+    },
+    test("TrustStoreFormat.wire is the backend token") {
+      assertTrue(TrustStoreFormat.Pkcs12.wire == "pkcs12", TrustStoreFormat.Jks.wire == "jks")
+    }
+  )

--- a/rift-embedded/src/main/java/zio/bdd/mock/rift/embedded/RiftFfiBridge.java
+++ b/rift-embedded/src/main/java/zio/bdd/mock/rift/embedded/RiftFfiBridge.java
@@ -98,6 +98,12 @@ public final class RiftFfiBridge implements AutoCloseable {
   private final MethodHandle spaceDelete;
   private final MethodHandle spaceRecorded;
 
+  // v0.11.0 intercept (rift#410): start the TLS-MITM forward-proxy + drive its rule store + export
+  // the CA truststore, so the embedded provider offers built-in HTTPS intercept over the C-ABI.
+  private final MethodHandle startIntercept;
+  private final MethodHandle interceptAddRules;
+  private final MethodHandle interceptExportTruststore;
+
   private RiftFfiBridge(Arena arena, SymbolLookup lookup, MemorySegment handle) {
     this.arena = arena;
     this.handle = handle;
@@ -130,6 +136,12 @@ public final class RiftFfiBridge implements AutoCloseable {
         ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_SHORT, ValueLayout.ADDRESS));
     this.spaceRecorded = downcall(lookup, "rift_space_recorded", FunctionDescriptor.of(
         ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_SHORT, ValueLayout.ADDRESS));
+    this.startIntercept = downcall(lookup, "rift_start_intercept",
+        FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+    this.interceptAddRules = downcall(lookup, "rift_intercept_add_rules",
+        FunctionDescriptor.of(ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+    this.interceptExportTruststore = downcall(lookup, "rift_intercept_export_truststore", FunctionDescriptor.of(
+        ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
   }
 
   /**
@@ -281,6 +293,52 @@ public final class RiftFfiBridge implements AutoCloseable {
       return readAndFree(result);
     } catch (Throwable t) {
       throw failure("rift_space_recorded", t);
+    }
+  }
+
+  /**
+   * Start the intercept/TLS-MITM forward-proxy listener; returns its bound-endpoint JSON
+   * ({@code {"interceptPort":N,"interceptUrl":"http://127.0.0.1:N"}}). Throws with the engine's
+   * {@code rift_last_error} on a null sentinel (bad options, bind failure, or already started).
+   */
+  public String startIntercept(String optionsJson) {
+    MemorySegment result;
+    try (Arena call = Arena.ofConfined()) {
+      result = (MemorySegment) startIntercept.invoke(handle, (MemorySegment) ALLOC_STRING.invoke(call, optionsJson));
+    } catch (Throwable t) {
+      throw failure("rift_start_intercept", t);
+    }
+    String json;
+    try {
+      json = readAndFree(result);
+    } catch (Throwable t) {
+      throw failure("rift_start_intercept", t);
+    }
+    if (json == null) {
+      throw new IllegalStateException("rift_start_intercept returned null" + lastErrorSuffix());
+    }
+    return json;
+  }
+
+  /** Add one intercept rule (a bare object) or many (a JSON array). Returns {@code 0}/{@code -1}. */
+  public int interceptAddRules(String rulesJson) {
+    try (Arena call = Arena.ofConfined()) {
+      return (int) interceptAddRules.invoke(handle, (MemorySegment) ALLOC_STRING.invoke(call, rulesJson));
+    } catch (Throwable t) {
+      throw failure("rift_intercept_add_rules", t);
+    }
+  }
+
+  /**
+   * Write a truststore for the intercept CA to {@code outPath} ({@code format} = {@code "pkcs12"}/
+   * {@code "jks"}). Returns {@code 0}/{@code -1}.
+   */
+  public int interceptExportTruststore(String format, String password, String outPath) {
+    try (Arena call = Arena.ofConfined()) {
+      return (int) interceptExportTruststore.invoke(handle, (MemorySegment) ALLOC_STRING.invoke(call, format),
+          (MemorySegment) ALLOC_STRING.invoke(call, password), (MemorySegment) ALLOC_STRING.invoke(call, outPath));
+    } catch (Throwable t) {
+      throw failure("rift_intercept_export_truststore", t);
     }
   }
 

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedIntercept.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedIntercept.scala
@@ -1,0 +1,89 @@
+package zio.bdd.mock.rift.embedded
+
+import zio.*
+import zio.bdd.mock.*
+import zio.json.*
+import zio.json.ast.Json
+
+import java.nio.file.Files
+
+/**
+ * The [[Intercept]] capability over the embedded engine's intercept FFI
+ * (rift#410, #219): starts the TLS-MITM forward-proxy lazily on first use
+ * (memoized in `started`), installs rules, and exports the CA truststore —
+ * entirely over the C-ABI, no loopback HTTP. The engine's scope owns the
+ * listener (`rift_stop` shuts it down), so this holds no finalizer of its own.
+ *
+ * Isolation semantics (#123): `redirectTo` forwards an intercepted host to the
+ * target space's imposter PORT. Under PerInstance (the embedded default) each
+ * space has its own port, so a redirect lands on exactly that space.
+ * `respondWith` is isolation-independent (an inline stub). A Correlated space
+ * shares one imposter port and is separated by a correlation header the
+ * intercepted request does not carry, so redirecting a host to a Correlated
+ * space would hit the shared imposter's unscoped stubs — use PerInstance (the
+ * default) for host redirects.
+ */
+private[embedded] final class EmbeddedIntercept(
+  engine: EmbeddedEngine,
+  started: Ref.Synchronized[Option[Int]]
+) extends Intercept:
+
+  def proxyPort: IO[MockError, Int] = ensureStarted
+
+  def add(rule: InterceptRule): IO[MockError, Unit] =
+    ZIO.fromEither(EmbeddedIntercept.ruleJson(rule)).flatMap(json => ensureStarted *> engine.interceptAddRules(json))
+
+  def trustStore(format: TrustStoreFormat): IO[MockError, TrustStore] =
+    for
+      _ <- ensureStarted
+      tmp <- ZIO.attemptBlocking {
+               val p = Files.createTempFile("rift-intercept-", s".${format.wire}")
+               p.toFile.deleteOnExit()
+               p
+             }
+               .mapError(t => MockError.CommunicationError(s"creating intercept truststore temp file: ${message(t)}"))
+      _ <- engine.interceptExportTruststore(format.wire, EmbeddedIntercept.DefaultPassword, tmp.toString)
+    yield TrustStore(tmp, EmbeddedIntercept.DefaultPassword, format)
+
+  // Start the listener at most once (race-safe), memoizing its bound proxy port.
+  private def ensureStarted: IO[MockError, Int] =
+    started.modifyZIO {
+      case s @ Some(p) => ZIO.succeed((p, s))
+      case None =>
+        engine.startIntercept(EmbeddedIntercept.StartOptions).map(i => (i.interceptPort, Some(i.interceptPort)))
+    }
+
+  private def message(t: Throwable): String = Option(t.getMessage).getOrElse(t.getClass.getSimpleName)
+
+private[embedded] object EmbeddedIntercept:
+  // Loopback, OS-assigned port — the listener binds where the SUT proxies through.
+  private val StartOptions: String    = Json.Obj("host" -> Json.Str("127.0.0.1"), "port" -> Json.Num(0)).toJson
+  private val DefaultPassword: String = "changeit"
+
+  /**
+   * Build the rift intercept-rule JSON from a portable [[InterceptRule]]. Left
+   * on a Redirect whose target space has no port in its `baseUri`.
+   */
+  private[embedded] def ruleJson(rule: InterceptRule): Either[MockError, String] =
+    rule match
+      case InterceptRule.Redirect(host, space) =>
+        portOf(space.baseUri).map { port =>
+          Json
+            .Obj("host" -> Json.Str(host), "action" -> Json.Obj("forward" -> Json.Obj("port" -> Json.Num(port))))
+            .toJson
+        }
+      case InterceptRule.Serve(host, stub) =>
+        val headers = Json.Obj(stub.headers.map((k, v) => k -> Json.Str(v)).toSeq*)
+        val serve = Json.Obj(
+          "statusCode" -> Json.Num(stub.status),
+          "headers"    -> headers,
+          "body"       -> stub.body.fold[Json](Json.Null)(Json.Str(_))
+        )
+        Right(Json.Obj("host" -> Json.Str(host), "action" -> Json.Obj("serve" -> serve)).toJson)
+
+  private def portOf(baseUri: String): Either[MockError, Int] =
+    scala.util
+      .Try(java.net.URI.create(baseUri).getPort)
+      .toOption
+      .filter(_ > 0)
+      .toRight(MockError.InvalidDefinition(s"intercept redirect target has no port in its baseUri: $baseUri"))

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
@@ -58,14 +58,15 @@ private[embedded] final case class EmbeddedRiftMockControl(
   spaces: Ref[Map[SpaceId, EmbeddedRiftMockControl.Imposter]],
   correlated: Ref[Map[SpaceId, EmbeddedRiftMockControl.CorrSpace]],
   sharedPort: Ref.Synchronized[Option[Int]],
-  ids: Ref[Int]
+  ids: Ref[Int],
+  interceptStarted: Ref.Synchronized[Option[Int]]
 ) extends MockControl:
 
   import EmbeddedRiftMockControl.{CorrSpace, Imposter}
 
   def backendName: String = "embedded"
 
-  // The v2 in-process admin plane makes the embedded adapter capability-complete: all six.
+  // The FFI admin plane + intercept make the embedded adapter capability-complete: all seven.
   def capabilities: Set[Capability] =
     Set(
       Capability.Faults,
@@ -73,7 +74,8 @@ private[embedded] final case class EmbeddedRiftMockControl(
       Capability.ProxyRecord,
       Capability.Templating,
       Capability.StatefulScenarios,
-      Capability.StateInspection
+      Capability.StateInspection,
+      Capability.Intercept
     )
 
   override def isolation: Isolation = mode match
@@ -172,7 +174,12 @@ private[embedded] final case class EmbeddedRiftMockControl(
   def faults: IO[Unsupported, Faults]           = ZIO.succeed(embeddedFaults)
   def scripting: IO[Unsupported, Scripting]     = ZIO.succeed(embeddedScripting)
   def proxyRecord: IO[Unsupported, ProxyRecord] = ZIO.succeed(embeddedProxyRecord)
-  def templating: IO[Unsupported, Templating]   = ZIO.succeed(embeddedTemplating)
+
+  // Built-in HTTPS intercept (#219) over the intercept FFI (rift#410); one instance per adapter so the
+  // TLS-MITM listener starts at most once (memoized in interceptStarted).
+  private val embeddedIntercept: Intercept           = EmbeddedIntercept(engine, interceptStarted)
+  override def intercept: IO[Unsupported, Intercept] = ZIO.succeed(embeddedIntercept)
+  def templating: IO[Unsupported, Templating]        = ZIO.succeed(embeddedTemplating)
 
   // Scenario/state route over the in-process admin plane (rift#343).
   def scenarios: IO[Unsupported, StatefulScenarios]     = ZIO.succeed(embeddedScenarios)
@@ -642,6 +649,7 @@ private[embedded] object EmbeddedRiftMockControl:
       correlated <- Ref.make(Map.empty[SpaceId, CorrSpace])
       sharedPort <- Ref.Synchronized.make(Option.empty[Int])
       ids        <- Ref.make(0)
-      control     = EmbeddedRiftMockControl(engine, provisioning, mode, spaces, correlated, sharedPort, ids)
+      intercept  <- Ref.Synchronized.make(Option.empty[Int])
+      control     = EmbeddedRiftMockControl(engine, provisioning, mode, spaces, correlated, sharedPort, ids, intercept)
       _          <- ZIO.addFinalizer(control.teardownShared)
     yield control

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/RiftFfi.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/RiftFfi.scala
@@ -80,6 +80,27 @@ private[embedded] trait EmbeddedEngine:
    */
   def spaceRecorded(port: Int, flowId: String): IO[MockError, String]
 
+  // Built-in HTTPS intercept over direct C-ABI (rift#410, #219): start the TLS-MITM forward-proxy,
+  // add rules to its store, and export the CA truststore — no loopback HTTP.
+
+  /**
+   * Start the intercept/TLS-MITM forward-proxy from `optionsJson`
+   * (`{"host","port"}`, or `{}`).
+   */
+  def startIntercept(optionsJson: String): IO[MockError, EmbeddedEngine.InterceptInfo]
+
+  /**
+   * Add one intercept rule (or a JSON array) — the shape rift's intercept rule
+   * store accepts.
+   */
+  def interceptAddRules(rulesJson: String): IO[MockError, Unit]
+
+  /**
+   * Write a truststore (`format` = "pkcs12"/"jks") for the intercept CA to
+   * `outPath`.
+   */
+  def interceptExportTruststore(format: String, password: String, outPath: String): IO[MockError, Unit]
+
 private[embedded] object EmbeddedEngine:
 
   /**
@@ -111,6 +132,13 @@ private[embedded] object EmbeddedEngine:
   private[embedded] final case class FlowStateValue(value: String)
   private[embedded] object FlowStateValue:
     given JsonDecoder[FlowStateValue] = DeriveJsonDecoder.gen[FlowStateValue]
+
+  /**
+   * The bound endpoint of the intercept listener, from `rift_start_intercept`.
+   */
+  final case class InterceptInfo(interceptPort: Int, interceptUrl: String)
+  object InterceptInfo:
+    given JsonDecoder[InterceptInfo] = DeriveJsonDecoder.gen[InterceptInfo]
 
   /**
    * The live engine over [[RiftFfiBridge]] — the Panama FFM bindings to
@@ -231,6 +259,31 @@ private[embedded] object EmbeddedEngine:
       }.flatMap {
         case Right(json) => ZIO.succeed(json)
         case Left(msg)   => ZIO.fail(MockError.CommunicationError(msg))
+      }
+
+    def startIntercept(optionsJson: String): IO[MockError, InterceptInfo] =
+      blocking("rift_start_intercept")(bridge.startIntercept(optionsJson)).flatMap { json =>
+        ZIO
+          .fromEither(json.fromJson[InterceptInfo])
+          .mapError(e => MockError.CommunicationError(s"rift_start_intercept returned unparseable info: $e ($json)"))
+      }
+
+    def interceptAddRules(rulesJson: String): IO[MockError, Unit] =
+      blocking("rift_intercept_add_rules") {
+        val rc = bridge.interceptAddRules(rulesJson)
+        if rc == 0 then None else Some(withReason(s"rift_intercept_add_rules returned $rc"))
+      }.flatMap {
+        case None      => ZIO.unit
+        case Some(msg) => ZIO.fail(MockError.CommunicationError(msg))
+      }
+
+    def interceptExportTruststore(format: String, password: String, outPath: String): IO[MockError, Unit] =
+      blocking("rift_intercept_export_truststore") {
+        val rc = bridge.interceptExportTruststore(format, password, outPath)
+        if rc == 0 then None else Some(withReason(s"rift_intercept_export_truststore returned $rc"))
+      }.flatMap {
+        case None      => ZIO.unit
+        case Some(msg) => ZIO.fail(MockError.CommunicationError(msg))
       }
 
     private def blocking[A](op: String)(thunk: => A): IO[MockError, A] =

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedInterceptSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedInterceptSpec.scala
@@ -1,0 +1,95 @@
+package zio.bdd.mock.rift.embedded
+
+import zio.*
+import zio.bdd.mock.*
+import zio.test.*
+
+import java.net.{InetSocketAddress, ProxySelector, URI}
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import java.nio.file.Files
+import java.security.KeyStore
+import javax.net.ssl.{SSLContext, TrustManagerFactory}
+
+/**
+ * End-to-end acceptance for the built-in HTTPS intercept capability (#219,
+ * AC4/AC6): the embedded engine runs the TLS-MITM forward-proxy with no extra
+ * container, and a real JVM HTTPS client — the stand-in SUT — trusting the
+ * exported CA and proxying through the intercept port has its call to a
+ * hard-coded external host intercepted and answered by the mock. This is the
+ * mitmproxy replacement.
+ *
+ * Gated on the native library ([[EmbeddedRift.available]]), mirroring the other
+ * embedded specs; the whole suite SKIPs (passes) when no library resolves for
+ * the host.
+ */
+object EmbeddedInterceptSpec extends ZIOSpecDefault:
+
+  private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
+
+  // The stand-in SUT: a JDK HttpClient trusting `ts` and proxying HTTPS through the intercept port.
+  // Forced HTTP/1.1 — the MITM tunnel serves 1.1 (an h2 upgrade over the tunnel would EOF, zb-183).
+  private def sutGet(url: String, proxyPort: Int, ts: TrustStore): Task[(Int, String)] =
+    ZIO.attemptBlocking {
+      val ks = KeyStore.getInstance(ts.format match
+        case TrustStoreFormat.Pkcs12 => "PKCS12"
+        case TrustStoreFormat.Jks    => "JKS"
+      )
+      val in = Files.newInputStream(ts.path)
+      try ks.load(in, ts.password.toCharArray)
+      finally in.close()
+      val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+      tmf.init(ks)
+      val ssl = SSLContext.getInstance("TLS")
+      ssl.init(null, tmf.getTrustManagers, null)
+      val client = HttpClient
+        .newBuilder()
+        .version(HttpClient.Version.HTTP_1_1)
+        .sslContext(ssl)
+        .proxy(ProxySelector.of(new InetSocketAddress("127.0.0.1", proxyPort)))
+        .build()
+      val resp =
+        client.send(HttpRequest.newBuilder(URI.create(url)).GET().build(), HttpResponse.BodyHandlers.ofString())
+      (resp.statusCode, resp.body)
+    }
+
+  private val cdnConfig = MockSource.Dsl(
+    MockSpec(
+      List(
+        MockRule(
+          RequestMatch(path = PathMatch.Exact("/config.json")),
+          ResponseDef(status = 200, body = Body.Text("""{"cdn":"mocked"}"""))
+        )
+      )
+    )
+  )
+
+  def spec = suite("EmbeddedIntercept (#219)")(
+    test("redirectTo: an HTTPS call to a hard-coded external host is intercepted and served by the mock imposter") {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
+      else
+        (for
+          mc    <- ZIO.service[MockControl]
+          space <- mc.provision(cdnConfig).mapError(asT).map(_.head)
+          ic    <- mc.intercept.mapError(u => new RuntimeException(u.message))
+          _     <- ic.redirectTo("cdn.example.com", space).mapError(asT)
+          ts    <- ic.trustStore(TrustStoreFormat.Jks).mapError(asT)
+          port  <- ic.proxyPort.mapError(asT)
+          res   <- sutGet("https://cdn.example.com/config.json", port, ts)
+        yield assertTrue(res._1 == 200, res._2.contains("mocked")))
+          .provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
+    },
+    test("respondWith: an intercepted host is answered inline from the CA-trusting SUT") {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
+      else
+        (for
+          mc <- ZIO.service[MockControl]
+          ic <- mc.intercept.mapError(u => new RuntimeException(u.message))
+          _ <-
+            ic.respondWith("api.example.com", InterceptStub(status = 418, body = Some("inline-teapot"))).mapError(asT)
+          ts   <- ic.trustStore(TrustStoreFormat.Jks).mapError(asT)
+          port <- ic.proxyPort.mapError(asT)
+          res  <- sutGet("https://api.example.com/anything", port, ts)
+        yield assertTrue(res._1 == 418, res._2.contains("inline-teapot")))
+          .provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
+    }
+  ) @@ TestAspect.withLiveClock @@ TestAspect.sequential

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
@@ -31,7 +31,10 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
     val replaced: Ref[Map[Int, String]],
     val deleted: Ref[Chunk[Int]],
     val flowState: Ref[Map[(Int, String, String), String]],
-    val spaceStubs: Ref[Map[(Int, String), Vector[String]]]
+    val spaceStubs: Ref[Map[(Int, String), Vector[String]]],
+    val interceptStarts: Ref[Int],
+    val interceptRules: Ref[Chunk[String]],
+    val truststoreExports: Ref[Chunk[(String, String, String)]]
   ) extends EmbeddedEngine:
     def createImposter(configJson: String): IO[MockError, Int] = ZIO.succeed(portOf(configJson))
     def replaceStubs(port: Int, stubsJson: String): IO[MockError, Unit] =
@@ -55,6 +58,14 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
       spaceStubs.update(_ - ((port, flowId)))
     def spaceRecorded(port: Int, flowId: String): IO[MockError, String] = ZIO.succeed("[]")
 
+    // Intercept FFI (#219): count listener starts (to prove memoization), capture the rule JSON and
+    // the truststore-export args the adapter drives.
+    def startIntercept(optionsJson: String): IO[MockError, EmbeddedEngine.InterceptInfo] =
+      interceptStarts.update(_ + 1).as(EmbeddedEngine.InterceptInfo(38080, "http://127.0.0.1:38080"))
+    def interceptAddRules(rulesJson: String): IO[MockError, Unit] = interceptRules.update(_ :+ rulesJson)
+    def interceptExportTruststore(format: String, password: String, outPath: String): IO[MockError, Unit] =
+      truststoreExports.update(_ :+ (format, password, outPath))
+
     private def portOf(cfg: String): Int =
       cfg
         .fromJson[zio.json.ast.Json]
@@ -75,7 +86,10 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
         deleted    <- Ref.make(Chunk.empty[Int])
         flowState  <- Ref.make(Map.empty[(Int, String, String), String])
         spaceStubs <- Ref.make(Map.empty[(Int, String), Vector[String]])
-        engine      = RecordingEngine(replaced, deleted, flowState, spaceStubs)
+        icStarts   <- Ref.make(0)
+        icRules    <- Ref.make(Chunk.empty[String])
+        icExports  <- Ref.make(Chunk.empty[(String, String, String)])
+        engine      = RecordingEngine(replaced, deleted, flowState, spaceStubs, icStarts, icRules, icExports)
         control    <- EmbeddedRiftMockControl.make(engine, prov, mode)
         result     <- use(control, engine)
       yield result
@@ -94,7 +108,7 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
         yield assertTrue(portFromUri(space.baseUri) > 0, portFromUri(space.baseUri) != 9998)
       }
     },
-    test("advertises all six capabilities and every accessor succeeds") {
+    test("advertises all seven capabilities and every accessor succeeds") {
       withControl() { (control, _) =>
         for
           faultsE   <- control.faults.either
@@ -103,6 +117,7 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
           templateE <- control.templating.either
           scenE     <- control.scenarios.either
           siE       <- control.stateInspection.either
+          icE       <- control.intercept.either
         yield assertTrue(
           control.capabilities == Set(
             Capability.Faults,
@@ -110,14 +125,16 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
             Capability.ProxyRecord,
             Capability.Templating,
             Capability.StatefulScenarios,
-            Capability.StateInspection
+            Capability.StateInspection,
+            Capability.Intercept
           ),
           faultsE.isRight,
           scriptE.isRight,
           proxyE.isRight,
           templateE.isRight,
           scenE.isRight,
-          siE.isRight
+          siE.isRight,
+          icE.isRight
         )
       }
     },
@@ -344,6 +361,60 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
           stubs.contains("/over") && stubs.contains("/base"),
           stubs.indexOf("/boom") < stubs.indexOf("/over"), // fault registered ahead of the rules
           stubs.indexOf("/over") < stubs.indexOf("/base")  // overlay first-match over the base rule
+        )
+      }
+    },
+    test(
+      "intercept: capability advertised, accessor succeeds, redirect/serve build the FFI rule JSON, start memoized"
+    ) {
+      withControl() { (control, engine) =>
+        for
+          space  <- control.provision(pingSource).map(_.head)
+          port    = portFromUri(space.baseUri)
+          ic     <- control.intercept
+          _      <- ic.redirectTo("cdn.example.com", space)
+          _      <- ic.respondWith("api.example.com", InterceptStub(status = 418, body = Some("teapot")))
+          p      <- ic.proxyPort
+          rules  <- engine.interceptRules.get
+          starts <- engine.interceptStarts.get
+        yield assertTrue(
+          control.capabilities.contains(Capability.Intercept),
+          p == 38080,
+          starts == 1, // one listener despite redirect + serve + proxyPort (memoized)
+          rules.exists(j =>
+            j.contains("\"forward\"") && j.contains(s"\"port\":$port") && j.contains("cdn.example.com")
+          ),
+          rules.exists(j =>
+            j.contains("\"serve\"") && j.contains("418") && j.contains("teapot") && j.contains("api.example.com")
+          )
+        )
+      }
+    },
+    test("intercept: a redirect whose target space has no port in its baseUri fails with InvalidDefinition") {
+      val portless = MockSpace("localhost-without-a-port", identity, SpaceId("x"))
+      val ok       = MockSpace("http://localhost:4545", identity, SpaceId("y"))
+      assertTrue(
+        EmbeddedIntercept.ruleJson(InterceptRule.Redirect("cdn.example.com", portless)).isLeft,
+        EmbeddedIntercept.ruleJson(InterceptRule.Redirect("cdn.example.com", ok)) match
+          case Right(j) => j.contains("\"forward\"") && j.contains("\"port\":4545")
+          case Left(_)  => false
+      )
+    },
+    test("intercept.trustStore defaults to JKS, exports to a temp file, and returns its path + password") {
+      withControl() { (control, engine) =>
+        for
+          ic      <- control.intercept
+          ts      <- ic.trustStore()
+          p12     <- ic.trustStore(TrustStoreFormat.Pkcs12)
+          exports <- engine.truststoreExports.get
+        yield assertTrue(
+          ts.format == TrustStoreFormat.Jks,
+          ts.password == "changeit",
+          ts.path.toString.endsWith(".jks"),
+          exports.exists((fmt, pw, path) => fmt == "jks" && pw == "changeit" && path == ts.path.toString),
+          // the format is honoured — PKCS#12 is still selectable
+          p12.format == TrustStoreFormat.Pkcs12,
+          exports.exists((fmt, _, path) => fmt == "pkcs12" && path == p12.path.toString)
         )
       }
     },

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftFfiSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftFfiSpec.scala
@@ -220,7 +220,8 @@ object EmbeddedRiftFfiSpec extends ZIOSpecDefault:
             Capability.ProxyRecord,
             Capability.Templating,
             Capability.StatefulScenarios,
-            Capability.StateInspection
+            Capability.StateInspection,
+            Capability.Intercept
           ),
           s0 == ScenarioState.Started,
           stepped.status == 200 && stepped.body == "one",

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -249,7 +249,8 @@ object RiftMockControlSpec extends ZIOSpecDefault:
           proxyE    <- control.proxyRecord.either
           templateE <- control.templating.either
         yield assertTrue(
-          control.capabilities == Capability.values.toSet,
+          // The container adapter advertises every capability except Intercept (#219 — embedded-only).
+          control.capabilities == Capability.values.toSet - Capability.Intercept,
           faultsE.isRight,
           scenE.isRight,
           siE.isRight,


### PR DESCRIPTION
## Summary

A SUT that hard-codes an external HTTPS host needed an external mitmproxy container to mock it. This adds a backend-neutral `Capability.Intercept` (DSL: `intercept(host).redirectTo(space)/respondWith(stub)` + truststore/CA accessor) wired in the embedded Rift adapter over the rift v0.11.0 intercept FFI (rift#410), so the whole flow runs in-process with no extra container. Defaults truststore to JKS (rift's PKCS12 export isn't JVM-trust-loadable yet — rift#417).

Closes #219

**Dependencies:** Rift v0.11.0 (already pinned). Surfaces rift#417 (PKCS12 truststore export) for future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)