### PR TITLE
build: create the GitHub Release object on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,3 +61,28 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+
+  # GitHub Release object (the "Releases" page): `ci-release` only publishes to Maven Central, so without
+  # this step a pushed tag never appears under Releases (only under Tags). Runs after both Sonatype bundles
+  # succeed, so a failed publish never yields a Release. A pre-release tag (contains a hyphen, e.g. v1.0.0-RC1)
+  # is flagged --prerelease (never marked Latest); a plain vX.Y.Z is marked --latest. Notes are auto-generated
+  # from the merged PRs since the previous release.
+  github-release:
+    needs: [publish, publish-preview]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Create the GitHub Release for this tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          flags="--verify-tag --generate-notes"
+          case "${GITHUB_REF_NAME}" in
+            *-*) flags="$flags --prerelease" ;;
+            *) flags="$flags --latest" ;;
+          esac
+          gh release create "${GITHUB_REF_NAME}" $flags


### PR DESCRIPTION
`release.yml` runs only `sbt ci-release` (Maven Central publish) — it never created the **GitHub Release** object, so a pushed `vX.Y.Z` tag showed up under **Tags** but not the **Releases** page (that was always a manual `gh release create`). This bit v1.4.0 and v1.4.1 (published to Maven, missing from Releases until created by hand).

Adds a `github-release` job that runs **after** both Sonatype bundles (`publish` + `publish-preview`) succeed — so a failed publish never yields a Release — and creates the Release for the pushed tag with auto-generated notes:
- plain `vX.Y.Z` → `--latest`
- hyphenated pre-release tag (e.g. `v1.0.0-RC1`) → `--prerelease` (never marked Latest)

Uses the built-in `GITHUB_TOKEN` with job-scoped `contents: write`. No change to what `ci-release` publishes.