### PR TITLE
Embedded intercept should accept a caller-provided (persistent) CA

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ import java.security.MessageDigest
 // Single source of truth for the pinned Rift release (#195). Both the FFI natives (riftNativesVersion,
 // downloaded into the embedded-natives jar) and the container image tag (Rift.DefaultImage, via the
 // generated RiftBuildInfo below) derive from it, so a version bump touches exactly one line.
-val riftVersion        = "0.11.2"
+val riftVersion        = "0.11.3"
 val riftNativesVersion = riftVersion
 
 // The (os, arch, ext) cdylibs bundled into the natives jar — linux/macOS × x86_64/aarch64 (#134).

--- a/docs/mock-advanced.md
+++ b/docs/mock-advanced.md
@@ -515,6 +515,27 @@ forwards intercepted traffic to the target space's imposter internally on
 loopback, so imposter ports stay private. See the `bindHost 0.0.0.0` case in
 `EmbeddedInterceptSpec` for a runnable check over a non-loopback interface.
 
+**Committed CA — no run-model change (requires rift ≥ 0.11.3).** By default the
+embedded proxy mints a **fresh CA on every start**, so a long-lived SUT container
+can't trust it at JVM startup (the truststore doesn't exist until the test starts
+the proxy). Point `InterceptConfig` at a **persistent, committed** CA instead — the
+proxy loads it at runtime, so the truststore you exported and committed once already
+matches:
+
+```scala
+val ca  = java.nio.file.Path.of("test/ca/intercept-ca.pem")   // committed once
+val key = java.nio.file.Path.of("test/ca/intercept-ca.key")
+val mock = Provisioning.live >>>
+  EmbeddedRift.layer(InterceptConfig(bindHost = "0.0.0.0", port = Some(8888), caCert = Some(ca), caKey = Some(key)))
+```
+
+`caCert`/`caKey` are **both-or-neither** (supplying one fails with
+`MockError.InvalidDefinition`); absent, the ephemeral default is unchanged. Now the
+SUT container mounts the pre-exported truststore and starts normally via `docker
+compose` — no test-owned container lifecycle, no two-phase ordering. See the
+persistent-CA reuse case in `EmbeddedInterceptSpec` (two instances, one committed CA,
+mutually-trusted leaves).
+
 **CONTAINER variant (`Rift.managed`).** The containerized Rift adapter
 (#253) advertises `Capability.Intercept` too, opt-in: pass a
 container-internal `interceptPort` to `Rift.managed`, and testcontainers

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedIntercept.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedIntercept.scala
@@ -55,6 +55,7 @@ private[embedded] final class EmbeddedIntercept(
       case s @ Some(ep) => ZIO.succeed((ep, s))
       case None =>
         ZIO.fromEither(EmbeddedIntercept.validateBindHost(config.bindHost)) *>
+          ZIO.fromEither(EmbeddedIntercept.validateCaPair(config)) *>
           engine
             .startIntercept(EmbeddedIntercept.startOptions(config))
             .flatMap { i =>
@@ -86,8 +87,23 @@ private[embedded] object EmbeddedIntercept:
   // Start options for the TLS-MITM listener. `bindHost` defaults to loopback (127.0.0.1); a wider bind
   // (0.0.0.0 / a NIC address) makes the proxy reachable from another host or container. `port` defaults
   // to 0 (OS-assigned); a pinned value binds a known port for a SUT whose proxy target is fixed up front.
+  // `caCertPath`/`caKeyPath` (both-or-neither) load a persistent caller CA (#273) — emitted only when both
+  // are set (rift's InterceptOptions uses deny_unknown_fields, so only known keys may appear).
   private[embedded] def startOptions(config: EmbeddedRift.InterceptConfig): String =
-    Json.Obj("host" -> Json.Str(config.bindHost), "port" -> Json.Num(config.port.getOrElse(0))).toJson
+    val base = List("host" -> Json.Str(config.bindHost), "port" -> Json.Num(config.port.getOrElse(0)))
+    val ca = (config.caCert, config.caKey) match
+      case (Some(cert), Some(key)) =>
+        List("caCertPath" -> Json.Str(cert.toString), "caKeyPath" -> Json.Str(key.toString))
+      case _ => Nil
+    Json.Obj((base ++ ca)*).toJson
+
+  // Both-or-neither: a lone caCert/caKey is a misconfiguration (rift needs the pair to load a CA). Reject
+  // it early with a clear message rather than silently dropping to an ephemeral CA / an opaque engine error.
+  private[embedded] def validateCaPair(config: EmbeddedRift.InterceptConfig): Either[MockError, Unit] =
+    (config.caCert, config.caKey) match
+      case (Some(_), None) | (None, Some(_)) =>
+        Left(MockError.InvalidDefinition("intercept caCert and caKey must be set together (both or neither)"))
+      case _ => Right(())
 
   // rift binds the intercept listener via SocketAddr::parse, which accepts only IP literals — a hostname
   // (`localhost` / a DNS name) fails there with an opaque error. Reject it early, DNS-free (no resolution),

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
@@ -69,8 +69,21 @@ object EmbeddedRift:
    * address) — the engine binds via a socket-address parse, so a hostname like
    * `localhost` is rejected with [[MockError.InvalidDefinition]] on first
    * intercept use (#262), not resolved.
+   *
+   * `caCert`/`caKey` (PEM file paths, **both or neither**) make the proxy load
+   * a **persistent, caller-provided** intercept CA instead of minting a fresh
+   * ephemeral one each start (#273, needs rift ≥ 0.11.3). Commit a rift CA once
+   * and a long-lived containerized SUT can trust it at JVM startup — before the
+   * test starts the proxy — so the ordering problem an ephemeral CA creates
+   * disappears. Absent → ephemeral CA, exactly as before. Supplying only one is
+   * rejected with [[MockError.InvalidDefinition]] on first intercept use.
    */
-  final case class InterceptConfig(bindHost: String = "127.0.0.1", port: Option[Int] = None)
+  final case class InterceptConfig(
+    bindHost: String = "127.0.0.1",
+    port: Option[Int] = None,
+    caCert: Option[Path] = None,
+    caKey: Option[Path] = None
+  )
 
   /**
    * A scoped [[MockControl]] backed by the in-process Rift engine, PerInstance

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedInterceptSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedInterceptSpec.scala
@@ -99,6 +99,68 @@ object EmbeddedInterceptSpec extends ZIOSpecDefault:
     )
   )
 
+  // A committed CA (cert + PKCS#8 key, CA:TRUE) for the persistent-CA reuse test (#273). Two engine
+  // instances loading this same pair mint leaves under one CA, so a truststore exported from one validates
+  // the other's intercepted TLS — which an ephemeral (per-start) CA does not.
+  private val CaCertPem: String =
+    """|-----BEGIN CERTIFICATE-----
+       |MIIDOzCCAiOgAwIBAgIUd4FP1xedkoSU6TmCHZDCYe5wTFwwDQYJKoZIhvcNAQEL
+       |BQAwJTEjMCEGA1UEAwwaemlvLWJkZC1wZXJzaXN0ZW50LXRlc3QtY2EwHhcNMjYw
+       |NzA4MTEzNjI5WhcNMzYwNzA1MTEzNjI5WjAlMSMwIQYDVQQDDBp6aW8tYmRkLXBl
+       |cnNpc3RlbnQtdGVzdC1jYTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+       |AN8lKT3RxrWABSDYAyl2FH57vx1wZe/qPV4SuXun3Z47bGT/ppaoqZIU9cd/IZye
+       |Zp3fqoONKmJHbLfsCN9RUXWIFtRC/1OcBoP4xZ2cNgcUoZ5EUTRHiV2xWzmib+th
+       |wqNh8ywICn8KhhTRlp6S/PLW680IzDEtcotOP20eFk5w/W5acHdmG78YBVS0IbZQ
+       |ONGFysJcvekVsQINyao3XN+5eVqeFDA5VTllj2lxNVTQQYhGfyfnBZKqTTOihJ99
+       |+ZMGhTUIPznzeinYA72b+eZqyqjKMPtbQERB0J3F7oPFtsVtvUDvr7y6ijr60LLU
+       |H6xvtuQVugAWIrhtiz5aAWMCAwEAAaNjMGEwHQYDVR0OBBYEFAjgTsN9t6fBGRF3
+       |dVQkUPiFNRdPMB8GA1UdIwQYMBaAFAjgTsN9t6fBGRF3dVQkUPiFNRdPMA8GA1Ud
+       |EwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMA0GCSqGSIb3DQEBCwUAA4IBAQAW
+       |peycXfE/ifmuNDlDSyqsGnSDr2LurluFfP3/bRS1U3rn2/XDXGMJA6lG6OaKbl/8
+       |EQ8kcJjuG3Xx5h4PbvO2saDAEGMB2v7Le8YFiM8H3Zzl+4OiFhm5l7LcTbWMS0B+
+       |NfZh58ixe1sqUOL+ITOxrQgIew8bv3DOZM16eTj24unpCDwiRg9jJHb8TDPyynL9
+       |tjAUlq8TDJBuKfjVyM6VRwPxGL1atjIc9EiMkmIBtmnbRbwUyb05h1kdOwDpYPSj
+       |I/W9WWL3S+jKKexw66A141DgRPU5cmhUBI9VH3UcfrIZpsaFsK2xsTK5wvHqIGPS
+       |vI7vtjy6CP3WIgFqfrua
+       |-----END CERTIFICATE-----""".stripMargin
+
+  private val CaKeyPem: String =
+    """|-----BEGIN PRIVATE KEY-----
+       |MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQDfJSk90ca1gAUg
+       |2AMpdhR+e78dcGXv6j1eErl7p92eO2xk/6aWqKmSFPXHfyGcnmad36qDjSpiR2y3
+       |7AjfUVF1iBbUQv9TnAaD+MWdnDYHFKGeRFE0R4ldsVs5om/rYcKjYfMsCAp/CoYU
+       |0Zaekvzy1uvNCMwxLXKLTj9tHhZOcP1uWnB3Zhu/GAVUtCG2UDjRhcrCXL3pFbEC
+       |DcmqN1zfuXlanhQwOVU5ZY9pcTVU0EGIRn8n5wWSqk0zooSfffmTBoU1CD8583op
+       |2AO9m/nmasqoyjD7W0BEQdCdxe6DxbbFbb1A76+8uoo6+tCy1B+sb7bkFboAFiK4
+       |bYs+WgFjAgMBAAECggEAFlrNMmXBH+621M7/Jhivveocv9DCTZIsWq/KiDJNd+wh
+       |FE8uO7qi3kEeTEGWtu+BfUBqfypVvCnGoPhS/ThSzlD3ZIVfudsQJgl2lq8PFI+D
+       |D21tqyydfNbnOjNlPfH5w09tQpR9pLODsjM7ASDdmWBhmBVRC34vkvggT4irmGj2
+       |ftdvt9f3hJq739Iybm2GkOtiIj++FFS4v4qo5OlPZ2cYZwrXHW1s4p3GFfztjyw2
+       |O+kHo/IbFdryLK8w44UuscpP2VC5YtYZabhhxZurVen0urMJoPFHMmmjJmwEFKK0
+       |dKlWixZ0tuYqSpXr7pr+m0stG5ZmWzVaj7CPIR6QrQKBgQDwz0mNf+bDZ5rNhvPa
+       |lRRkd7LQeVdeoHtrB7ylWSjC1T7i/jB+zBGEOeRQukbhtFsGOTdX/tRiiO0gqTM5
+       |cJ0tpKR1pGE7/Hg893TQ5ZIU7eyuB+qkQVxAiLNEJRZox9tAFVtMkY7Gtac6T4MG
+       |GrAyUWqNlsLlM9gwPY63jwsfPQKBgQDtOJ4wr5HuFisQNJvAlYczYDOE4EZM0XOm
+       |I/uxraKGIJtPGS1qpVkb9T5suSWMYBJzKOBDcyq7hr7AgllloXjRHj6/lo6Jmmsv
+       |KrbRDZiWNEZoFz3bm4cYE1VnaFJ39s08XIVXOfSAZilQyY5s5Wy8Y+Y0rWYYZ7uR
+       |Y5F0dcmtHwKBgQDT3r0rJvYkxHn6DJtunK3Ve08zhx8s3WvZDnSW0iw/x5lN5DFM
+       |zkU3HixYLpyApstTXXHpFQdOLoTbsKKmDgPsjag47Uizm306vsnjpahyi6cqs0Jq
+       |BCujh+KZuTvPMtAfwOqUIpkJEfgxIJX5/+84RlPGgXe2a3fxcaeors0tTQKBgQCX
+       |CYh22SJh481xWP2eBdZ6WJMU1DMOcAFhU+HKRBKJsbMRDqfDEhoFWgVv9gY5NWYp
+       |2mnHqEkZ8vX63kOLGN8yzj4HgBWq+R2rf1e9DRoM8KWvWrTw4TqHkq+60kpHxWTx
+       |PLtNSUIqimFd5acAIKc136lP+uNZQJrFPA79ho1s4wKBgQCl99+8lWVI75FWbOmF
+       |8JafS9hRZza7RTW9uMfGm1rTzJfV+EsdhtQO2kFkvvr+W12nEG9pCcMlV7aUgYe/
+       |2kNhEH/RROoCpCYWTX7FpcvhP8T7oBmtiB/2iLfPBuiiysWgEmI7B+H6/79WeHCs
+       |UALkJ4TuH6dsEar2G9caVFSobw==
+       |-----END PRIVATE KEY-----""".stripMargin
+
+  // Run `use` against a fresh scoped embedded MockControl built with `cfg` (its own engine, torn down on
+  // scope close) — so a test can run two independent instances with the same committed CA (#273).
+  private def withEmbedded[A](cfg: EmbeddedRift.InterceptConfig)(use: MockControl => Task[A]): Task[A] =
+    ZIO
+      .scoped(EmbeddedRift.layer(cfg).build.mapError(asT).flatMap(env => use(env.get[MockControl])))
+      .provide(Provisioning.live)
+
   def spec = suite("EmbeddedIntercept (#219)")(
     test("redirectTo: an HTTPS call to a hard-coded external host is intercepted and served by the mock imposter") {
       if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
@@ -176,6 +238,34 @@ object EmbeddedInterceptSpec extends ZIOSpecDefault:
         configured == """{"host":"0.0.0.0","port":8888}"""
       )
     },
+    // Pure CA start-options + both-or-neither validation (#273); no native library needed.
+    test("startOptions emits caCertPath/caKeyPath only when both are set; validateCaPair rejects a lone one") {
+      val none = EmbeddedIntercept.startOptions(EmbeddedRift.InterceptConfig())
+      val both = EmbeddedIntercept.startOptions(
+        EmbeddedRift.InterceptConfig(
+          caCert = Some(java.nio.file.Path.of("/ca.pem")),
+          caKey = Some(java.nio.file.Path.of("/ca.key"))
+        )
+      )
+      assertTrue(
+        !none.contains("caCertPath") && !none.contains("caKeyPath"), // absent → no CA keys (deny_unknown_fields ok)
+        both.contains(""""caCertPath":"/ca.pem"""") && both.contains(""""caKeyPath":"/ca.key""""),
+        EmbeddedIntercept.validateCaPair(EmbeddedRift.InterceptConfig()).isRight,
+        EmbeddedIntercept
+          .validateCaPair(
+            EmbeddedRift.InterceptConfig(
+              caCert = Some(java.nio.file.Path.of("/ca.pem")),
+              caKey = Some(java.nio.file.Path.of("/ca.key"))
+            )
+          )
+          .isRight,
+        EmbeddedIntercept.validateCaPair(
+          EmbeddedRift.InterceptConfig(caCert = Some(java.nio.file.Path.of("/ca.pem")))
+        ) match
+          case Left(MockError.InvalidDefinition(m)) => m.contains("both or neither")
+          case _                                    => false
+      )
+    },
     // Pure bind-host validation (#262); runs without the native library.
     test("validateBindHost: IP literals pass; a hostname is rejected with a clear InvalidDefinition naming it") {
       val ok  = List("127.0.0.1", "0.0.0.0", "192.168.1.5", "10.0.0.1", "255.255.255.255", "::1", "fe80::1")
@@ -248,5 +338,74 @@ object EmbeddedInterceptSpec extends ZIOSpecDefault:
           mergedN > caN // merged store (CA + system anchors) written to + loaded from the caller path
         ))
           .provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
+    },
+    test("caller-provided CA is reused across instances: run A's truststore validates run B's intercepted TLS (#273)") {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
+      else
+        for
+          dir   <- ZIO.attemptBlocking(Files.createTempDirectory("rift-ca"))
+          caCert = dir.resolve("ca.pem")
+          caKey  = dir.resolve("ca.key")
+          _     <- ZIO.attemptBlocking { Files.writeString(caCert, CaCertPem); Files.writeString(caKey, CaKeyPem) }
+          cfg    = EmbeddedRift.InterceptConfig(caCert = Some(caCert), caKey = Some(caKey))
+          // Run A (committed CA): export a truststore for that CA; A's engine is then torn down.
+          tsA <- withEmbedded(cfg)(mc =>
+                   mc.intercept.mapError(u => new RuntimeException(u.message)).flatMap(_.trustStore().mapError(asT))
+                 )
+          // Run B (the SAME committed CA): a SUT trusting tsA completes an intercepted call — only possible
+          // because B's per-host leaf is signed by the shared CA that tsA already trusts.
+          shared <- withEmbedded(cfg)(mc =>
+                      for
+                        space <- mc.provision(cdnConfig).mapError(asT).map(_.head)
+                        ic    <- mc.intercept.mapError(u => new RuntimeException(u.message))
+                        _     <- ic.redirectTo("cdn.example.com", space).mapError(asT)
+                        port  <- ic.proxyPort.mapError(asT)
+                        res   <- sutGet("https://cdn.example.com/config.json", port, tsA)
+                      yield res
+                    )
+          // Negative control: an EPHEMERAL instance mints its leaf under a different CA → tsA does NOT trust it.
+          ephemeral <- withEmbedded(EmbeddedRift.InterceptConfig())(mc =>
+                         for
+                           space <- mc.provision(cdnConfig).mapError(asT).map(_.head)
+                           ic    <- mc.intercept.mapError(u => new RuntimeException(u.message))
+                           _     <- ic.redirectTo("cdn.example.com", space).mapError(asT)
+                           port  <- ic.proxyPort.mapError(asT)
+                           res   <- sutGet("https://cdn.example.com/config.json", port, tsA).either
+                         yield res
+                       )
+        yield assertTrue(
+          shared._1 == 200,
+          shared._2.contains("mocked"), // shared committed CA → run A's truststore validates run B's TLS
+          // ephemeral CA → the same truststore does NOT validate: a TLS/cert-trust failure (lenient across
+          // JDKs), not merely "some error" — pins the negative control to the CA-distrust cause.
+          ephemeral.left.exists { t =>
+            val s = (t.toString + Option(t.getCause).fold("")(_.toString)).toLowerCase
+            s.contains("ssl") || s.contains("certif") || s.contains("handshake") || s.contains("trust")
+          }
+        )
+    },
+    test("misconfigured caller CA fails loudly on first intercept use: a lone caCert, and unreadable paths (#273)") {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
+      else
+        for
+          // (1) a lone caCert (no caKey) → validateCaPair rejects it with InvalidDefinition, via the real call.
+          lone <-
+            withEmbedded(EmbeddedRift.InterceptConfig(caCert = Some(java.nio.file.Path.of("/no/such/ca.pem"))))(mc =>
+              mc.intercept.mapError(u => new RuntimeException(u.message)).flatMap(_.proxyPort.either)
+            )
+          // (2) both set but pointing at nonexistent PEM files → rift's CA load fails → a loud MockError, not a hang.
+          bad <- withEmbedded(
+                   EmbeddedRift.InterceptConfig(
+                     caCert = Some(java.nio.file.Path.of("/no/such/ca.pem")),
+                     caKey = Some(java.nio.file.Path.of("/no/such/ca.key"))
+                   )
+                 )(mc => mc.intercept.mapError(u => new RuntimeException(u.message)).flatMap(_.proxyPort.either))
+        yield assertTrue(
+          lone match
+            case Left(MockError.InvalidDefinition(m)) => m.contains("both or neither")
+            case _                                    => false
+          ,
+          bad.isLeft // a nonexistent CA file surfaces as a MockError (loud), never a silent success or hang
+        )
     }
   ) @@ TestAspect.withLiveClock @@ TestAspect.sequential

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
@@ -14,9 +14,9 @@ object RiftBuildInfoSpec extends ZIOSpecDefault:
   def spec = suite("RiftBuildInfo")(
     test("DefaultImage is derived from the single rift-version source of truth") {
       assertTrue(
-        RiftBuildInfo.riftVersion == "0.11.2",
+        RiftBuildInfo.riftVersion == "0.11.3",
         Rift.DefaultImage == s"zainalpour/rift-proxy:v${RiftBuildInfo.riftVersion}",
-        Rift.DefaultImage == "zainalpour/rift-proxy:v0.11.2"
+        Rift.DefaultImage == "zainalpour/rift-proxy:v0.11.3"
       )
     }
   )


### PR DESCRIPTION
Adds a caller-provided persistent CA to the embedded intercept proxy. Bumps
`riftVersion` 0.11.2 → 0.11.3 (rift#430 added `caCertPath`/`caKeyPath` to
`rift_start_intercept`), and adds `InterceptConfig.caCert`/`caKey: Option[Path]`
(both-or-neither, validated with `MockError.InvalidDefinition`): when set, the
proxy loads that committed CA instead of minting an ephemeral one — so a
long-lived containerized SUT can trust a pre-committed truststore at JVM startup,
before the test starts the proxy. Absent → ephemeral CA, exactly as before.

Tests (verified on JDK 21): always-on `startOptions`/`validateCaPair` unit test;
a gated reuse e2e (two engine instances, one committed CA → mutually-trusted
leaves, with an ephemeral negative control that asserts a TLS-trust failure); and
a misconfig test (lone `caCert` → `InvalidDefinition`; nonexistent CA files →
loud `MockError`). `RiftBuildInfoSpec` updated to 0.11.3.

Closes #273