### PR TITLE
Intercept: loud-fail guard when the embedded natives don't resolve (don't SKIP-pass a hermetic suite)

### DIFF
--- a/docs/mock-advanced.md
+++ b/docs/mock-advanced.md
@@ -398,6 +398,16 @@ ready-to-use JVM truststore (JKS by default) + password, and `proxyPort` is the
 loopback port the SUT proxies through. Starting the listener is lazy and opt-in:
 a suite that never calls `mc.intercept` pays nothing.
 
+> **Fail loudly in a hermetic CI suite.** The embedded specs guard on
+> `EmbeddedRift.available` and **SKIP** (pass) when no `librift_ffi` resolves —
+> right for a cross-platform matrix, but for a suite whose whole point is to
+> exercise intercept, a missing/misconfigured natives jar would then read as a
+> green run that never ran. Guard the setup so it fails loudly instead:
+> `EmbeddedRift.requireAvailable` (a `no-op` when a native resolves; otherwise a
+> `MockError.ProvisionFailed` naming the host `os-arch` and how to fix it — add
+> the `zio-bdd-rift-embedded-natives` dependency or set `-Drift.ffi.lib`). Use
+> the boolean `EmbeddedRift.available` only where a SKIP is genuinely desired.
+
 Build rules with the DSL — `intercept(host).redirectTo(space)` or
 `.respondWith(stub)` — and apply them through the capability:
 

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
@@ -37,6 +37,25 @@ object EmbeddedRift:
   def available: Boolean = NativeLibrary.available
 
   /**
+   * Fail loudly — rather than SKIP — when no `librift_ffi` resolves for the
+   * host, for a suite that REQUIRES the embedded engine (e.g. a hermetic
+   * intercept CI run where a missing/misconfigured natives jar must not read as
+   * a green skip). Surfaces the same host-resolution error [[layer]] fails with
+   * at construction — a [[MockError.ProvisionFailed]] naming the host `os-arch`
+   * and how to fix it (add the `zio-bdd-rift-embedded-natives` dependency or
+   * set `-Drift.ffi.lib`). A no-op when a native resolves. [[available]] is the
+   * soft boolean form for a suite that legitimately wants to SKIP on an
+   * unsupported platform (zio-bdd's own cross-platform matrix); use this when a
+   * skip would hide a real gap.
+   */
+  def requireAvailable: IO[MockError, Unit] = requireResolved(NativeLibrary.resolveSource)
+
+  // Testable core of `requireAvailable`: a Left host-resolution error becomes a loud failure; a Right is
+  // a no-op. Split out so both branches are covered without depending on the host actually lacking a lib.
+  private[embedded] def requireResolved(source: Either[MockError, LibSource]): IO[MockError, Unit] =
+    ZIO.fromEither(source).unit
+
+  /**
    * Bind configuration for the built-in [[Intercept]] TLS-MITM proxy. Defaults
    * preserve today's behavior: loopback bind, OS-assigned port. Set `bindHost =
    * "0.0.0.0"` (or a specific NIC address) so a SUT running elsewhere — e.g. a

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/NativeLibrarySpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/NativeLibrarySpec.scala
@@ -1,5 +1,6 @@
 package zio.bdd.mock.rift.embedded
 
+import zio.*
 import zio.bdd.mock.MockError
 import zio.test.*
 
@@ -60,5 +61,43 @@ object NativeLibrarySpec extends ZIOSpecDefault:
     },
     test("the live host resolves out-of-the-box — no -Drift.ffi.lib override set, yet available") {
       assertTrue(!sys.props.contains(NativeLibrary.LibPathProperty), EmbeddedRift.available)
+    },
+    // The loud-fail guard (#258): a resolution Left becomes a hard failure (surfacing its os-arch-naming
+    // message), a Right is a no-op — both branches, without needing the host to actually lack a native.
+    test("requireResolved: a Left host-resolution error fails loudly; a Right is a no-op (#258)") {
+      val err = MockError.ProvisionFailed(
+        "no bundled librift_ffi for host darwin-aarch64 on the classpath; add the zio-bdd-rift-embedded-natives dependency"
+      )
+      for
+        failed <- EmbeddedRift.requireResolved(Left(err)).either
+        ok     <- EmbeddedRift.requireResolved(Right(LibSource.Bundled("native/linux-x86_64/librift_ffi.so"))).either
+      yield assertTrue(failed == Left(err), ok.isRight)
+    },
+    test("requireAvailable succeeds iff a native resolves for the host (#258)") {
+      for result <- EmbeddedRift.requireAvailable.either
+      yield assertTrue(result.isRight == EmbeddedRift.available)
+    },
+    // End-to-end proof that `requireAvailable` is really wired to `NativeLibrary.resolveSource` and takes
+    // the loud-failure path: force an unresolvable host on ANY platform via a bogus -Drift.ffi.lib override
+    // (CI always runs on a supported host, so this is the only way to exercise the failure branch here).
+    test("requireAvailable fails loudly when no native resolves — forced via a bogus -Drift.ffi.lib (#258)") {
+      val prop  = NativeLibrary.LibPathProperty
+      val bogus = "/no/such/librift_ffi.so"
+      // java.lang.System — `import zio.*` brings `zio.System` (the ZIO service) into scope, which shadows it.
+      ZIO.acquireReleaseWith(
+        ZIO.succeed {
+          val prev = Option(java.lang.System.getProperty(prop))
+          java.lang.System.setProperty(prop, bogus)
+          prev
+        }
+      )(prev => ZIO.succeed(prev.fold(java.lang.System.clearProperty(prop))(java.lang.System.setProperty(prop, _))))(
+        _ =>
+          EmbeddedRift.requireAvailable.either.map(r =>
+            assertTrue(r match
+              case Left(MockError.ProvisionFailed(m)) => m.contains(bogus)
+              case _                                  => false
+            )
+          )
+      )
     }
-  )
+  ) @@ TestAspect.sequential


### PR DESCRIPTION
Adds `EmbeddedRift.requireAvailable: IO[MockError, Unit]` — for a suite that
REQUIRES the embedded engine (e.g. a hermetic intercept CI run), fail loudly
rather than SKIP when no `librift_ffi` resolves. It surfaces the same
host-resolution error `layer` fails with — a `MockError.ProvisionFailed` naming
the host `os-arch` and how to fix it (add `zio-bdd-rift-embedded-natives` or set
`-Drift.ffi.lib`); a no-op when a native resolves. `EmbeddedRift.available`
stays the soft boolean for where a SKIP is genuinely wanted. Docs (mock-advanced
§9) show the CI guard.

Tests (in NativeLibrarySpec): both branches of the pure seam, plus an end-to-end
forced-failure (bogus `-Drift.ffi.lib`) proving `requireAvailable` takes the loud
path — so a wiring regression can't slip through on an always-available CI host.

Closes #258

Repurposed from the original #258 (natives-release tracker); the release/publish half was release-ops, carved off.