### PR TITLE
Embedded Intercept proxy needs a configurable bind host (+ optional fixed port) to serve a containerized SUT

### DIFF
--- a/docs/mock-advanced.md
+++ b/docs/mock-advanced.md
@@ -451,3 +451,34 @@ PerInstance (the default) for host redirects.
 > keystore type since JDK 9); `TrustStoreFormat.Jks` is selectable. Both load as a
 > `trustedCertEntry` the default `TrustManagerFactory` reads out of the box, so
 > either works for a JVM SUT.
+
+**Containerized SUT (bind a reachable interface).** The examples above bind the
+intercept proxy to **loopback** — right when the SUT is a host process. When the
+SUT runs in a **Docker container** while the test + engine run on the host, a
+loopback socket refuses the container's gateway-originated connection. Bind a
+wider interface with `InterceptConfig` (opt-in — the default stays `127.0.0.1`,
+so nothing is exposed off loopback unless you ask):
+
+```scala
+import zio.bdd.mock.rift.embedded.EmbeddedRift.InterceptConfig
+
+// Reachable from another container/host via the Docker host-gateway; pin the port
+// so a compose-orchestrated SUT can be told its proxy target up front.
+val mock = Provisioning.live >>> EmbeddedRift.layer(InterceptConfig(bindHost = "0.0.0.0", port = Some(8888)))
+```
+
+`proxyEndpoint` reports the **actually-bound** host and port (not just the
+loopback port), so you can log or inject them. The SUT container points its HTTPS
+proxy at the Docker host-gateway and trusts the exported truststore mounted into
+the container:
+
+```
+# in the SUT container (host-gateway = host.docker.internal on Docker Desktop):
+-Djavax.net.ssl.trustStore=/mnt/intercept-truststore.p12 -Djavax.net.ssl.trustStorePassword=<pw>
+-Dhttps.proxyHost=host.docker.internal -Dhttps.proxyPort=8888
+```
+
+Only the **one** intercept proxy port needs to be container-reachable: the engine
+forwards intercepted traffic to the target space's imposter internally on
+loopback, so imposter ports stay private. See the `bindHost 0.0.0.0` case in
+`EmbeddedInterceptSpec` for a runnable check over a non-loopback interface.

--- a/mock/src/main/scala/zio/bdd/mock/Capability.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Capability.scala
@@ -121,6 +121,17 @@ trait Intercept:
   def proxyPort: IO[MockError, Int]
 
   /**
+   * The host and port the SUT points its HTTPS proxy at — the interface the
+   * intercept listener actually bound. Defaults to [[proxyPort]] on loopback;
+   * an adapter that can bind a wider interface (e.g. `0.0.0.0`, so a SUT in a
+   * container reaches the proxy via the Docker host-gateway) reports its
+   * configured bind host here. Starts the listener on first use (memoized). An
+   * adapter that can bind a non-loopback interface MUST override this — the
+   * default assumes the listener bound loopback.
+   */
+  def proxyEndpoint: IO[MockError, (String, Int)] = proxyPort.map(("127.0.0.1", _))
+
+  /**
    * Install an intercept `rule` — build it with
    * `dsl.intercept(host).redirectTo(space)` / `.respondWith(stub)`. Rules are
    * first-match in installation order.

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedIntercept.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedIntercept.scala
@@ -25,10 +25,15 @@ import java.nio.file.Files
  */
 private[embedded] final class EmbeddedIntercept(
   engine: EmbeddedEngine,
-  started: Ref.Synchronized[Option[Int]]
+  started: Ref.Synchronized[Option[Int]],
+  config: EmbeddedRift.InterceptConfig
 ) extends Intercept:
 
   def proxyPort: IO[MockError, Int] = ensureStarted
+
+  // The listener binds `config.bindHost` (loopback by default), so report that as the reachable host —
+  // a wider bind (e.g. 0.0.0.0 for a containerized SUT) is where a caller points its proxy, not 127.0.0.1.
+  override def proxyEndpoint: IO[MockError, (String, Int)] = ensureStarted.map((config.bindHost, _))
 
   def add(rule: InterceptRule): IO[MockError, Unit] =
     ZIO.fromEither(EmbeddedIntercept.ruleJson(rule)).flatMap(json => ensureStarted *> engine.interceptAddRules(json))
@@ -50,15 +55,21 @@ private[embedded] final class EmbeddedIntercept(
     started.modifyZIO {
       case s @ Some(p) => ZIO.succeed((p, s))
       case None =>
-        engine.startIntercept(EmbeddedIntercept.StartOptions).map(i => (i.interceptPort, Some(i.interceptPort)))
+        engine
+          .startIntercept(EmbeddedIntercept.startOptions(config))
+          .map(i => (i.interceptPort, Some(i.interceptPort)))
     }
 
   private def message(t: Throwable): String = Option(t.getMessage).getOrElse(t.getClass.getSimpleName)
 
 private[embedded] object EmbeddedIntercept:
-  // Loopback, OS-assigned port — the listener binds where the SUT proxies through.
-  private val StartOptions: String    = Json.Obj("host" -> Json.Str("127.0.0.1"), "port" -> Json.Num(0)).toJson
   private val DefaultPassword: String = "changeit"
+
+  // Start options for the TLS-MITM listener. `bindHost` defaults to loopback (127.0.0.1); a wider bind
+  // (0.0.0.0 / a NIC address) makes the proxy reachable from another host or container. `port` defaults
+  // to 0 (OS-assigned); a pinned value binds a known port for a SUT whose proxy target is fixed up front.
+  private[embedded] def startOptions(config: EmbeddedRift.InterceptConfig): String =
+    Json.Obj("host" -> Json.Str(config.bindHost), "port" -> Json.Num(config.port.getOrElse(0))).toJson
 
   /**
    * Build the rift intercept-rule JSON from a portable [[InterceptRule]]. Left

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
@@ -37,11 +37,33 @@ object EmbeddedRift:
   def available: Boolean = NativeLibrary.available
 
   /**
+   * Bind configuration for the built-in [[Intercept]] TLS-MITM proxy. Defaults
+   * preserve today's behavior: loopback bind, OS-assigned port. Set `bindHost =
+   * "0.0.0.0"` (or a specific NIC address) so a SUT running elsewhere — e.g. a
+   * Docker container reaching the host engine via the host-gateway — can reach
+   * the proxy; a loopback socket refuses gateway-originated connections. Pin
+   * `port` when the SUT's proxy target must be known *before* the test assigns
+   * it (a compose-orchestrated SUT). Binding a wider interface is strictly
+   * opt-in — nothing is exposed off loopback unless asked.
+   */
+  final case class InterceptConfig(bindHost: String = "127.0.0.1", port: Option[Int] = None)
+
+  /**
    * A scoped [[MockControl]] backed by the in-process Rift engine, PerInstance
    * isolation (own port per space). See the `mode` overload below for
    * Correlated.
    */
-  def layer: ZLayer[Provisioning, MockError, MockControl] = layer(RiftMode.PerInstance)
+  def layer: ZLayer[Provisioning, MockError, MockControl] = layer(RiftMode.PerInstance, InterceptConfig())
+
+  /**
+   * As [[layer]], with the intercept proxy bound per `intercept` (bind host /
+   * fixed port).
+   */
+  def layer(intercept: InterceptConfig): ZLayer[Provisioning, MockError, MockControl] =
+    layer(RiftMode.PerInstance, intercept)
+
+  /** As the `mode` overload, with the intercept proxy bound per `intercept`. */
+  def layer(mode: RiftMode): ZLayer[Provisioning, MockError, MockControl] = layer(mode, InterceptConfig())
 
   /**
    * A scoped [[MockControl]] backed by the in-process Rift engine, in the given
@@ -51,14 +73,15 @@ object EmbeddedRift:
    * Correlated mode, the shared imposter's teardown) on close. Entirely FFI
    * (#244) — no loopback HTTP admin plane, so the public requirement stays just
    * [[Provisioning]]. Fails with [[MockError.ProvisionFailed]] when no native
-   * library resolves for the host, or it cannot be loaded.
+   * library resolves for the host, or it cannot be loaded. The `intercept`
+   * config governs the built-in intercept proxy's bind host + port (#254).
    */
-  def layer(mode: RiftMode): ZLayer[Provisioning, MockError, MockControl] =
+  def layer(mode: RiftMode, intercept: InterceptConfig): ZLayer[Provisioning, MockError, MockControl] =
     ZLayer.scoped {
       for
         prov    <- ZIO.service[Provisioning]
         engine  <- startEngine
-        control <- EmbeddedRiftMockControl.make(engine, prov, mode)
+        control <- EmbeddedRiftMockControl.make(engine, prov, mode, intercept)
       yield control
     }
 

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
@@ -59,7 +59,8 @@ private[embedded] final case class EmbeddedRiftMockControl(
   correlated: Ref[Map[SpaceId, EmbeddedRiftMockControl.CorrSpace]],
   sharedPort: Ref.Synchronized[Option[Int]],
   ids: Ref[Int],
-  interceptStarted: Ref.Synchronized[Option[Int]]
+  interceptStarted: Ref.Synchronized[Option[Int]],
+  interceptConfig: EmbeddedRift.InterceptConfig
 ) extends MockControl:
 
   import EmbeddedRiftMockControl.{CorrSpace, Imposter}
@@ -177,7 +178,7 @@ private[embedded] final case class EmbeddedRiftMockControl(
 
   // Built-in HTTPS intercept (#219) over the intercept FFI (rift#410); one instance per adapter so the
   // TLS-MITM listener starts at most once (memoized in interceptStarted).
-  private val embeddedIntercept: Intercept           = EmbeddedIntercept(engine, interceptStarted)
+  private val embeddedIntercept: Intercept           = EmbeddedIntercept(engine, interceptStarted, interceptConfig)
   override def intercept: IO[Unsupported, Intercept] = ZIO.succeed(embeddedIntercept)
   def templating: IO[Unsupported, Templating]        = ZIO.succeed(embeddedTemplating)
 
@@ -636,7 +637,8 @@ private[embedded] object EmbeddedRiftMockControl:
   def make(
     engine: EmbeddedEngine,
     provisioning: Provisioning,
-    mode: RiftMode = RiftMode.PerInstance
+    mode: RiftMode = RiftMode.PerInstance,
+    interceptConfig: EmbeddedRift.InterceptConfig = EmbeddedRift.InterceptConfig()
   ): URIO[Scope, MockControl] =
     for
       spaces     <- Ref.make(Map.empty[SpaceId, Imposter])
@@ -644,6 +646,17 @@ private[embedded] object EmbeddedRiftMockControl:
       sharedPort <- Ref.Synchronized.make(Option.empty[Int])
       ids        <- Ref.make(0)
       intercept  <- Ref.Synchronized.make(Option.empty[Int])
-      control     = EmbeddedRiftMockControl(engine, provisioning, mode, spaces, correlated, sharedPort, ids, intercept)
-      _          <- ZIO.addFinalizer(control.teardownShared)
+      control =
+        EmbeddedRiftMockControl(
+          engine,
+          provisioning,
+          mode,
+          spaces,
+          correlated,
+          sharedPort,
+          ids,
+          intercept,
+          interceptConfig
+        )
+      _ <- ZIO.addFinalizer(control.teardownShared)
     yield control

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedInterceptSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedInterceptSpec.scala
@@ -26,9 +26,37 @@ object EmbeddedInterceptSpec extends ZIOSpecDefault:
 
   private def asT(e: MockError): Throwable = new RuntimeException(s"MockError: $e")
 
+  // A non-loopback site-local IPv4 of this host — what a container reaches the host engine at (the
+  // Docker host-gateway routes to it). None on hosts with no such NIC (e.g. loopback-only CI) → skip.
+  private def siteLocalIPv4: Option[String] =
+    import scala.jdk.CollectionConverters.*
+    scala.util
+      .Try(
+        java.net.NetworkInterface.getNetworkInterfaces.asScala.toList
+          .filter(ni => ni.isUp && !ni.isLoopback)
+          .flatMap(_.getInetAddresses.asScala.toList)
+          .collectFirst { case a: java.net.Inet4Address if a.isSiteLocalAddress => a.getHostAddress }
+      )
+      .toOption
+      .flatten
+
+  // Reserve a currently-free TCP port, then release it — a pinned port for the fixed-port test.
+  private val reserveFreePort: Task[Int] =
+    ZIO.attemptBlocking {
+      val s = new java.net.ServerSocket(0)
+      try s.getLocalPort
+      finally s.close()
+    }
+
   // The stand-in SUT: a JDK HttpClient trusting `ts` and proxying HTTPS through the intercept port.
   // Forced HTTP/1.1 — the MITM tunnel serves 1.1 (an h2 upgrade over the tunnel would EOF, zb-183).
-  private def sutGet(url: String, proxyPort: Int, ts: TrustStore): Task[(Int, String)] =
+  // `proxyHost` is loopback by default; a non-loopback address exercises the wider-bind topology (#254).
+  private def sutGet(
+    url: String,
+    proxyPort: Int,
+    ts: TrustStore,
+    proxyHost: String = "127.0.0.1"
+  ): Task[(Int, String)] =
     ZIO.attemptBlocking {
       val ks = KeyStore.getInstance(ts.format match
         case TrustStoreFormat.Pkcs12 => "PKCS12"
@@ -45,7 +73,7 @@ object EmbeddedInterceptSpec extends ZIOSpecDefault:
         .newBuilder()
         .version(HttpClient.Version.HTTP_1_1)
         .sslContext(ssl)
-        .proxy(ProxySelector.of(new InetSocketAddress("127.0.0.1", proxyPort)))
+        .proxy(ProxySelector.of(new InetSocketAddress(proxyHost, proxyPort)))
         .build()
       val resp =
         client.send(HttpRequest.newBuilder(URI.create(url)).GET().build(), HttpResponse.BodyHandlers.ofString())
@@ -91,5 +119,53 @@ object EmbeddedInterceptSpec extends ZIOSpecDefault:
           res  <- sutGet("https://api.example.com/anything", port, ts)
         yield assertTrue(res._1 == 418, res._2.contains("inline-teapot")))
           .provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
+    },
+    test("bindHost 0.0.0.0: the proxy binds a wider interface, reports it, and a redirect completes through it") {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
+      else
+        // Bind 0.0.0.0 (all interfaces). Prefer a real non-loopback NIC — the container-via-host-gateway
+        // topology — but fall back to loopback, which a 0.0.0.0 socket also accepts, so this always
+        // exercises the bind + `proxyEndpoint` reporting instead of silently skipping on a loopback-only host.
+        val proxyHost = siteLocalIPv4.getOrElse("127.0.0.1")
+        (for
+          mc    <- ZIO.service[MockControl]
+          space <- mc.provision(cdnConfig).mapError(asT).map(_.head)
+          ic    <- mc.intercept.mapError(u => new RuntimeException(u.message))
+          _     <- ic.redirectTo("cdn.example.com", space).mapError(asT)
+          ts    <- ic.trustStore().mapError(asT)
+          ep    <- ic.proxyEndpoint.mapError(asT)
+          res   <- sutGet("https://cdn.example.com/config.json", ep._2, ts, proxyHost = proxyHost)
+        yield assertTrue(res._1 == 200, res._2.contains("mocked"), ep._1 == "0.0.0.0"))
+          .provide(
+            Provisioning.live,
+            EmbeddedRift.layer(EmbeddedRift.InterceptConfig(bindHost = "0.0.0.0")).mapError(asT)
+          )
+    },
+    test("fixed port: the intercept listener binds the pinned port instead of an OS-assigned one") {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
+      else
+        reserveFreePort.flatMap { pinned =>
+          (for
+            mc   <- ZIO.service[MockControl]
+            ic   <- mc.intercept.mapError(u => new RuntimeException(u.message))
+            port <- ic.proxyPort.mapError(asT)
+            ep   <- ic.proxyEndpoint.mapError(asT)
+          yield assertTrue(port == pinned, ep == ("127.0.0.1", pinned)))
+            .provide(
+              Provisioning.live,
+              EmbeddedRift.layer(EmbeddedRift.InterceptConfig(port = Some(pinned))).mapError(asT)
+            )
+        }
+    },
+    // Pure translation of InterceptConfig -> FFI start-options JSON; runs even without the native library,
+    // so the host/port wiring is covered on any host (the e2e tests above SKIP when no library resolves).
+    test("startOptions maps InterceptConfig to the FFI host/port JSON; default stays loopback + OS-assigned") {
+      val default = EmbeddedIntercept.startOptions(EmbeddedRift.InterceptConfig())
+      val configured =
+        EmbeddedIntercept.startOptions(EmbeddedRift.InterceptConfig(bindHost = "0.0.0.0", port = Some(8888)))
+      assertTrue(
+        default == """{"host":"127.0.0.1","port":0}""",
+        configured == """{"host":"0.0.0.0","port":8888}"""
+      )
     }
   ) @@ TestAspect.withLiveClock @@ TestAspect.sequential


### PR DESCRIPTION
Makes the embedded Rift `Intercept` TLS-MITM proxy's bind host configurable
(default `127.0.0.1`) with an optional fixed proxy port, and exposes the
actually-bound `(host, port)` via a new `Intercept.proxyEndpoint`. This lets a
SUT in a container reach the host engine's intercept proxy via the Docker
host-gateway (a loopback socket refuses gateway-originated connections).
Purely additive — loopback + OS-assigned port remain the defaults, so existing
suites are unchanged.

Verified on JDK 21 (`riftEmbedded21`): 5 new/updated tests green, including a
`0.0.0.0`-bind reachability test and an offline `startOptions` unit test.

Closes #254

Milestone: M4 (embedded) — follow-up to #219 (embedded Intercept). Distinct from #253 (container adapter).