### PR TITLE
Intercept: export a truststore that merges the intercept CA with the JVM default trust anchors (don't strip real-host trust)

### DIFF
--- a/docs/mock-advanced.md
+++ b/docs/mock-advanced.md
@@ -452,6 +452,19 @@ PerInstance (the default) for host redirects.
 > `trustedCertEntry` the default `TrustManagerFactory` reads out of the box, so
 > either works for a JVM SUT.
 
+**CA-only vs. merged truststore.** `trustStore` exports a store containing **only**
+the intercept CA. Pointing a SUT at it via `-Djavax.net.ssl.trustStore` *replaces*
+the JVM's default trust store (`cacerts`) wholesale — the SUT trusts the mocked
+hosts but **loses trust for every real HTTPS endpoint** (AWS, other downstreams).
+That's exactly right for a **fully hermetic** SUT (every external call mocked). For
+a **mostly hermetic** SUT that mocks one vendor yet still calls real infrastructure,
+use `trustStoreWithSystemCAs`, which exports the intercept CA **plus** the JVM's
+default trust anchors so both keep validating:
+
+```scala
+ts <- ic.trustStoreWithSystemCAs()   // intercept CA + the JVM's cacerts, one store
+```
+
 **Containerized SUT (bind a reachable interface).** The examples above bind the
 intercept proxy to **loopback** — right when the SUT is a host process. When the
 SUT runs in a **Docker container** while the test + engine run on the host, a

--- a/mock/src/main/scala/zio/bdd/mock/Capability.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Capability.scala
@@ -150,6 +150,19 @@ trait Intercept:
   def trustStore(format: TrustStoreFormat = TrustStoreFormat.Pkcs12): IO[MockError, TrustStore]
 
   /**
+   * As [[trustStore]], but the exported store ALSO contains the JVM's default
+   * trust anchors. Pointing a SUT at the CA-only [[trustStore]] via
+   * `-Djavax.net.ssl.trustStore` *replaces* its default trust store, so the SUT
+   * trusts the intercepted (mocked) hosts but loses trust for real HTTPS
+   * endpoints (AWS, etc.). Use this merged export for a "mostly hermetic" SUT
+   * that mocks some hosts yet still calls real ones; the CA-only [[trustStore]]
+   * is right for a fully hermetic SUT. Built on [[trustStore]], so it is
+   * backend-neutral — every `Intercept` adapter gets it for free.
+   */
+  def trustStoreWithSystemCAs(format: TrustStoreFormat = TrustStoreFormat.Pkcs12): IO[MockError, TrustStore] =
+    trustStore(format).flatMap(TrustStore.plusSystemCAs)
+
+  /**
    * Convenience: intercept `host` and forward its requests to `space`'s
    * imposter.
    */

--- a/mock/src/main/scala/zio/bdd/mock/Intercept.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Intercept.scala
@@ -1,6 +1,12 @@
 package zio.bdd.mock
 
-import java.nio.file.Path
+import zio.{IO, ZIO}
+
+import java.nio.file.{Files, Path}
+import java.security.KeyStore
+import java.security.cert.X509Certificate
+import javax.net.ssl.{TrustManagerFactory, X509TrustManager}
+import scala.util.Using
 
 /**
  * Portable value types for the [[Capability.Intercept]] capability (#219): a
@@ -22,6 +28,11 @@ enum TrustStoreFormat:
     case Pkcs12 => "pkcs12"
     case Jks    => "jks"
 
+  /** The JCE keystore type for `KeyStore.getInstance` (uppercase). */
+  def keystoreName: String = this match
+    case Pkcs12 => "PKCS12"
+    case Jks    => "JKS"
+
 /**
  * A ready-to-use truststore file containing the intercept CA, plus the password
  * that opens it. Hand both to the SUT's JVM so it trusts the intercept's
@@ -29,6 +40,58 @@ enum TrustStoreFormat:
  * -Djavax.net.ssl.trustStorePassword=<password>`.
  */
 final case class TrustStore(path: Path, password: String, format: TrustStoreFormat)
+
+object TrustStore:
+  /**
+   * Return a copy of `caOnly` whose store ALSO contains the running JVM's
+   * default trust anchors (its `cacerts`). Pointing a SUT at the CA-only export
+   * via `-Djavax.net.ssl.trustStore` *replaces* the JVM default store, so the
+   * SUT would trust the intercept CA but lose trust for every real HTTPS host;
+   * the merged store keeps both. Preserves `caOnly`'s format + password and
+   * writes a fresh temp file. Backend-neutral — pure `java.security`, no
+   * adapter types.
+   */
+  def plusSystemCAs(caOnly: TrustStore): IO[MockError, TrustStore] =
+    ZIO.attemptBlocking {
+      // The whole point is to ADD the JVM defaults; an empty set means a misconfigured/empty cacerts
+      // and a merged store that is silently CA-only — fail loudly rather than degrade to that.
+      val anchors = systemTrustAnchors
+      if anchors.isEmpty then
+        throw new IllegalStateException(
+          "no default JVM trust anchors resolved (empty cacerts?); the merged truststore would trust only the intercept CA"
+        )
+
+      val ksType  = caOnly.format.keystoreName
+      val caStore = KeyStore.getInstance(ksType)
+      Using.resource(Files.newInputStream(caOnly.path))(in => caStore.load(in, caOnly.password.toCharArray))
+
+      val merged = KeyStore.getInstance(ksType)
+      merged.load(null, null)
+      // Index-keyed aliases: system anchors can share a subject, so a subject-derived alias would collide.
+      anchors.zipWithIndex.foreach((cert, i) => merged.setCertificateEntry(s"system-ca-$i", cert))
+      val aliases = caStore.aliases()
+      while aliases.hasMoreElements do
+        val alias = aliases.nextElement()
+        Option(caStore.getCertificate(alias)).foreach(cert => merged.setCertificateEntry(s"intercept-$alias", cert))
+
+      val out = Files.createTempFile("rift-intercept-merged-", s".${caOnly.format.wire}")
+      out.toFile.deleteOnExit()
+      Using.resource(Files.newOutputStream(out))(os => merged.store(os, caOnly.password.toCharArray))
+      TrustStore(out, caOnly.password, caOnly.format)
+    }
+      // A local java.security failure, not a backend round-trip — ProvisionFailed, per the package's
+      // error taxonomy (CommunicationError is reserved for backend comms).
+      .mapError(t =>
+        MockError.ProvisionFailed(
+          s"merging the intercept CA with the JVM default trust anchors: ${Option(t.getMessage).getOrElse(t.getClass.getSimpleName)}"
+        )
+      )
+
+  // The running JVM's default trust anchors (its cacerts), read via the platform TrustManager.
+  private def systemTrustAnchors: Vector[X509Certificate] =
+    val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+    tmf.init(null: KeyStore)
+    tmf.getTrustManagers.collect { case x: X509TrustManager => x.getAcceptedIssuers }.flatten.toVector
 
 /**
  * An inline response served for an intercepted host (the `respondWith` action).

--- a/mock/src/test/scala/zio/bdd/mock/InterceptTrustStoreSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/InterceptTrustStoreSpec.scala
@@ -1,0 +1,122 @@
+package zio.bdd.mock
+
+import zio.*
+import zio.test.*
+
+import java.io.ByteArrayInputStream
+import java.nio.file.Files
+import java.security.KeyStore
+import java.security.cert.{CertificateFactory, X509Certificate}
+import javax.net.ssl.{TrustManagerFactory, X509TrustManager}
+
+/**
+ * Always-on unit coverage for [[TrustStore.plusSystemCAs]] (#259): the pure
+ * java.security merge that adds the JVM default trust anchors to the intercept
+ * CA-only store. Runs on any host — no native library — using a synthetic
+ * (non-system) self-signed CA as the stand-in intercept CA.
+ */
+object InterceptTrustStoreSpec extends ZIOSpecDefault:
+
+  // A throwaway self-signed cert (CN=zio-bdd-intercept-test-ca) — a plausible intercept CA that is
+  // guaranteed NOT to be one of the JVM's real trust anchors, so the merge is genuinely additive.
+  private val testCaPem: String =
+    """|-----BEGIN CERTIFICATE-----
+       |MIIDKTCCAhGgAwIBAgIULNSwCU4uf6H4c3MUW69w2kgrElowDQYJKoZIhvcNAQEL
+       |BQAwJDEiMCAGA1UEAwwZemlvLWJkZC1pbnRlcmNlcHQtdGVzdC1jYTAeFw0yNjA3
+       |MDgwMzQzMTJaFw0zNjA3MDUwMzQzMTJaMCQxIjAgBgNVBAMMGXppby1iZGQtaW50
+       |ZXJjZXB0LXRlc3QtY2EwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDw
+       |QAAYQdIW1kcSdSv7WbyeO6J+2IO5ou2nRIM1CxigvS5NjrhWShCWhaGOkj3SCAOm
+       |Lqa4KIcErUvEJrSE6Fuom/2ZXS8pjSexk4ziL4a8V+wTwUIdS3r4E9prxXb+PkTx
+       |IU/nkCjtHBfTgL0aub1jAHvJoUsnEaAbEvYg2A2t0NYkFqF16ZTpJF96Edrc8OhU
+       |k1VoTxq/DwptqLRcvIOE/gzrU3H4T17fqY6faahNueCePvOsbFYMTTlHlAwrp/GZ
+       |JZ7+4LjmwkHhzbMr7YYJWaO7xoJTCxgGXRlQShW84tulk2yARWsUk4AydJQ40dSI
+       |v7g+b+q/mcaGho4Pp7KnAgMBAAGjUzBRMB0GA1UdDgQWBBTyVD4dwsvzUcPvv2RD
+       |5sNoe86xyDAfBgNVHSMEGDAWgBTyVD4dwsvzUcPvv2RD5sNoe86xyDAPBgNVHRMB
+       |Af8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCAQaNXkxIVTIeA20eqpaxTjv9u
+       |BnoRyYmjiBKjHXrXfl0LmugOwBgwVLBbb0FWeBlbUAryEo7bVqq1iXpZAbAoLdbM
+       |NSArEWT9cLCpRM7kKF1f+nyAbfzrPkmk20RMYpTFvXghO+W37aVEvXWABnI5XNmP
+       |Glg6P7jvUNj0wl/RUYUYZwofeYlG9Nihb6hcdGUnyLE+zjLsTAEn0H6TdFNRTTPJ
+       |cdAC9HqlUzW0Iolzedilal8/HpdKsl3BVGcMUkV9mqa15gnbbXIv8aJ8O2FQd21+
+       |0kqVJayZKMdjLHBDBnOYyqm+QIouPNWhP0P6ewXvFE/iHNcT+3xWjsPL7U2F
+       |-----END CERTIFICATE-----""".stripMargin
+
+  private val password = "changeit"
+
+  private def parseCert(pem: String): X509Certificate =
+    CertificateFactory
+      .getInstance("X.509")
+      .generateCertificate(new ByteArrayInputStream(pem.getBytes("UTF-8")))
+      .asInstanceOf[X509Certificate]
+
+  // A synthetic CA-only truststore file in `format`, containing exactly the test CA — the shape
+  // `Intercept.trustStore(format)` produces, without needing a running intercept engine.
+  private def caOnlyStore(format: TrustStoreFormat): Task[TrustStore] =
+    ZIO.attemptBlocking {
+      val ks = KeyStore.getInstance(format.keystoreName)
+      ks.load(null, null)
+      ks.setCertificateEntry("intercept-ca", parseCert(testCaPem))
+      val p = Files.createTempFile("test-ca-only-", s".${format.wire}")
+      p.toFile.deleteOnExit()
+      val os = Files.newOutputStream(p)
+      try ks.store(os, password.toCharArray)
+      finally os.close()
+      TrustStore(p, password, format)
+    }
+
+  private def certsOf(ts: TrustStore): Task[Set[X509Certificate]] =
+    ZIO.attemptBlocking {
+      import scala.jdk.CollectionConverters.*
+      val ks = KeyStore.getInstance(ts.format.keystoreName)
+      val in = Files.newInputStream(ts.path)
+      try ks.load(in, ts.password.toCharArray)
+      finally in.close()
+      ks.aliases().asScala.flatMap(a => Option(ks.getCertificate(a))).collect { case x: X509Certificate => x }.toSet
+    }
+
+  private val systemAnchors: Task[Set[X509Certificate]] =
+    ZIO.attemptBlocking {
+      val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+      tmf.init(null: KeyStore)
+      tmf.getTrustManagers.collect { case x: X509TrustManager => x.getAcceptedIssuers.toSet }.flatten.toSet
+    }
+
+  // The trust anchors a real JSSE TrustManagerFactory derives from the store — i.e. what the store
+  // would actually validate against — not just its raw keystore entries.
+  private def acceptedIssuersOf(ts: TrustStore): Task[Set[X509Certificate]] =
+    ZIO.attemptBlocking {
+      val ks = KeyStore.getInstance(ts.format.keystoreName)
+      val in = Files.newInputStream(ts.path)
+      try ks.load(in, ts.password.toCharArray)
+      finally in.close()
+      val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm)
+      tmf.init(ks)
+      tmf.getTrustManagers.collect { case x: X509TrustManager => x.getAcceptedIssuers.toSet }.flatten.toSet
+    }
+
+  private def mergeTest(format: TrustStoreFormat) =
+    test(s"plusSystemCAs(${format.wire}) keeps the intercept CA and adds every JVM default trust anchor") {
+      for
+        caOnly  <- caOnlyStore(format)
+        merged  <- TrustStore.plusSystemCAs(caOnly)
+        certs   <- certsOf(merged)
+        issuers <- acceptedIssuersOf(merged)
+        system  <- systemAnchors
+        testCa   = parseCert(testCaPem)
+      yield assertTrue(
+        merged.format == format,            // format preserved
+        merged.password == caOnly.password, // password preserved
+        merged.path != caOnly.path,         // fresh file, original untouched
+        certs.contains(testCa),             // the intercept CA survived the merge
+        system.nonEmpty,                    // sanity: the JVM actually has default anchors
+        !system.contains(testCa),           // the test CA is genuinely non-system → the merge is additive
+        system.subsetOf(certs),             // every JVM default anchor is present in the merged store
+        // …and the store functions as a real JSSE trust source over BOTH the intercept CA and the defaults:
+        issuers.contains(testCa),
+        system.subsetOf(issuers)
+      )
+    }
+
+  def spec = suite("TrustStore.plusSystemCAs (#259)")(
+    mergeTest(TrustStoreFormat.Pkcs12),
+    mergeTest(TrustStoreFormat.Jks)
+  )

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedInterceptSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedInterceptSpec.scala
@@ -48,6 +48,17 @@ object EmbeddedInterceptSpec extends ZIOSpecDefault:
       finally s.close()
     }
 
+  // Count the trusted-cert entries in a truststore file — CA-only vs merged (#259).
+  private def anchorCount(ts: TrustStore): Task[Int] =
+    ZIO.attemptBlocking {
+      import scala.jdk.CollectionConverters.*
+      val ks = KeyStore.getInstance(ts.format.keystoreName)
+      val in = Files.newInputStream(ts.path)
+      try ks.load(in, ts.password.toCharArray)
+      finally in.close()
+      ks.aliases().asScala.count(ks.isCertificateEntry)
+    }
+
   // The stand-in SUT: a JDK HttpClient trusting `ts` and proxying HTTPS through the intercept port.
   // Forced HTTP/1.1 — the MITM tunnel serves 1.1 (an h2 upgrade over the tunnel would EOF, zb-183).
   // `proxyHost` is loopback by default; a non-loopback address exercises the wider-bind topology (#254).
@@ -58,10 +69,7 @@ object EmbeddedInterceptSpec extends ZIOSpecDefault:
     proxyHost: String = "127.0.0.1"
   ): Task[(Int, String)] =
     ZIO.attemptBlocking {
-      val ks = KeyStore.getInstance(ts.format match
-        case TrustStoreFormat.Pkcs12 => "PKCS12"
-        case TrustStoreFormat.Jks    => "JKS"
-      )
+      val ks = KeyStore.getInstance(ts.format.keystoreName)
       val in = Files.newInputStream(ts.path)
       try ks.load(in, ts.password.toCharArray)
       finally in.close()
@@ -167,5 +175,24 @@ object EmbeddedInterceptSpec extends ZIOSpecDefault:
         default == """{"host":"127.0.0.1","port":0}""",
         configured == """{"host":"0.0.0.0","port":8888}"""
       )
+    },
+    test("trustStoreWithSystemCAs: the merged store trusts the intercepted host AND keeps the JVM default anchors") {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
+      else
+        (for
+          mc      <- ZIO.service[MockControl]
+          space   <- mc.provision(cdnConfig).mapError(asT).map(_.head)
+          ic      <- mc.intercept.mapError(u => new RuntimeException(u.message))
+          _       <- ic.redirectTo("cdn.example.com", space).mapError(asT)
+          caOnly  <- ic.trustStore().mapError(asT)
+          merged  <- ic.trustStoreWithSystemCAs().mapError(asT)
+          port    <- ic.proxyPort.mapError(asT)
+          caN     <- anchorCount(caOnly)
+          mergedN <- anchorCount(merged)
+          // (a) the merged store still trusts the intercept CA → the redirected HTTPS call succeeds through it.
+          res <- sutGet("https://cdn.example.com/config.json", port, merged)
+        // (b) the merged store also carries the JVM default anchors → strictly more entries than CA-only.
+        yield assertTrue(res._1 == 200, res._2.contains("mocked"), caN >= 1, mergedN > caN))
+          .provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
     }
   ) @@ TestAspect.withLiveClock @@ TestAspect.sequential


### PR DESCRIPTION
Adds an opt-in `Intercept.trustStoreWithSystemCAs(format)` — a backend-neutral
trait default over `TrustStore.plusSystemCAs` — that exports the intercept CA
**plus** the JVM's default trust anchors. A "mostly hermetic" SUT (mocks one
vendor, still calls real HTTPS) can point `-Djavax.net.ssl.trustStore` at it and
keep validating both mocked and real hosts, instead of the CA-only export
replacing the JVM default store wholesale. CA-only `trustStore` stays the default.

Verified on JDK 21 (`mock` + `riftEmbedded21`): an always-on PKCS12/JKS merge unit
test (synthetic non-system CA, JSSE TrustManagerFactory validation) + a gated
embedded e2e proving the merged store trusts the intercepted host and carries the
system anchors.

Closes #259

Milestone: M4 (embedded) — follow-up to #254/#219. Applies to the container adapter (#253) for free once that lands.