### PR TITLE
Intercept: validate InterceptConfig.bindHost is an IP literal (rift binds via SocketAddr::parse — a hostname fails cryptically)

### DIFF
--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedIntercept.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedIntercept.scala
@@ -50,14 +50,16 @@ private[embedded] final class EmbeddedIntercept(
       _ <- engine.interceptExportTruststore(format.wire, EmbeddedIntercept.DefaultPassword, tmp.toString)
     yield TrustStore(tmp, EmbeddedIntercept.DefaultPassword, format)
 
-  // Start the listener at most once (race-safe), memoizing its bound proxy port.
+  // Start the listener at most once (race-safe), memoizing its bound proxy port. Validate the bind host
+  // first so a hostname fails with a clear message here, not opaquely inside the engine (#262).
   private def ensureStarted: IO[MockError, Int] =
     started.modifyZIO {
       case s @ Some(p) => ZIO.succeed((p, s))
       case None =>
-        engine
-          .startIntercept(EmbeddedIntercept.startOptions(config))
-          .map(i => (i.interceptPort, Some(i.interceptPort)))
+        ZIO.fromEither(EmbeddedIntercept.validateBindHost(config.bindHost)) *>
+          engine
+            .startIntercept(EmbeddedIntercept.startOptions(config))
+            .map(i => (i.interceptPort, Some(i.interceptPort)))
     }
 
   private def message(t: Throwable): String = Option(t.getMessage).getOrElse(t.getClass.getSimpleName)
@@ -70,6 +72,34 @@ private[embedded] object EmbeddedIntercept:
   // to 0 (OS-assigned); a pinned value binds a known port for a SUT whose proxy target is fixed up front.
   private[embedded] def startOptions(config: EmbeddedRift.InterceptConfig): String =
     Json.Obj("host" -> Json.Str(config.bindHost), "port" -> Json.Num(config.port.getOrElse(0))).toJson
+
+  // rift binds the intercept listener via SocketAddr::parse, which accepts only IP literals — a hostname
+  // (`localhost` / a DNS name) fails there with an opaque error. Reject it early, DNS-free (no resolution),
+  // with a clear message. IPv4 is validated strictly (rejecting leading zeros, matching Rust's parser);
+  // IPv6 leniently (colon + hex/dot chars) so a valid literal passes through.
+  private[embedded] def validateBindHost(host: String): Either[MockError, Unit] =
+    if isIpLiteral(host) then Right(())
+    else
+      Left(
+        MockError.InvalidDefinition(
+          s"intercept bindHost must be an IP literal (e.g. 0.0.0.0 or a NIC address), not a hostname: $host"
+        )
+      )
+
+  private def isIpLiteral(host: String): Boolean =
+    // ASCII digits only — Rust's socket-address parser rejects non-ASCII, and `Char.isDigit`/`toInt`
+    // would otherwise accept Unicode decimal digits (e.g. Arabic-Indic) that the engine won't.
+    def asciiDigit(c: Char): Boolean = c >= '0' && c <= '9'
+    def isIpv4: Boolean =
+      val parts = host.split("\\.", -1)
+      parts.length == 4 && parts.forall { p =>
+        p.nonEmpty && p.length <= 3 && p.forall(asciiDigit) && p.toInt <= 255 && (p == "0" || !p.startsWith("0"))
+      }
+    def isIpv6: Boolean =
+      host.contains(":") && host.forall { c =>
+        asciiDigit(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') || c == ':' || c == '.'
+      }
+    isIpv4 || isIpv6
 
   /**
    * Build the rift intercept-rule JSON from a portable [[InterceptRule]]. Left

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
@@ -45,6 +45,11 @@ object EmbeddedRift:
    * `port` when the SUT's proxy target must be known *before* the test assigns
    * it (a compose-orchestrated SUT). Binding a wider interface is strictly
    * opt-in — nothing is exposed off loopback unless asked.
+   *
+   * `bindHost` must be an **IP literal** (e.g. `127.0.0.1`, `0.0.0.0`, a NIC
+   * address) — the engine binds via a socket-address parse, so a hostname like
+   * `localhost` is rejected with [[MockError.InvalidDefinition]] on first
+   * intercept use (#262), not resolved.
    */
   final case class InterceptConfig(bindHost: String = "127.0.0.1", port: Option[Int] = None)
 

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedInterceptSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedInterceptSpec.scala
@@ -176,6 +176,19 @@ object EmbeddedInterceptSpec extends ZIOSpecDefault:
         configured == """{"host":"0.0.0.0","port":8888}"""
       )
     },
+    // Pure bind-host validation (#262); runs without the native library.
+    test("validateBindHost: IP literals pass; a hostname is rejected with a clear InvalidDefinition naming it") {
+      val ok  = List("127.0.0.1", "0.0.0.0", "192.168.1.5", "10.0.0.1", "255.255.255.255", "::1", "fe80::1")
+      val bad = List("localhost", "myhost.local", "example.com", "not-an-ip", "999.1.1.1", "127.0.0.01", "1.2.3")
+      assertTrue(
+        ok.forall(h => EmbeddedIntercept.validateBindHost(h).isRight),
+        bad.forall { h =>
+          EmbeddedIntercept.validateBindHost(h) match
+            case Left(MockError.InvalidDefinition(msg)) => msg.contains(h)
+            case _                                      => false
+        }
+      )
+    },
     test("trustStoreWithSystemCAs: the merged store trusts the intercepted host AND keeps the JVM default anchors") {
       if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
       else

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
@@ -76,7 +76,10 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
 
   private def portFromUri(baseUri: String): Int = baseUri.substring(baseUri.lastIndexOf(':') + 1).toInt
 
-  private def withControl(mode: RiftMode = RiftMode.PerInstance)(
+  private def withControl(
+    mode: RiftMode = RiftMode.PerInstance,
+    intercept: EmbeddedRift.InterceptConfig = EmbeddedRift.InterceptConfig()
+  )(
     use: (MockControl, RecordingEngine) => IO[Any, TestResult]
   ): ZIO[Provisioning, Any, TestResult] =
     ZIO.scoped {
@@ -90,7 +93,7 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
         icRules    <- Ref.make(Chunk.empty[String])
         icExports  <- Ref.make(Chunk.empty[(String, String, String)])
         engine      = RecordingEngine(replaced, deleted, flowState, spaceStubs, icStarts, icRules, icExports)
-        control    <- EmbeddedRiftMockControl.make(engine, prov, mode)
+        control    <- EmbeddedRiftMockControl.make(engine, prov, mode, intercept)
         result     <- use(control, engine)
       yield result
     }
@@ -388,6 +391,21 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
             j.contains("\"serve\"") && j.contains("418") && j.contains("teapot") && j.contains("api.example.com")
           )
         )
+      }
+    },
+    test(
+      "intercept: a non-IP bindHost fails with InvalidDefinition on first use, without starting the listener (#262)"
+    ) {
+      withControl(intercept = EmbeddedRift.InterceptConfig(bindHost = "localhost")) { (control, engine) =>
+        for
+          ic     <- control.intercept
+          res    <- ic.proxyPort.either
+          starts <- engine.interceptStarts.get
+        yield
+          val rejected = res match
+            case Left(MockError.InvalidDefinition(m)) => m.contains("localhost")
+            case _                                    => false
+          assertTrue(rejected, starts == 0) // validation short-circuits before engine.startIntercept
       }
     },
     test("intercept: a redirect whose target space has no port in its baseUri fails with InvalidDefinition") {


### PR DESCRIPTION
`EmbeddedRift.InterceptConfig.bindHost` was passed straight to the rift FFI,
which binds via Rust's `SocketAddr::parse` (IP literals only) — so a hostname
like `localhost` failed opaquely inside the engine. Adds a DNS-free IP-literal
validation (IPv4 strict incl. leading-zero rejection, IPv6 lenient, ASCII
digits only) that fails on first intercept use with a clear
`MockError.InvalidDefinition` naming the value, before the FFI call. `127.0.0.1`
/ `0.0.0.0` / NIC-IP configs are unaffected.

Tests (always-on, no native lib): a pure `validateBindHost` boundary test, and
a wiring test (via the RecordingEngine double) proving the listener is NOT
started when the bind host is invalid.

Closes #262

Follow-up to #254 (configurable bind host).