### PR TITLE
test: de-flake DuringSpec probe-count assertion

### DIFF
--- a/core/src/test/scala/zio/bdd/core/DuringSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/DuringSpec.scala
@@ -17,7 +17,10 @@ object DuringSpec extends ZIOSpecDefault {
         probes <- Ref.make(0)
         _      <- Assertions.during(probes.update(_ + 1), duration = 120.millis, interval = 20.millis)
         count  <- probes.get
-      yield assertTrue(count >= 4)
+      // A 120ms window at 20ms yields ~6 probes ideally, but fiber-scheduling jitter on a loaded CI
+      // runner can bunch them up — assert only that it probed repeatedly (the point of AC1/AC3), not an
+      // exact count, so this wall-clock test doesn't flake (it intermittently saw count=3 vs a >=4 bound).
+      yield assertTrue(count >= 2)
     } @@ TestAspect.withLiveClock,
     test("during probes repeatedly using the default interval when only duration is given (AC4 — default)") {
       // interval left at the default (200ms); ~500ms window ⇒ a small handful of probes.


### PR DESCRIPTION
`DuringSpec`'s AC1/AC3 test asserted `count >= 4` probes over a 120ms/20ms
window; fiber-scheduling jitter on loaded CI runners intermittently delivered
3, failing the `build` job on unrelated PRs (observed on #266's post-merge
master push and on #267). Loosens the bound to `count >= 2` — a jitter-robust
lower bound that still proves `during` probes repeatedly across the window.
Test-only; verified locally (JDK 11, `DuringSpec` green).