### PR TITLE
zio-bdd-rift-embedded-jdk21 is compiled to Java-22 bytecode (class 66) — won't load on JDK 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,15 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libluajit-5.1-dev
       - name: Preview embedded tests
         run: sbt "riftEmbedded21/test"
+      # The point of the -jdk21 cut is to load on JDK 21, where FFM is preview (class <= 65). Guard
+      # against a regression to class 66 (Java 22), which shipped in 1.3.1 (#247) and would break the
+      # documented JDK-21 + --enable-preview path.
+      - name: Assert the JDK-21 bridge is class <= 65
+        run: |
+          bridges=$(find rift-embedded-jdk21/target -name RiftFfiBridge.class)
+          count=$(printf '%s' "$bridges" | grep -c . || true)
+          if [ "$count" -ne 1 ]; then
+            echo "::error::expected exactly one RiftFfiBridge.class under rift-embedded-jdk21/target, found $count"
+            exit 1
+          fi
+          bash scripts/assert-class-max-version.sh "$bridges" 65

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,18 @@ jobs:
           java-version: 21
           cache: sbt
       - uses: sbt/setup-sbt@v1
+      # Gate the artifact BEFORE publishing: the -jdk21 cut must be class <= 65 so it loads on JDK 21.
+      # v1.3.1 published it as class 66 (#247); this check would have caught that.
+      - name: Assert the JDK-21 bridge is class <= 65 before publishing
+        run: |
+          sbt "riftEmbedded21/Compile/compile"
+          bridges=$(find rift-embedded-jdk21/target -name RiftFfiBridge.class)
+          count=$(printf '%s' "$bridges" | grep -c . || true)
+          if [ "$count" -ne 1 ]; then
+            echo "::error::expected exactly one RiftFfiBridge.class under rift-embedded-jdk21/target, found $count"
+            exit 1
+          fi
+          bash scripts/assert-class-max-version.sh "$bridges" 65
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/scripts/assert-class-max-version.sh
+++ b/scripts/assert-class-max-version.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Fail if a .class file's bytecode major version exceeds a ceiling.
+#
+# Guards issue #247: the JDK-21 embedded FFM bridge (`RiftFfiBridge`) must stay class-file major
+# version <= 65 so it loads on a JDK-21 runtime. v1.3.1 shipped it as class 66 (Java 22) with nothing
+# preventing the regression; this script is wired into the CI preview job and the release publish job.
+#
+# Reads the major version straight from the class-file header: bytes 0-3 are the 0xCAFEBABE magic,
+# bytes 4-5 the minor version, bytes 6-7 the (big-endian) major version. A preview class (e.g.
+# class 65 built with --enable-preview) has minor 0xFFFF but the major is still 65, so this is the
+# right field to compare. No JDK toolchain required.
+#
+# Usage: assert-class-max-version.sh <class-file> <max-major>
+#
+# `set -u` is load-bearing: on a truncated/non-.class file `od` yields too few tokens, so the
+# positional args below are unset and the arithmetic aborts rather than silently computing major=0.
+set -euo pipefail
+
+class_file=${1:?usage: assert-class-max-version.sh <class-file> <max-major>}
+max_major=${2:?usage: assert-class-max-version.sh <class-file> <max-major>}
+
+if [ ! -f "$class_file" ]; then
+  echo "::error::class file not found: $class_file" >&2
+  exit 2
+fi
+
+# Verify the 0xCAFEBABE magic before trusting the version bytes, so a non-class file (a partial
+# compile, a wrong path) can't slip through as a bogus "major version 0".
+magic=$(od -An -tx1 -N4 "$class_file" | tr -d ' \n')
+if [ "$magic" != "cafebabe" ]; then
+  echo "::error::$class_file is not a Java class file (magic=$magic)" >&2
+  exit 2
+fi
+
+# Word-split the two bytes on any whitespace (od's spacing differs between GNU and BSD).
+set -- $(od -An -tu1 -j6 -N2 "$class_file")
+major=$(( $1 * 256 + $2 ))
+
+if [ "$major" -gt "$max_major" ]; then
+  echo "::error::$class_file is class-file major version $major (> $max_major) — won't load on the target JDK" >&2
+  exit 1
+fi
+
+echo "OK: $(basename "$class_file") is class-file major version $major (<= $max_major)"


### PR DESCRIPTION
The `-jdk21` embedded FFM bridge (`RiftFfiBridge`) must be class-file major version <= 65 to load on JDK 21; v1.3.1 shipped it as class 66 with no regression guard.

`build.sbt` already compiles `riftEmbedded21` with `--release 21 --enable-preview`, and both the CI preview and release publish-preview jobs run on JDK 21 — so master already produces class <= 65 (the green preview-JDK-21 CI job loads the bridge). This PR adds a durable guard rather than a compile-flag change:

- `scripts/assert-class-max-version.sh <class-file> <max-major>` — reads the class-file major version (validating the `0xCAFEBABE` magic first) and fails past the ceiling.
- CI "preview (JDK 21)" job asserts `RiftFfiBridge <= class 65` after the embedded tests (catches PR regressions).
- Release "publish-preview" job runs the same check before `ci-release`, so a class-66 bridge can never be published again — the check that would have caught 1.3.1.

Closes #247
Milestone: none.