### PR TITLE
refactor: consume the engine's bound host from InterceptInfo.interceptUrl

### DIFF
--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedIntercept.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedIntercept.scala
@@ -23,15 +23,16 @@ import zio.json.ast.Json
  */
 private[embedded] final class EmbeddedIntercept(
   engine: EmbeddedEngine,
-  started: Ref.Synchronized[Option[Int]],
+  started: Ref.Synchronized[Option[(String, Int)]],
   config: EmbeddedRift.InterceptConfig
 ) extends Intercept:
 
-  def proxyPort: IO[MockError, Int] = ensureStarted
+  def proxyPort: IO[MockError, Int] = ensureStarted.map(_._2)
 
-  // The listener binds `config.bindHost` (loopback by default), so report that as the reachable host —
-  // a wider bind (e.g. 0.0.0.0 for a containerized SUT) is where a caller points its proxy, not 127.0.0.1.
-  override def proxyEndpoint: IO[MockError, (String, Int)] = ensureStarted.map((config.bindHost, _))
+  // Report the engine's actual bound endpoint: the host parsed from `rift_start_intercept`'s interceptUrl
+  // (ground truth since rift#425), paired with interceptPort. For the common loopback / 0.0.0.0 binds this
+  // equals the requested `config.bindHost`; for a specific-NIC bind it surfaces the interface the engine bound.
+  override def proxyEndpoint: IO[MockError, (String, Int)] = ensureStarted
 
   def add(rule: InterceptRule): IO[MockError, Unit] =
     ZIO.fromEither(EmbeddedIntercept.ruleJson(rule)).flatMap(json => ensureStarted *> engine.interceptAddRules(json))
@@ -47,16 +48,34 @@ private[embedded] final class EmbeddedIntercept(
       _ <- engine.interceptExportTruststore(format.wire, EmbeddedIntercept.DefaultPassword, out.toString)
     yield TrustStore(out, EmbeddedIntercept.DefaultPassword, format)
 
-  // Start the listener at most once (race-safe), memoizing its bound proxy port. Validate the bind host
-  // first so a hostname fails with a clear message here, not opaquely inside the engine (#262).
-  private def ensureStarted: IO[MockError, Int] =
+  // Start the listener at most once (race-safe), memoizing its bound endpoint (host, port). Validate the
+  // bind host first so a hostname fails with a clear message here, not opaquely inside the engine (#262).
+  private def ensureStarted: IO[MockError, (String, Int)] =
     started.modifyZIO {
-      case s @ Some(p) => ZIO.succeed((p, s))
+      case s @ Some(ep) => ZIO.succeed((ep, s))
       case None =>
         ZIO.fromEither(EmbeddedIntercept.validateBindHost(config.bindHost)) *>
           engine
             .startIntercept(EmbeddedIntercept.startOptions(config))
-            .map(i => (i.interceptPort, Some(i.interceptPort)))
+            .flatMap { i =>
+              EmbeddedIntercept
+                .hostOf(i.interceptUrl)
+                // A host-less / unparseable interceptUrl (the class of bug rift#425 fixed) is not fatal: fall
+                // back to the requested bindHost so the endpoint never regresses. Log it — the memoized result
+                // locks the fallback in for the listener's life, so a silent degrade would be hard to diagnose.
+                .fold(
+                  ZIO
+                    .logWarning(
+                      s"rift_start_intercept returned interceptUrl '${i.interceptUrl}' with no usable host; " +
+                        s"reporting the requested bindHost '${config.bindHost}'"
+                    )
+                    .as(config.bindHost)
+                )(ZIO.succeed(_))
+                .map { host =>
+                  val ep = (host, i.interceptPort)
+                  (ep, Some(ep))
+                }
+            }
     }
 
   private def message(t: Throwable): String = Option(t.getMessage).getOrElse(t.getClass.getSimpleName)
@@ -97,6 +116,15 @@ private[embedded] object EmbeddedIntercept:
         asciiDigit(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') || c == ':' || c == '.'
       }
     isIpv4 || isIpv6
+
+  // Parse the reachable host from the engine's reported interceptUrl (ground truth since rift#425); None
+  // for a malformed URL or one without a host (the caller then falls back to the requested bindHost).
+  private[embedded] def hostOf(interceptUrl: String): Option[String] =
+    scala.util
+      .Try(java.net.URI.create(interceptUrl).getHost)
+      .toOption
+      .flatMap(Option(_))
+      .filter(_.nonEmpty)
 
   /**
    * Build the rift intercept-rule JSON from a portable [[InterceptRule]]. Left

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
@@ -59,7 +59,7 @@ private[embedded] final case class EmbeddedRiftMockControl(
   correlated: Ref[Map[SpaceId, EmbeddedRiftMockControl.CorrSpace]],
   sharedPort: Ref.Synchronized[Option[Int]],
   ids: Ref[Int],
-  interceptStarted: Ref.Synchronized[Option[Int]],
+  interceptStarted: Ref.Synchronized[Option[(String, Int)]],
   interceptConfig: EmbeddedRift.InterceptConfig
 ) extends MockControl:
 
@@ -645,7 +645,7 @@ private[embedded] object EmbeddedRiftMockControl:
       correlated <- Ref.make(Map.empty[SpaceId, CorrSpace])
       sharedPort <- Ref.Synchronized.make(Option.empty[Int])
       ids        <- Ref.make(0)
-      intercept  <- Ref.Synchronized.make(Option.empty[Int])
+      intercept  <- Ref.Synchronized.make(Option.empty[(String, Int)])
       control =
         EmbeddedRiftMockControl(
           engine,

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedInterceptSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedInterceptSpec.scala
@@ -189,6 +189,18 @@ object EmbeddedInterceptSpec extends ZIOSpecDefault:
         }
       )
     },
+    // Pure parse of the engine's interceptUrl into the reported host (#264); runs on any host. The engine
+    // value is ground truth (rift#425); a malformed / host-less URL yields None (caller → bindHost fallback).
+    test("hostOf reads the engine's bound host from interceptUrl; None when absent") {
+      assertTrue(
+        EmbeddedIntercept.hostOf("http://127.0.0.1:38080").contains("127.0.0.1"),
+        EmbeddedIntercept.hostOf("http://0.0.0.0:38080").contains("0.0.0.0"),
+        // a specific-NIC ground truth is surfaced verbatim (it would win over a requested wildcard bind)
+        EmbeddedIntercept.hostOf("http://192.168.1.5:38080").contains("192.168.1.5"),
+        EmbeddedIntercept.hostOf("").isEmpty,         // no host → None
+        EmbeddedIntercept.hostOf("not a url").isEmpty // unparseable → None
+      )
+    },
     test("trustStoreWithSystemCAs: the merged store trusts the intercepted host AND keeps the JVM default anchors") {
       if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
       else

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
@@ -60,8 +60,11 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
 
     // Intercept FFI (#219): count listener starts (to prove memoization), capture the rule JSON and
     // the truststore-export args the adapter drives.
+    // The interceptUrl host (a documentation address, RFC 5737) deliberately differs from the default
+    // bindHost (127.0.0.1) so a test can prove proxyEndpoint reports the engine's bound host (#264) rather
+    // than echoing the requested bindHost.
     def startIntercept(optionsJson: String): IO[MockError, EmbeddedEngine.InterceptInfo] =
-      interceptStarts.update(_ + 1).as(EmbeddedEngine.InterceptInfo(38080, "http://127.0.0.1:38080"))
+      interceptStarts.update(_ + 1).as(EmbeddedEngine.InterceptInfo(38080, "http://192.0.2.10:38080"))
     def interceptAddRules(rulesJson: String): IO[MockError, Unit] = interceptRules.update(_ :+ rulesJson)
     def interceptExportTruststore(format: String, password: String, outPath: String): IO[MockError, Unit] =
       truststoreExports.update(_ :+ (format, password, outPath))
@@ -378,12 +381,15 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
           _      <- ic.redirectTo("cdn.example.com", space)
           _      <- ic.respondWith("api.example.com", InterceptStub(status = 418, body = Some("teapot")))
           p      <- ic.proxyPort
+          ep     <- ic.proxyEndpoint
           rules  <- engine.interceptRules.get
           starts <- engine.interceptStarts.get
         yield assertTrue(
           control.capabilities.contains(Capability.Intercept),
           p == 38080,
-          starts == 1, // one listener despite redirect + serve + proxyPort (memoized)
+          // proxyEndpoint reports the engine's bound host from interceptUrl (#264), not the requested bindHost.
+          ep == ("192.0.2.10", 38080),
+          starts == 1, // one listener despite redirect + serve + proxyPort + proxyEndpoint (memoized)
           rules.exists(j =>
             j.contains("\"forward\"") && j.contains(s"\"port\":$port") && j.contains("cdn.example.com")
           ),


### PR DESCRIPTION
proxyEndpoint now derives its reported host by parsing the engine's
interceptUrl (the ground-truth bound address, rift#425/rift v0.11.2) instead
of echoing the requested config.bindHost. Falls back to bindHost with a
logWarning for host-less/unparseable URLs, ensuring no regression.

Closes #264