### PR TITLE
build: bump Rift to v0.11.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ import java.security.MessageDigest
 // Single source of truth for the pinned Rift release (#195). Both the FFI natives (riftNativesVersion,
 // downloaded into the embedded-natives jar) and the container image tag (Rift.DefaultImage, via the
 // generated RiftBuildInfo below) derive from it, so a version bump touches exactly one line.
-val riftVersion        = "0.11.1"
+val riftVersion        = "0.11.2"
 val riftNativesVersion = riftVersion
 
 // The (os, arch, ext) cdylibs bundled into the natives jar — linux/macOS × x86_64/aarch64 (#134).

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
@@ -14,9 +14,9 @@ object RiftBuildInfoSpec extends ZIOSpecDefault:
   def spec = suite("RiftBuildInfo")(
     test("DefaultImage is derived from the single rift-version source of truth") {
       assertTrue(
-        RiftBuildInfo.riftVersion == "0.11.1",
+        RiftBuildInfo.riftVersion == "0.11.2",
         Rift.DefaultImage == s"zainalpour/rift-proxy:v${RiftBuildInfo.riftVersion}",
-        Rift.DefaultImage == "zainalpour/rift-proxy:v0.11.1"
+        Rift.DefaultImage == "zainalpour/rift-proxy:v0.11.2"
       )
     }
   )


### PR DESCRIPTION
Bumps `riftVersion` 0.11.1 → 0.11.2 (the single source of truth, #195), which
repoints the bundled `librift_ffi` natives fetch, the generated `RiftBuildInfo`,
and `Rift.DefaultImage` (`zainalpour/rift-proxy:v0.11.2`).

Verified locally: all four native triples fetch from the v0.11.2 GitHub release,
and the embedded FFM suite (`riftEmbedded21`, JDK 21) is green against the 0.11.2
binaries (38 tests, 0 failures).