### PR TITLE
build: bump Rift to v0.11.1 — apply flow-state not-found signal (#416) + JVM-loadable PKCS12 (#418)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ import java.security.MessageDigest
 // Single source of truth for the pinned Rift release (#195). Both the FFI natives (riftNativesVersion,
 // downloaded into the embedded-natives jar) and the container image tag (Rift.DefaultImage, via the
 // generated RiftBuildInfo below) derive from it, so a version bump touches exactly one line.
-val riftVersion        = "0.11.0"
+val riftVersion        = "0.11.1"
 val riftNativesVersion = riftVersion
 
 // The (os, arch, ext) cdylibs bundled into the natives jar — linux/macOS × x86_64/aarch64 (#134).

--- a/docs/mock-advanced.md
+++ b/docs/mock-advanced.md
@@ -447,8 +447,7 @@ isolation-independent. Because a Correlated space shares one imposter port and i
 separated by a correlation header the intercepted request does not carry, use
 PerInstance (the default) for host redirects.
 
-> **Truststore format.** `trustStore` defaults to **JKS**, which the JVM's
-> default `TrustManagerFactory` loads as a `trustedCertEntry` out of the box.
-> `TrustStoreFormat.Pkcs12` is selectable, but rift's PKCS#12 export is not yet
-> surfaced as a trust anchor by the JVM `KeyStore` (rift#417) — prefer JKS for a
-> JVM SUT.
+> **Truststore format.** `trustStore` defaults to **PKCS#12** (the JVM's default
+> keystore type since JDK 9); `TrustStoreFormat.Jks` is selectable. Both load as a
+> `trustedCertEntry` the default `TrustManagerFactory` reads out of the box, so
+> either works for a JVM SUT.

--- a/mock/src/main/scala/zio/bdd/mock/Capability.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Capability.scala
@@ -130,13 +130,13 @@ trait Intercept:
   /**
    * Export a truststore containing the intercept CA to a fresh temp file,
    * returning its path + password — hand both to the SUT's JVM so it trusts the
-   * intercept's per-host leaf certificates. Defaults to JKS: it loads as a JVM
-   * truststore out of the box (a `trustedCertEntry` the default
-   * `TrustManagerFactory` reads); PKCS#12 is selectable but see rift#417 —
-   * rift's PKCS#12 export is not yet exposed as a trust anchor by the JVM's
-   * `KeyStore`.
+   * intercept's per-host leaf certificates. Defaults to PKCS#12 (the JVM's
+   * default keystore type since JDK 9); JKS is selectable. Both load as a JVM
+   * truststore out of the box — a `trustedCertEntry` the default
+   * `TrustManagerFactory` reads (rift's PKCS#12 export was made JVM-loadable in
+   * rift#418).
    */
-  def trustStore(format: TrustStoreFormat = TrustStoreFormat.Jks): IO[MockError, TrustStore]
+  def trustStore(format: TrustStoreFormat = TrustStoreFormat.Pkcs12): IO[MockError, TrustStore]
 
   /**
    * Convenience: intercept `host` and forward its requests to `space`'s

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
@@ -314,38 +314,32 @@ private[embedded] final case class EmbeddedRiftMockControl(
     )
 
   private val embeddedStateInspection: StateInspection = new StateInspection:
-    // Guard `currentState` on the locally-tracked scenarios (like `setState`/`reset`) so an undeclared
-    // name is an accurate InvalidDefinition from the Ref — not inferred from a `flow_state_get` null,
-    // which the crate also returns on a genuine engine error (rift#415: null conflates absent-key and
-    // error).
     def currentState(space: MockSpace, name: String): IO[MockError, ScenarioState] =
-      dispatch(space)(cs => guardDefined(cs.scenarios, space.id, name)(readState(cs.port, cs.flowId, space.id, name)))(
-        imp => guardDefined(imp.scenarios, space.id, name)(readState(imp.port, imp.port.toString, space.id, name))
+      dispatch(space)(cs => readState(cs.port, cs.flowId, space.id, name))(imp =>
+        readState(imp.port, imp.port.toString, space.id, name)
       )
     def setState(space: MockSpace, name: String, to: ScenarioState): IO[MockError, Unit] =
       dispatch(space)(cs => guardDefined(cs.scenarios, space.id, name)(putScenarioState(cs.port, cs.flowId, name, to)))(
         imp => guardDefined(imp.scenarios, space.id, name)(putScenarioState(imp.port, imp.port.toString, name, to))
       )
 
-  private def guardDefined[A](
+  private def guardDefined(
     scenarios: Ref[Map[String, ScenarioState]],
     spaceId: SpaceId,
     name: String
-  )(action: => IO[MockError, A]): IO[MockError, A] =
+  )(action: => IO[MockError, Unit]): IO[MockError, Unit] =
     scenarios.get.flatMap(s =>
       if s.contains(name) then action
       else ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${spaceId.value}"))
     )
 
-  // Reached only for a scenario the guard confirmed is declared (so `define` has pinned its state):
-  // a `Some` is its current state. A `None` here is anomalous — a declared scenario whose flow-state
-  // key vanished, or a genuine engine error the null-return can't distinguish — surfaced as a
-  // CommunicationError rather than masked as "no scenario" (which the guard already rules out).
+  // rift#416 gives `flow_state_get` an unambiguous not-found signal, so a `None` accurately means the
+  // scenario was never declared (`define` always pins its initial state) — mapped to InvalidDefinition,
+  // not masked over a genuine engine error (which now surfaces from `flowStateGet` as a CommunicationError).
   private def readState(port: Int, flowId: String, spaceId: SpaceId, name: String): IO[MockError, ScenarioState] =
     engine.flowStateGet(port, flowId, name).flatMap {
       case Some(s) => ZIO.succeed(ScenarioState(s))
-      case None =>
-        ZIO.fail(MockError.CommunicationError(s"scenario '$name' on space ${spaceId.value} has no readable state"))
+      case None    => ZIO.fail(MockError.InvalidDefinition(s"no scenario '$name' on space ${spaceId.value}"))
     }
 
   // flowId = the imposter port (PerInstance) / the correlation value (Correlated): the slice a

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/RiftFfi.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/RiftFfi.scala
@@ -125,13 +125,33 @@ private[embedded] object EmbeddedEngine:
     given JsonDecoder[BuildInfo] = DeriveJsonDecoder.gen[BuildInfo]
 
   /**
-   * The `value` field of a `rift_flow_state_get` result
-   * (`{"flowId","key","value"}`), decoded as its string form — scenario state
-   * (the sole reader) is stored as a JSON string. Extra fields ignored.
+   * A `rift_flow_state_get` result envelope
+   * (`{"found","flowId","key","value"}`, rift#416): `found` disambiguates an
+   * absent key (`found=false`, a non-error outcome) from a value present, while
+   * a null pointer means a genuine error alone. `value` is the scenario state's
+   * string form (or absent when not found). Extra fields ignored.
    */
-  private[embedded] final case class FlowStateValue(value: String)
-  private[embedded] object FlowStateValue:
-    given JsonDecoder[FlowStateValue] = DeriveJsonDecoder.gen[FlowStateValue]
+  private[embedded] final case class FlowStateResult(found: Boolean, value: Option[String] = None)
+  private[embedded] object FlowStateResult:
+    given JsonDecoder[FlowStateResult] = DeriveJsonDecoder.gen[FlowStateResult]
+
+  /**
+   * Interpret a `rift_flow_state_get` non-null envelope: `found=false` → `None`
+   * (a clean not-found); `found=true` → `Some(value)`. A `found=true` with no
+   * value is a contract violation — surfaced as a CommunicationError, not
+   * silently coerced to not-found (so an engine anomaly never masquerades as
+   * "no scenario"). Unparseable JSON is likewise a CommunicationError.
+   */
+  private[embedded] def interpretFlowState(json: String): Either[MockError, Option[String]] =
+    json
+      .fromJson[FlowStateResult]
+      .left
+      .map(e => MockError.CommunicationError(s"rift_flow_state_get returned unparseable JSON: $e ($json)"))
+      .flatMap {
+        case FlowStateResult(true, None) =>
+          Left(MockError.CommunicationError(s"rift_flow_state_get returned found=true with no value ($json)"))
+        case r => Right(if r.found then r.value else None)
+      }
 
   /**
    * The bound endpoint of the intercept listener, from `rift_start_intercept`.
@@ -212,17 +232,15 @@ private[embedded] object EmbeddedEngine:
             .mapError(e => MockError.CommunicationError(s"rift_build_info returned unparseable build info: $e ($json)"))
       }
 
-    // A null return is "key absent" (mapped to None) — the crate also returns null on a genuine
-    // error, but the adapter only reads a scenario it defined on a live imposter, so absence is the
-    // meaningful case (mirrors the HTTP path's `Option[String]`). rift's null conflates the two.
+    // rift#416: a null pointer is a genuine error (→ CommunicationError); an absent key is the
+    // non-error `{"found":false}` envelope (→ None). So absence and failure are no longer conflated.
     def flowStateGet(port: Int, flowId: String, key: String): IO[MockError, Option[String]] =
-      blocking("rift_flow_state_get")(Option(bridge.flowStateGet(port, flowId, key))).flatMap {
-        case None => ZIO.none
-        case Some(json) =>
-          ZIO
-            .fromEither(json.fromJson[FlowStateValue])
-            .mapError(e => MockError.CommunicationError(s"rift_flow_state_get returned unparseable JSON: $e ($json)"))
-            .map(v => Some(v.value))
+      blocking("rift_flow_state_get") {
+        val json = bridge.flowStateGet(port, flowId, key)
+        if json == null then Left(withReason(s"rift_flow_state_get returned null for port $port")) else Right(json)
+      }.flatMap {
+        case Left(msg)   => ZIO.fail(MockError.CommunicationError(msg))
+        case Right(json) => ZIO.fromEither(interpretFlowState(json))
       }
 
     def flowStatePut(port: Int, flowId: String, key: String, valueJson: String): IO[MockError, Unit] =

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedInterceptSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedInterceptSpec.scala
@@ -72,7 +72,7 @@ object EmbeddedInterceptSpec extends ZIOSpecDefault:
           space <- mc.provision(cdnConfig).mapError(asT).map(_.head)
           ic    <- mc.intercept.mapError(u => new RuntimeException(u.message))
           _     <- ic.redirectTo("cdn.example.com", space).mapError(asT)
-          ts    <- ic.trustStore(TrustStoreFormat.Jks).mapError(asT)
+          ts    <- ic.trustStore().mapError(asT) // default PKCS#12 (JVM-loadable since rift#418)
           port  <- ic.proxyPort.mapError(asT)
           res   <- sutGet("https://cdn.example.com/config.json", port, ts)
         yield assertTrue(res._1 == 200, res._2.contains("mocked")))

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
@@ -400,23 +400,35 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
           case Left(_)  => false
       )
     },
-    test("intercept.trustStore defaults to JKS, exports to a temp file, and returns its path + password") {
+    test("intercept.trustStore defaults to PKCS#12, exports to a temp file, and returns its path + password") {
       withControl() { (control, engine) =>
         for
           ic      <- control.intercept
           ts      <- ic.trustStore()
-          p12     <- ic.trustStore(TrustStoreFormat.Pkcs12)
+          jks     <- ic.trustStore(TrustStoreFormat.Jks)
           exports <- engine.truststoreExports.get
         yield assertTrue(
-          ts.format == TrustStoreFormat.Jks,
+          ts.format == TrustStoreFormat.Pkcs12,
           ts.password == "changeit",
-          ts.path.toString.endsWith(".jks"),
-          exports.exists((fmt, pw, path) => fmt == "jks" && pw == "changeit" && path == ts.path.toString),
-          // the format is honoured — PKCS#12 is still selectable
-          p12.format == TrustStoreFormat.Pkcs12,
-          exports.exists((fmt, _, path) => fmt == "pkcs12" && path == p12.path.toString)
+          ts.path.toString.endsWith(".pkcs12"),
+          exports.exists((fmt, pw, path) => fmt == "pkcs12" && pw == "changeit" && path == ts.path.toString),
+          // the format is honoured — JKS is still selectable
+          jks.format == TrustStoreFormat.Jks,
+          exports.exists((fmt, _, path) => fmt == "jks" && path == jks.path.toString)
         )
       }
+    },
+    test("interpretFlowState: found→Some, not-found→None, found-without-value→error, garbage→error (rift#416)") {
+      assertTrue(
+        EmbeddedEngine.interpretFlowState("""{"found":true,"flowId":"5","key":"s","value":"Paid"}""") == Right(
+          Some("Paid")
+        ),
+        EmbeddedEngine.interpretFlowState("""{"found":false,"value":null}""") == Right(None),
+        // a null pointer is the error path (handled in Live before parse); a found=true with no value is
+        // a contract violation surfaced as an error, never silently coerced to not-found.
+        EmbeddedEngine.interpretFlowState("""{"found":true,"value":null}""").isLeft,
+        EmbeddedEngine.interpretFlowState("not json").isLeft
+      )
     },
     test("destroy frees the port via rift_delete_imposter; later ops on the space fail SpaceNotFound") {
       withControl() { (control, engine) =>

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftFfiSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftFfiSpec.scala
@@ -212,7 +212,11 @@ object EmbeddedRiftFfiSpec extends ZIOSpecDefault:
           s1      <- si.currentState(space, "checkout").mapError(asT)
           _       <- ss.reset(space, "checkout").mapError(asT)
           s2      <- si.currentState(space, "checkout").mapError(asT)
-          _       <- control.destroy(space).mapError(asT)
+          // rift#416 over the live engine: an undeclared scenario is a clean not-found
+          // (`found:false` → None → InvalidDefinition), NOT a null pointer (which would be a
+          // CommunicationError). Proves the revert's load-bearing assumption against the real crate.
+          notFound <- si.currentState(space, "neverDefined").either
+          _        <- control.destroy(space).mapError(asT)
         yield assertTrue(
           control.capabilities == Set(
             Capability.Faults,
@@ -226,7 +230,10 @@ object EmbeddedRiftFfiSpec extends ZIOSpecDefault:
           s0 == ScenarioState.Started,
           stepped.status == 200 && stepped.body == "one",
           s1 == ScenarioState("Done"), // serving /step advanced the FSM
-          s2 == ScenarioState.Started  // reset re-pinned the initial state
+          s2 == ScenarioState.Started, // reset re-pinned the initial state
+          notFound match
+            case Left(MockError.InvalidDefinition(_)) => true
+            case _                                    => false
         )).provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
     },
     test("v2: destroy frees the port via rift_delete_imposter — an immediate re-provision serves again") {

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
@@ -14,9 +14,9 @@ object RiftBuildInfoSpec extends ZIOSpecDefault:
   def spec = suite("RiftBuildInfo")(
     test("DefaultImage is derived from the single rift-version source of truth") {
       assertTrue(
-        RiftBuildInfo.riftVersion == "0.11.0",
+        RiftBuildInfo.riftVersion == "0.11.1",
         Rift.DefaultImage == s"zainalpour/rift-proxy:v${RiftBuildInfo.riftVersion}",
-        Rift.DefaultImage == "zainalpour/rift-proxy:v0.11.0"
+        Rift.DefaultImage == "zainalpour/rift-proxy:v0.11.1"
       )
     }
   )


### PR DESCRIPTION
## Summary

v0.11.1 ships rift#416 (rift_flow_state_get now returns a {found,value} envelope) and rift#418 (export_pkcs12 is now JVM-loadable).

The embedded adapter parses the flow-state envelope and reverts its v0.11.0 workaround; Intercept.trustStore defaults back to PKCS#12. Verified end-to-end on real 0.11.1 natives.

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)