### PR TITLE
Intercept: trustStore export to a caller-specified path (mountable into a containerized SUT)

### DIFF
--- a/docs/mock-advanced.md
+++ b/docs/mock-advanced.md
@@ -481,9 +481,18 @@ val mock = Provisioning.live >>> EmbeddedRift.layer(InterceptConfig(bindHost = "
 ```
 
 `proxyEndpoint` reports the **actually-bound** host and port (not just the
-loopback port), so you can log or inject them. The SUT container points its HTTPS
-proxy at the Docker host-gateway and trusts the exported truststore mounted into
-the container:
+loopback port), so you can log or inject them. Export the truststore **straight
+to a bind-mounted path** the container reads via `to` (default is a temp file),
+so there's no copy step — it also creates parent dirs and works with
+`trustStoreWithSystemCAs`:
+
+```scala
+// /host/mnt is bind-mounted to /mnt in the SUT container:
+ts <- ic.trustStore(to = Some(java.nio.file.Path.of("/host/mnt/intercept-truststore.p12")))
+```
+
+The SUT container points its HTTPS proxy at the Docker host-gateway and trusts
+that mounted truststore:
 
 ```
 # in the SUT container (host-gateway = host.docker.internal on Docker Desktop):

--- a/mock/src/main/scala/zio/bdd/mock/Capability.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Capability.scala
@@ -2,6 +2,8 @@ package zio.bdd.mock
 
 import zio.IO
 
+import java.nio.file.Path
+
 /**
  * Optional capabilities an adapter MAY implement beyond the total core port. An
  * adapter advertises a capability via [[MockControl.capabilities]]; for each
@@ -139,15 +141,21 @@ trait Intercept:
   def add(rule: InterceptRule): IO[MockError, Unit]
 
   /**
-   * Export a truststore containing the intercept CA to a fresh temp file,
-   * returning its path + password — hand both to the SUT's JVM so it trusts the
-   * intercept's per-host leaf certificates. Defaults to PKCS#12 (the JVM's
-   * default keystore type since JDK 9); JKS is selectable. Both load as a JVM
-   * truststore out of the box — a `trustedCertEntry` the default
-   * `TrustManagerFactory` reads (rift's PKCS#12 export was made JVM-loadable in
-   * rift#418).
+   * Export a truststore containing the intercept CA, returning its path +
+   * password — hand both to the SUT's JVM so it trusts the intercept's per-host
+   * leaf certificates. Defaults to PKCS#12 (the JVM's default keystore type
+   * since JDK 9); JKS is selectable. Both load as a JVM truststore out of the
+   * box — a `trustedCertEntry` the default `TrustManagerFactory` reads (rift's
+   * PKCS#12 export was made JVM-loadable in rift#418).
+   *
+   * `to` chooses where the file lands: `None` (default) writes a fresh temp
+   * file; `Some(path)` writes to that exact path (creating parent dirs,
+   * overwriting) — e.g. a host dir bind-mounted into a containerized SUT.
    */
-  def trustStore(format: TrustStoreFormat = TrustStoreFormat.Pkcs12): IO[MockError, TrustStore]
+  def trustStore(
+    format: TrustStoreFormat = TrustStoreFormat.Pkcs12,
+    to: Option[Path] = None
+  ): IO[MockError, TrustStore]
 
   /**
    * As [[trustStore]], but the exported store ALSO contains the JVM's default
@@ -158,9 +166,15 @@ trait Intercept:
    * that mocks some hosts yet still calls real ones; the CA-only [[trustStore]]
    * is right for a fully hermetic SUT. Built on [[trustStore]], so it is
    * backend-neutral — every `Intercept` adapter gets it for free.
+   *
+   * `to` places the merged store: `None` (default) a fresh temp file;
+   * `Some(path)` that exact path (parent dirs created) — for a mounted SUT.
    */
-  def trustStoreWithSystemCAs(format: TrustStoreFormat = TrustStoreFormat.Pkcs12): IO[MockError, TrustStore] =
-    trustStore(format).flatMap(TrustStore.plusSystemCAs)
+  def trustStoreWithSystemCAs(
+    format: TrustStoreFormat = TrustStoreFormat.Pkcs12,
+    to: Option[Path] = None
+  ): IO[MockError, TrustStore] =
+    trustStore(format).flatMap(TrustStore.plusSystemCAs(_, to))
 
   /**
    * Convenience: intercept `host` and forward its requests to `space`'s

--- a/mock/src/main/scala/zio/bdd/mock/Intercept.scala
+++ b/mock/src/main/scala/zio/bdd/mock/Intercept.scala
@@ -43,15 +43,31 @@ final case class TrustStore(path: Path, password: String, format: TrustStoreForm
 
 object TrustStore:
   /**
+   * The file a truststore export writes to. `None` → a fresh temp file (removed
+   * on JVM exit); `Some(p)` → `p` itself, with its parent directories created —
+   * a caller-chosen path, e.g. a host dir bind-mounted into a containerized SUT
+   * (#263). Does file-system work, so call it inside a blocking effect.
+   */
+  def exportPath(to: Option[Path], format: TrustStoreFormat): Path =
+    to match
+      case Some(p) =>
+        Option(p.getParent).foreach(Files.createDirectories(_))
+        p
+      case None =>
+        val tmp = Files.createTempFile("rift-intercept-", s".${format.wire}")
+        tmp.toFile.deleteOnExit()
+        tmp
+
+  /**
    * Return a copy of `caOnly` whose store ALSO contains the running JVM's
    * default trust anchors (its `cacerts`). Pointing a SUT at the CA-only export
    * via `-Djavax.net.ssl.trustStore` *replaces* the JVM default store, so the
    * SUT would trust the intercept CA but lose trust for every real HTTPS host;
-   * the merged store keeps both. Preserves `caOnly`'s format + password and
-   * writes a fresh temp file. Backend-neutral — pure `java.security`, no
-   * adapter types.
+   * the merged store keeps both. Preserves `caOnly`'s format + password. Writes
+   * a fresh temp file, or `to` when given (see [[exportPath]]). Backend-neutral
+   * — pure `java.security`, no adapter types.
    */
-  def plusSystemCAs(caOnly: TrustStore): IO[MockError, TrustStore] =
+  def plusSystemCAs(caOnly: TrustStore, to: Option[Path] = None): IO[MockError, TrustStore] =
     ZIO.attemptBlocking {
       // The whole point is to ADD the JVM defaults; an empty set means a misconfigured/empty cacerts
       // and a merged store that is silently CA-only — fail loudly rather than degrade to that.
@@ -74,8 +90,7 @@ object TrustStore:
         val alias = aliases.nextElement()
         Option(caStore.getCertificate(alias)).foreach(cert => merged.setCertificateEntry(s"intercept-$alias", cert))
 
-      val out = Files.createTempFile("rift-intercept-merged-", s".${caOnly.format.wire}")
-      out.toFile.deleteOnExit()
+      val out = exportPath(to, caOnly.format)
       Using.resource(Files.newOutputStream(out))(os => merged.store(os, caOnly.password.toCharArray))
       TrustStore(out, caOnly.password, caOnly.format)
     }

--- a/mock/src/test/scala/zio/bdd/mock/InterceptTrustStoreSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/InterceptTrustStoreSpec.scala
@@ -116,7 +116,59 @@ object InterceptTrustStoreSpec extends ZIOSpecDefault:
       )
     }
 
+  // plusSystemCAs(to = Some(path)) writes to that exact path, creating parent dirs, JVM-loadable (#263).
+  private def toPathTest(format: TrustStoreFormat) =
+    test(s"plusSystemCAs(${format.wire}, to = Some(path)) writes to the given path (parent dirs created)") {
+      for
+        caOnly <- caOnlyStore(format)
+        base   <- ZIO.attemptBlocking(Files.createTempDirectory("rift-mnt"))
+        // a parent dir that does NOT exist yet — plusSystemCAs must create it
+        target  = base.resolve("sub").resolve(s"intercept.${format.wire}")
+        merged <- TrustStore.plusSystemCAs(caOnly, to = Some(target))
+        certs  <- certsOf(merged)
+        system <- systemAnchors
+        exists <- ZIO.attemptBlocking(Files.exists(target))
+      yield assertTrue(
+        merged.path == target, // returned at the exact requested path
+        exists,                // parent dir was created and the file written
+        certs.contains(parseCert(testCaPem)),
+        system.subsetOf(certs) // JVM-loadable merged store at the mounted path
+      )
+    }
+
+  // A stub Intercept whose only real method is `trustStore` (recording the `to` it receives) — to unit-test
+  // the trait DEFAULT `trustStoreWithSystemCAs` threading, with no native library (#263).
+  private def stubIntercept(seen: Ref[Option[Option[java.nio.file.Path]]]): Intercept =
+    new Intercept:
+      def proxyPort: IO[MockError, Int]                 = ZIO.succeed(0)
+      def add(rule: InterceptRule): IO[MockError, Unit] = ZIO.unit
+      def trustStore(format: TrustStoreFormat, to: Option[java.nio.file.Path]): IO[MockError, TrustStore] =
+        seen.set(Some(to)) *> caOnlyStore(format).mapError(t =>
+          MockError.ProvisionFailed(Option(t.getMessage).getOrElse(t.getClass.getSimpleName))
+        )
+
   def spec = suite("TrustStore.plusSystemCAs (#259)")(
     mergeTest(TrustStoreFormat.Pkcs12),
-    mergeTest(TrustStoreFormat.Jks)
+    mergeTest(TrustStoreFormat.Jks),
+    toPathTest(TrustStoreFormat.Pkcs12),
+    toPathTest(TrustStoreFormat.Jks),
+    test(
+      "trustStoreWithSystemCAs(to = Some(p)) applies `to` at the merge step; the inner CA export stays default (#263)"
+    ) {
+      for
+        seen  <- Ref.make(Option.empty[Option[java.nio.file.Path]])
+        base  <- ZIO.attemptBlocking(Files.createTempDirectory("rift-mnt"))
+        target = base.resolve("out").resolve("merged.p12") // parent 'out' does not exist yet
+        merged <-
+          stubIntercept(seen).trustStoreWithSystemCAs(to = Some(target)).mapError(e => new RuntimeException(e.toString))
+        inner  <- seen.get
+        certs  <- certsOf(merged)
+        system <- systemAnchors
+      yield assertTrue(
+        inner == Some(None),   // the trait default calls the inner CA export with to=None, NOT the merged target
+        merged.path == target, // `to` is applied only at the merge write → merged store at the requested path
+        certs.contains(parseCert(testCaPem)),
+        system.subsetOf(certs) // JVM-loadable merged store
+      )
+    }
   )

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedIntercept.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedIntercept.scala
@@ -5,8 +5,6 @@ import zio.bdd.mock.*
 import zio.json.*
 import zio.json.ast.Json
 
-import java.nio.file.Files
-
 /**
  * The [[Intercept]] capability over the embedded engine's intercept FFI
  * (rift#410, #219): starts the TLS-MITM forward-proxy lazily on first use
@@ -38,17 +36,16 @@ private[embedded] final class EmbeddedIntercept(
   def add(rule: InterceptRule): IO[MockError, Unit] =
     ZIO.fromEither(EmbeddedIntercept.ruleJson(rule)).flatMap(json => ensureStarted *> engine.interceptAddRules(json))
 
-  def trustStore(format: TrustStoreFormat): IO[MockError, TrustStore] =
+  def trustStore(format: TrustStoreFormat, to: Option[java.nio.file.Path]): IO[MockError, TrustStore] =
     for
       _ <- ensureStarted
-      tmp <- ZIO.attemptBlocking {
-               val p = Files.createTempFile("rift-intercept-", s".${format.wire}")
-               p.toFile.deleteOnExit()
-               p
-             }
-               .mapError(t => MockError.CommunicationError(s"creating intercept truststore temp file: ${message(t)}"))
-      _ <- engine.interceptExportTruststore(format.wire, EmbeddedIntercept.DefaultPassword, tmp.toString)
-    yield TrustStore(tmp, EmbeddedIntercept.DefaultPassword, format)
+      out <- ZIO
+               // Local filesystem work (temp file / caller path), not a backend round-trip → ProvisionFailed,
+               // per the package's error taxonomy (CommunicationError is reserved for backend comms).
+               .attemptBlocking(TrustStore.exportPath(to, format))
+               .mapError(t => MockError.ProvisionFailed(s"resolving intercept truststore path: ${message(t)}"))
+      _ <- engine.interceptExportTruststore(format.wire, EmbeddedIntercept.DefaultPassword, out.toString)
+    yield TrustStore(out, EmbeddedIntercept.DefaultPassword, format)
 
   // Start the listener at most once (race-safe), memoizing its bound proxy port.
   private def ensureStarted: IO[MockError, Int] =

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedInterceptSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedInterceptSpec.scala
@@ -194,5 +194,34 @@ object EmbeddedInterceptSpec extends ZIOSpecDefault:
         // (b) the merged store also carries the JVM default anchors → strictly more entries than CA-only.
         yield assertTrue(res._1 == 200, res._2.contains("mocked"), caN >= 1, mergedN > caN))
           .provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
+    },
+    test(
+      "trustStore(to = Some(path)) / trustStoreWithSystemCAs(to = …): export to a caller path, JVM-loadable there (#263)"
+    ) {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
+      else
+        (for
+          mc           <- ZIO.service[MockControl]
+          _            <- mc.provision(cdnConfig).mapError(asT)
+          ic           <- mc.intercept.mapError(u => new RuntimeException(u.message))
+          base         <- ZIO.attemptBlocking(Files.createTempDirectory("rift-mnt"))
+          caPath        = base.resolve("ca").resolve("intercept.p12")     // parent 'ca' does not exist yet
+          mergedPath    = base.resolve("merged").resolve("intercept.jks") // parent 'merged' does not exist yet
+          ca           <- ic.trustStore(to = Some(caPath)).mapError(asT)
+          merged       <- ic.trustStoreWithSystemCAs(TrustStoreFormat.Jks, to = Some(mergedPath)).mapError(asT)
+          caExists     <- ZIO.attemptBlocking(Files.exists(caPath))
+          mergedExists <- ZIO.attemptBlocking(Files.exists(mergedPath))
+          caN          <- anchorCount(ca)
+          mergedN      <- anchorCount(merged)
+        yield assertTrue(
+          ca.path == caPath,
+          caExists,
+          caN >= 1, // CA-only store written to + loaded from the caller path
+          merged.path == mergedPath,
+          merged.format == TrustStoreFormat.Jks,
+          mergedExists,
+          mergedN > caN // merged store (CA + system anchors) written to + loaded from the caller path
+        ))
+          .provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
     }
   ) @@ TestAspect.withLiveClock @@ TestAspect.sequential


### PR DESCRIPTION
Adds an optional `to: Option[Path]` to `Intercept.trustStore` and
`trustStoreWithSystemCAs`: `None` (default) writes a fresh temp file; `Some(path)`
writes the store to that exact path, creating parent dirs — so a containerized
SUT can read it straight from a bind-mounted path with no copy step. A shared
`TrustStore.exportPath` helper centralizes temp-vs-path resolution; covers CA-only
and merged (#259) exports, both PKCS12 and JKS.

Tests: always-on unit tests for `plusSystemCAs(to=)` (both formats) and the
trait-default `trustStoreWithSystemCAs(to=)` threading (via a stub Intercept), plus
a native-gated e2e exporting to caller paths and asserting JVM-loadability there.

Closes #263

Follow-up to #254 (bind host) and #259 (merged truststore) for the containerized-SUT topology.