### PR TITLE
docs: close the accumulated documentation gaps (hooks, aspects, mock, state, reporters, running, flags, property, performance)

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -183,7 +183,42 @@ Within each tier, hooks registered earlier run before hooks registered later.
   The state still contains whatever the last step left behind.
 - `beforeStep` / `afterStep` fire around **each individual step**, including Background steps
   that are prepended to a scenario.
-- `afterAll` always runs, even if features fail.
+- `afterAll` runs after all features have completed, provided nothing upstream died. Unlike
+  `afterScenario`/`afterFeature`, the `beforeAll → features → afterAll` sequence is a plain
+  for-comprehension with no `.ensuring` guard — a defect in `beforeAll` or an unrecovered
+  feature-level defect skips `afterAll`.
+
+---
+
+## `afterStep` execution guarantees
+
+`afterStep` always runs after the step body, whether the step passed or failed:
+
+- If the step body **passed** and `afterStep` **fails**, the step is flipped to **failed** —
+  `afterStep` can turn a passing step into a failing one.
+- If the step body **failed**, the step keeps its **original failure cause** even if
+  `afterStep` also fails; `afterStep`'s outcome does not overwrite an existing failure.
+- If `beforeStep` fails, neither the step body nor `afterStep` runs — the step is recorded as
+  failed from the `beforeStep` cause alone.
+
+## Hook error propagation
+
+Every hook type is a `URIO` (see [`Hooks.scala`](../core/src/main/scala/zio/bdd/core/Hooks.scala))
+— hooks have no typed error channel, so a failure only reaches the test run as a **defect**.
+How that defect is handled differs by hook:
+
+| Hook | On failure | Guarded by `.ensuring`? |
+|------|------------|--------------------------|
+| `beforeScenario` | Recorded as the scenario's `setupError`; steps are skipped | No |
+| `afterScenario` | Fails the scenario (even if all steps passed) | Yes — always runs |
+| `beforeFeature` | Propagates as a defect, skipping the feature's scenarios | No |
+| `afterFeature` | Propagates as a defect after teardown | Yes — always runs |
+| `beforeAll` | Propagates as a defect, skipping all features and `afterAll` | No |
+| `afterAll` | Propagates as a defect | No |
+
+A genuine interruption (fiber cancellation / shutdown), as opposed to a hook failure, is never
+treated as a retryable error — an interrupt-only `Cause` always propagates rather than being
+recorded as a setup/step failure (see #231).
 
 ---
 
@@ -281,3 +316,11 @@ afterScenario { _ => cleanupResource() }
 // Good — log the cleanup failure without propagating
 afterScenario { _ => cleanupResource().catchAll(e => ZIO.logWarning(s"cleanup failed: $e")) }
 ```
+
+### Don't call `pending()` inside a hook
+
+`pending()` returns `ZIO[Any, Throwable, Unit]` and is meant for step bodies only — it fails
+with a `PendingException` that the step executor specifically recognizes and renders as
+"pending" rather than "failed". Hooks are `URIO[R, Unit]` (no error channel), so they cannot
+run a `Task`-typed effect like `pending()` at all; the call won't type-check inside a
+`beforeScenario`/`afterStep`/etc. body.

--- a/docs/mock-advanced.md
+++ b/docs/mock-advanced.md
@@ -297,6 +297,16 @@ need full-fidelity access to a backend's raw feature set (e.g. a Mountebank
 imposter field or a WireMock stub-mapping option the canonical model doesn't
 expose), not for anything you expect to run against a second adapter.
 
+A malformed `NativeSpec` fails fast at provision-time — invalid JSON syntax is
+rejected locally with `MockError.InvalidDefinition`, and a syntactically valid
+document the backend itself refuses surfaces as `MockError.CommunicationError`
+— but a document that's valid and accepted yet semantically wrong isn't caught
+there at all: matching against it is delegated entirely to the backend's own
+matcher, so the defect only shows up later as an unexpected match result, not
+a typed error. Contrast the portable model's `MatchClause`, which is opaque
+and never user-constructible outside the DSL builders (`header(..)`,
+`bodyEquals(..)`, …), so a malformed match can't be built in the first place.
+
 From `Native17Suite` — each scenario is tagged for its backend and the
 harness runs the matching one:
 
@@ -490,6 +500,11 @@ import zio.bdd.mock.rift.embedded.EmbeddedRift.InterceptConfig
 val mock = Provisioning.live >>> EmbeddedRift.layer(InterceptConfig(bindHost = "0.0.0.0", port = Some(8888)))
 ```
 
+`bindHost` must be an IP literal — `0.0.0.0`, a specific NIC address, and the
+like; a hostname such as `localhost` is rejected with
+`MockError.InvalidDefinition` the first time the intercept listener starts
+(#262).
+
 `proxyEndpoint` reports the **actually-bound** host and port (not just the
 loopback port), so you can log or inject them. Export the truststore **straight
 to a bind-mounted path** the container reads via `to` (default is a temp file),
@@ -558,3 +573,51 @@ SUT proxies through the **host-mapped** port (`ic.proxyPort` reports it, already
 translated), so it works the same whether the SUT is a host process or another
 container reaching the published port. See `RiftInterceptSpec` (RIFT_IT-gated)
 for the runnable end-to-end version against a real container.
+
+---
+
+## 10. Scoped overlays — `MockOverlay`
+
+`MockOverlay` (#116) layers revertible rule mutation on top of the core
+`MockControl` port. `scoped` installs each rule at `Priority.Overlay` (highest
+priority, shadowing the base rules) on acquire and removes it on release, so
+rules applied inside a `ZIO.scoped` block — in a hook, or a `When` step —
+auto-revert exactly when the scope closes. Each rule registers its own
+finalizer, so a failure partway through still tears down only the rules that
+were actually added; a teardown failure is logged and skipped so one bad
+removal can't strand its siblings. `remove` and `replaceAll` are the
+non-scoped counterparts — targeted and wholesale mutation for steps that
+permanently change a live space (e.g. "now everything times out").
+
+```scala
+import zio.bdd.mock.MockOverlay
+
+ZIO.scoped {
+  for
+    _ <- MockOverlay.scoped(space)(MockRule(get("/flaky"), ResponseDef(status = 503)))
+    _ <- runScenarioAgainstFlakyEndpoint(space) // sees the 503 overlay
+  yield ()
+} // scope closes here — the overlay rule is removed, base rules resume
+```
+
+`MockOverlay.remove(space, id)` deletes a single rule by its `RuleId`;
+`MockOverlay.replaceAll(space, rules*)` swaps every rule in `space` at once.
+
+---
+
+## 11. Mock test aspects — `MockAspects`
+
+`MockAspects` wraps `MockOverlay.scoped` as `TestAspect`s that override a
+`MockSpace`'s behavior for one test and auto-revert afterward — mirroring
+zio-openfeature's `TestFeatureProvider` delay/error aspects. `withLatency(d)`
+adds delay `d` to every response in the space for the duration of the test;
+`withImposter(rules*)` overlays an arbitrary set of rules as a scoped
+imposter. Both require `MockControl & MockSpace` in the test environment.
+
+```scala
+import zio.bdd.mock.MockAspects.*
+
+test("times out under latency") {
+  ...
+} @@ withLatency(2.seconds)
+```

--- a/docs/mock-dsl.md
+++ b/docs/mock-dsl.md
@@ -7,6 +7,10 @@ the same rule written by hand. Use it when you want type-checked, refactorable
 stubs in Scala; use raw JSON sources when you're porting an existing
 Mountebank/WireMock fixture (see §6).
 
+Covers request matching, response, rule-id, and scenario builders. The
+`intercept(host)` builder (`Capability.Intercept` rules) is documented
+alongside that capability — see [Advanced](mock-advanced.md) §9.
+
 ---
 
 ## 1. Import + shape
@@ -71,6 +75,12 @@ post(path).where(jsonPath(jp).equalTo(v)).respondWith(ok.text(body))
 
 (Verbatim from `Value03Suite` / `Body04Suite` in the samples.)
 
+`header`/`query` return a `ValueClause` and `jsonPath` returns a
+`JsonPathClause` — both `private[dsl]`, so you always go through these
+builders rather than constructing a clause directly. Every clause builder
+(including the body matchers) ultimately produces a `MatchClause`, an
+`opaque type` over `RequestMatch => RequestMatch`.
+
 To match on something other than an exact path, replace the path matcher with
 `.withPath(...)`:
 
@@ -101,6 +111,26 @@ overwrites whatever path matcher the entry point set.
 `header`/`query` clauses stack per-name in `.where(...)` — only body clauses
 are mutually exclusive (each rule has at most one `BodyMatch`; the last one in
 `.where(...)` wins).
+
+> **Headers reference.** `Headers` (`zio.bdd.mock.Headers`) is an opaque
+> `Map[String, List[String]]` — keys are lower-cased **on construction**, so
+> `header("X-Trace").equalTo(v)` and a recorded `X-Trace`/`x-trace` header
+> match regardless of case.
+>
+> Construct one with `Headers.empty`, `Headers(pairs*)` (one value per key),
+> `Headers.multi(entries*)` (several values per key), or
+> `Headers.fromSingle(map)` (lift a single-valued map). There is no
+> `Headers.of`.
+>
+> Query it with `values(key)`, `first(key)` (the head in insertion order),
+> `contains(key)`, `keys`, `isEmpty`, `nonEmpty`, `toMultiMap`, and `entries`.
+> There is no `get`/`getFirst`/`getAll`.
+>
+> ```scala
+> val h = Headers.multi("Set-Cookie" -> List("a=1", "b=2"))
+> h.values("set-cookie") // List("a=1", "b=2")
+> h.first("Set-Cookie")  // Some("a=1")
+> ```
 
 ---
 

--- a/docs/mocking.md
+++ b/docs/mocking.md
@@ -234,4 +234,58 @@ or a direct `.scripting` call, since it lacks Scripting/ProxyRecord/Templating.
 
 ---
 
+## 7. Calling the mock: `SutClient`
+
+`SutClient` is the built-in HTTP client for driving a provisioned `MockSpace`
+from a step — it plays the role of "the SUT" in a scenario that doesn't wire
+up a real system under test. It's bound to one `MockSpace`: it derives its
+target from `space.baseUri` and applies `space.inject` to every request, so
+the isolation decoration (e.g. a `Correlated` backend's correlation header,
+§3) rides along automatically — steps never need to branch on isolation mode.
+
+Construct it either way:
+
+- **`SutClient.make(space)`** — a plain value, handy inline in a step.
+- **`SutClient.layer(space)`** — the same client as a `ULayer[SutClient]`, for
+  wiring into a suite's environment.
+
+```scala
+trait SutClient:
+  def baseUrl: String
+
+  def send(
+    method: Method,
+    path: String,
+    headers: Headers = Headers.empty,
+    body: Option[String] = None
+  ): IO[Throwable, SutResponse]
+```
+
+`send` resolves `path` against `baseUrl` and sends the (injected) request;
+the result is a `SutResponse`:
+
+```scala
+final case class SutResponse(status: Int, body: String, headers: Headers)
+```
+
+A step calling it against a space obtained elsewhere (e.g. from `MockFixture`,
+§1), adapted from the sample corpus:
+
+```scala
+When("the client sends " / string / " " / string) { (m: String, path: String) =>
+  for
+    method <- ZIO
+                .fromOption(Method.values.find(_.toString.equalsIgnoreCase(m)))
+                .orElseFail(new IllegalArgumentException(s"bad method $m"))
+    resp  <- SutClient.make(space).send(method, path)
+    _     <- Stage.put(resp)
+  yield ()
+}
+```
+
+The full worked example — including how `space` is obtained from a tagged
+fixture — is in [the Gherkin guide](mock-gherkin.md).
+
+---
+
 Next: [the DSL](mock-dsl.md) · [Adapters](mock-adapters.md)

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,197 @@
+# Performance
+
+Guidance for tuning parallelism, understanding memory growth over a run, and reasoning
+about the runtime cost of zio-bdd's state mechanisms. There are no published
+benchmark numbers here — the framework's performance depends entirely on your step
+bodies, backends, and CI hardware. What follows is the *mechanism* behind each cost
+so you can reason about your own suite, plus heuristics to start from and measure.
+
+---
+
+## 1. Parallelism tuning
+
+The full mechanism — `--parallelism` / `--scenario-parallelism`, the `@Suite`
+annotation fields, the `ZIO_BDD_SCENARIO_PARALLELISM` / `ZIO_BDD_FEATURE_PARALLELISM`
+env vars, the `scenarioParallelism` / `featureParallelism` suite overrides, and their
+precedence order — is documented in
+[Running Tests → Parallelism](running.md#parallelism) and
+[Runtime overrides and precedence](running.md#runtime-overrides-and-precedence). This
+section only adds workload-keyed guidance for *how high* to set those knobs. Treat
+every number below as a starting point to measure against your own suite, not a
+guarantee.
+
+### CPU-bound, pure scenarios
+
+Steps that only exercise in-process logic (parsing, validation, pure transformations,
+in-memory fakes) are typically bottlenecked on CPU. Scenario/feature parallelism above
+the number of available cores buys little — fibers end up time-slicing the same cores.
+A reasonable starting point is **up to `Runtime.getRuntime.availableProcessors()`**
+(which is also what `auto` / `0` resolves to for `scenarioParallelism`, per
+[running.md → Parallelism](running.md#parallelism)), then back off if you see
+diminishing returns or contention on a shared in-process resource (a single
+in-memory database, a shared mutable fake).
+
+### Container / mock-heavy suites (Rift)
+
+Suites that stand up a Rift container per scenario or per feature (see
+[Mock Adapters](mock-adapters.md)) are bottlenecked on Docker and network resources,
+not CPU: each `Rift.managed(...)` instance binds an admin port and one or more
+imposter ports (`adminPort`, `imposterBasePort` / `imposterPorts` in the adapter
+config). Running many of these concurrently multiplies container start time,
+Docker daemon load, and the chance of port collisions or flaky container startup.
+**Keep parallelism low — 1 to 2 — for suites where each scenario or feature
+provisions its own container**, and prefer a single shared long-lived Rift instance
+(via `globalLayer`, see [layers.md](layers.md)) over many short-lived ones when the
+scenarios don't need full isolation from each other. If scenarios only need
+correlated isolation within one running instance (`RiftMode.Correlated` or a
+`WireMock` per-request correlation header — see
+[Mock Adapters § The three backends at a glance](mock-adapters.md#1-the-three-backends-at-a-glance)
+and [Mock Advanced](mock-advanced.md)), you can raise parallelism further because
+you're no longer paying a container-startup cost per scenario.
+
+### I/O- or network-bound scenarios
+
+Steps that mostly wait on an external HTTP call, database round-trip, or other
+network I/O spend most of their wall-clock time blocked, not consuming a CPU core.
+For this shape, parallelism **can exceed the core count** — ZIO's fiber scheduler
+multiplexes many suspended fibers cheaply over a small thread pool, so the limiting
+factor becomes the downstream service's own concurrency budget (connection pool
+size, rate limits) rather than your JVM's core count. Push parallelism up
+incrementally and watch the downstream service, not your own CPU graph.
+
+### General approach
+
+There's no single right number — measure. Start from the heuristics above, run the
+suite, and look for either (a) wall-clock time not improving as you raise
+parallelism (you're past the useful ceiling — CPU or a shared resource is now the
+bottleneck), or (b) new flakiness/failures appearing as you raise it (you've hit a
+real concurrency limit — port exhaustion, a rate limit, a shared-state bug in the
+suite itself). See [running.md's precedence table](running.md#runtime-overrides-and-precedence)
+for wiring different values per environment (e.g. sequential locally, parallel in CI).
+
+---
+
+## 2. Memory
+
+### Captured logs grow with the whole run, not per scenario
+
+`LogCollector` (`core/src/main/scala/zio/bdd/core/LogCollector.scala`) is
+instantiated **once per suite run** — `ZIOBDDTask.execute` builds a single
+`LogCollector.live(...)` layer and `++`s it into the environment shared by every
+feature and scenario in that run (`core/src/main/scala/zio/bdd/ZIOBDDFramework.scala:168-169`).
+Internally it's backed by a single `ConcurrentHashMap[String, CollectedLogs]` keyed
+by `"scenarioId::stepId"` (`LogCollector.scala:58-91`), and entries are only ever
+*added* to that map via `merge` — nothing removes or clears entries for the
+duration of the run.
+
+The practical consequence: captured-log memory is proportional to **(total
+scenarios × total steps) for the entire suite run**, not to any single scenario or
+feature. A suite with a handful of scenarios barely notices this. A large suite run
+with `logLevel = "debug"` (or `--log-level debug`) set suite-wide captures every
+debug-level log line from every step, for the run's full lifetime — with no upper
+bound and no eviction, this is effectively unbounded growth while the run is in
+flight. If you see rising heap usage over a long-running debug suite, this map is
+the first place to look. There is currently no per-scenario eviction; the mitigation
+is to scope `debug` logging narrowly — a specific `@Suite(logLevel = ...)` on a
+small diagnostic suite, or `--log-level debug` on a filtered subset via
+`--scenario-name` / `--include-tags` — rather than leaving it on for a full,
+large-scale run. See [running.md's `@Suite` fields table](running.md#fields) and
+[CLI flags reference](running.md#cli-flags-reference) for how `logLevel` /
+`--log-level` are set.
+
+### Property-test failures persist to disk, not memory
+
+`PropertyFailureStore` (`core/src/main/scala/zio/bdd/core/property/PropertyFailureStore.scala:36`)
+writes one JSON file per failing `@property` scenario to `.zio-bdd/failures/<slug>.json`
+on disk — it is not an in-memory accumulation concern. These files are small (a
+seed, sample index, and the shrunk values/labels) and are read back on the next run
+to replay the failing case first. If your CI workspace is ephemeral, `.zio-bdd/failures/`
+won't persist between runs; if it's cached/reused, stale failure records for
+since-changed scenarios are self-invalidating (the store hashes the scenario's step
+list and discards the record with a warning if it no longer matches). See
+[Property-Based Testing](property-testing.md) for the full replay mechanism.
+
+---
+
+## 3. State mechanism cost
+
+zio-bdd offers three ways to carry data across step bodies within a scenario:
+`ScenarioContext` (the `S` type parameter, via `State[S]`), `Stage`, and `TypeMap`
+(see [State Management](state.md) for when to use which). All three are backed by
+a plain ZIO `FiberRef`, and all three have comparable get/update cost:
+
+- **`ScenarioContext` / `State[S]`** (`core/src/main/scala/zio/bdd/core/step/State.scala:6-23`):
+  `get` and `update` delegate directly to `FiberRef[S].get` / `.update`. No
+  serialization happens on this path.
+- **`Stage`** (`core/src/main/scala/zio/bdd/core/step/Stage.scala`): a
+  `FiberRef[Map[String, Any]]` keyed by runtime class name; `put`/`get`/`modify` are
+  plain immutable-`Map` operations on top of `FiberRef.update`/`.get`.
+- **`TypeMap`** (`core/src/main/scala/zio/bdd/core/step/TypeMap.scala`): a
+  `State[TypeMap]` (itself `FiberRef`-backed, same as `ScenarioContext`) holding an
+  immutable `Map[Any, Any]` keyed by `Tag`; `TypeMapOps.get`/`update` layer a
+  `Map` lookup/insert on top of the same `State.get`/`State.update`.
+
+None of the three touches `Schema` derivation or does any serialization on the
+per-step path — the cost of a `TypeMap`/`Stage` access is an immutable-map
+operation plus a `FiberRef` read/write, the same order of cost as a direct
+`ScenarioContext` access.
+
+### `Schema[S]` is a startup/seed cost, not a per-step cost
+
+`Schema[S]` is used to derive `Default[S]` (`core/src/main/scala/zio/bdd/core/Default.scala`),
+which supplies the initial value for a scenario's `S` state. Per
+`ScenarioExecutor.runAttempt` (`core/src/main/scala/zio/bdd/core/ScenarioExecutor.scala:81`),
+`Default[S].default` is read exactly once per scenario **attempt** — when the
+FiberRef backing that attempt's `ScenarioContext` is created — not once per step.
+(An `@retry`/`@flaky` scenario re-seeds it once per attempt, since every attempt
+gets fully independent state.) After that single seed, every `ScenarioContext.get`/
+`.update` call within the scenario is a plain `FiberRef` operation as described
+above — `Schema[S]` is never consulted again during step execution. There is no
+per-step schema-derivation or serialization cost; the only place `Schema[S]`'s
+default-value computation runs is that one-time seed at the start of each scenario
+attempt.
+
+---
+
+## 4. Startup & discovery
+
+A few principled considerations for suite startup time, without invented figures —
+measure your own suite if startup time matters to your feedback loop:
+
+- **`@Suite` discovery** is done by sbt's own test-framework machinery: zio-bdd
+  registers an `AnnotatedFingerprint` for `zio.bdd.core.Suite`
+  (`core/src/main/scala/zio/bdd/ZIOBDDFramework.scala:13-16`), and sbt's
+  incremental-compiler-backed test discovery locates annotated classes from its own
+  compiled-class analysis rather than zio-bdd performing a runtime reflection scan
+  of the classpath. This work is proportional to your project's own compiled-class
+  count via sbt/zinc, not something zio-bdd adds independently.
+- **`.feature` file scanning** for a filesystem `featureDirs` entry is a flat
+  `File.listFiles()` over each configured directory
+  (`core/src/main/scala/zio/bdd/ZIOBDDFramework.scala:105-114`) — proportional to
+  the number of files in that directory, done once at suite startup before any
+  scenario runs.
+- **`classpath:` feature directories** resolve via `ClassLoader.getResources(...)`
+  followed by treating each resolved URL as a `java.io.File` and listing it
+  (`ZIOBDDFramework.scala:98-103`). This assumes the classpath entry is an
+  unpacked directory (a normal `test:resources`/`test:managedResources` layout, or
+  an exploded classpath as sbt typically presents it). **If your `.feature` files
+  are packaged inside a fat/uber jar** rather than left as loose classpath
+  directories, a `classpath:` resource URL points *into* the jar
+  (`jar:file:...!/features`), and turning that into a `File` for `listFiles()` is
+  not guaranteed to enumerate the packed entries the way it does for a real
+  directory. If you rely on `classpath:` feature loading from a packaged
+  test-jar, verify feature discovery still finds all files in that packaging
+  — or keep feature resources unpacked on the classpath (the common sbt
+  multi-module case documented in [running.md's `@Suite` fields table](running.md#fields))
+  rather than shaded into a single fat jar.
+
+---
+
+## See also
+
+- [Running Tests → Parallelism](running.md#parallelism) — the full parallelism
+  mechanism: CLI flags, `@Suite` fields, env vars, suite overrides, and precedence.
+- [Reporters](reporters.md) — pretty/JUnit XML output, including how captured logs
+  and log levels surface per step.
+- [Troubleshooting](troubleshooting.md) — startup failures, state-not-updating
+  issues, and other runtime problems with root cause and fix.

--- a/docs/property-testing.md
+++ b/docs/property-testing.md
@@ -114,13 +114,18 @@ for detection, so either location works.
 |---|---|---|
 | `samples` | `100` | Number of generated samples to run |
 | `seed` | random | Fixed `Long` seed for reproducible runs. Always logged so any failure carries a reproducer. |
-| `shrink` | `true` | Walk the ZIO Test shrink tree on failure to find a minimal counterexample |
-| `maxShrinks` | `1000` | Cap on shrink-tree steps |
+| `shrink` | `true` | Walk the ZIO Test shrink tree on failure to find a minimal counterexample. **Parsed, not yet functional (v1)** — see [What is NOT yet supported](#what-is-not-yet-supported) |
+| `maxShrinks` | `1000` | Cap on shrink-tree steps. **Parsed, not yet functional (v1)** — see [What is NOT yet supported](#what-is-not-yet-supported) |
 | `maxDiscarded` | `samples × 5` | Reserved for a future `Assume` step; not yet active |
-| `verbose` | `false` | Print full shrink path in failure output |
+| `verbose` | `false` | Print full shrink path in failure output. **Parsed, not yet functional (v1)** — see [What is NOT yet supported](#what-is-not-yet-supported) |
 | `replay` | `true` | Consult and update the failure replay file (see [Failure replay](#failure-replay)) |
 
 A bare `@property` with no arguments is valid and equivalent to `@property(samples=100)`.
+
+`shrink`, `maxShrinks`, and `verbose` are all accepted by the tag parser and stored on
+`PropertyConfig`, but v1's executor never reads them — full shrink-tree walking is deferred
+to v2 (v1 always records the failing seed instead; see [Failure replay](#failure-replay)).
+Setting them today has no effect on behavior.
 
 ---
 
@@ -441,6 +446,18 @@ override def flagLayer(meta: ScenarioMetadata, flags: Map[String, String]) =
 
 If you don't override `flagLayer`, it defaults to `scenarioLayer(meta)` — flags are visible in
 `meta.flagValues` but not injected into the environment, same as for literal scenarios.
+
+---
+
+## Combining with `@retry` / `@flaky` / `@nonFlaky`
+
+These scenario aspects apply **per generated sample**, not once for the whole property run.
+Each sample is executed as its own scenario run that carries the original `scenario.tags`
+forward unchanged, so a `@retry(n)` (or `@flaky(n)`/`@nonFlaky(n)`) tag alongside `@property(...)`
+re-runs *every individual sample* up to `n` times until it passes (or fails, for `@nonFlaky`) —
+multiplying the worst-case number of scenario executions by `n` (e.g. `@retry(3)` with
+`samples=500` is up to 1500 runs, not 500). Keep this in mind before combining a large `samples`
+count with a retry aspect.
 
 ---
 

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -30,6 +30,17 @@ sbt "testOnly -- --reporter pretty --reporter junitxml"
 
 ## Built-in reporters
 
+Both built-in reporters implement the batch `Reporter` trait:
+
+```scala
+trait Reporter:
+  def report(results: List[FeatureResult]): ZIO[LogCollector, Throwable, Unit]
+```
+
+`report` receives the full `List[FeatureResult]` after the run completes and requires a
+`LogCollector` in its environment (used to fetch step/scenario logs while rendering — see
+"LogCollector" below).
+
 ### pretty
 
 `PrettyReporter` writes a Unicode tree to the console using ANSI colors. It is the default
@@ -37,20 +48,38 @@ reporter when `reporters` is not specified.
 
 **Color palette:**
 
+Colors are theme-aware (`Theme.Dark` / `Theme.Light` / `Theme.Plain`, auto-detected from
+`NO_COLOR`/`TERM`/`COLORFGBG` — see `PrettyReporter.scala`). `Plain` emits no ANSI codes.
+Icon and status come from the `StatusColor[A]` given instances; dark-theme codes are shown
+below.
+
 | Element | Color | Icon |
 |---|---|---|
-| Feature — passed | Green (`\e[92m`) | `◉` |
+| Feature — passed | Green (`\e[38;5;35m`) | `◉` |
 | Feature — ignored | Gray (`\e[90m`) | `◉` |
 | Feature — failed | Red (`\e[91m`) | `◉` |
-| Scenario — passed | Yellow (`\e[93m`) | `◑` |
+| Scenario — passed | Blue (`\e[38;5;75m`) | `✓` |
 | Scenario — ignored | Gray (`\e[90m`) | `◑` |
 | Scenario — pending | Orange (`\e[38;5;214m`) | `◑` |
-| Scenario — failed | Red (`\e[91m`) | `◑` |
-| Step — passed | Blue (`\e[94m`) | `•` |
-| Step — skipped | Gray (`\e[90m`) | `•` |
-| Step — pending | Orange (`\e[38;5;214m`) | `•` |
-| Step — failed | Red (`\e[91m`) | `•` |
+| Scenario — failed | Red (`\e[91m`) | `✗` |
+| Scenario — XFAIL (expected failure) | Gray (`\e[90m`) | `✓` |
+| Scenario — unexpectedly passing (XPASS) | Red (`\e[91m`) | `✗` |
+| Step — passed | Mint (`\e[38;5;121m`) | `•` |
+| Step — skipped | Gray (`\e[90m`) | `○` |
+| Step — pending | Orange (`\e[38;5;214m`) | `◌` |
+| Step — failed | Red (`\e[91m`) | `✗` |
+| Step — timed out | Red (`\e[91m`) | `⏱` |
 | Summary / headings | Cyan (`\e[96m`) | — |
+
+**Internal log level palette** (used when rendering `LogCollector` entries under a step):
+
+| Level | Color | Icon |
+|---|---|---|
+| Debug | Steel gray (`\e[38;5;242m`) | — |
+| Info | Dusty teal (`\e[38;2;100;180;160m`) | — |
+| Warning | Muted gold (`\e[38;2;200;170;80m`) | `⚠` |
+| Error | Muted rose (`\e[38;2;210;100;100m`) | `✖` |
+| Fatal | Bright red (`\e[91m`) | `✖` |
 
 **Sample output:**
 
@@ -181,11 +210,85 @@ is measured in milliseconds by the scenario executor and converted to seconds fo
 
 ---
 
+## LogCollector
+
+`LogCollector` captures log output (`ZIO.log*` calls made from step bodies, tagged with
+`scenarioId`/`stepId` annotations) during a run so reporters can attach it to the relevant
+step or scenario when rendering.
+
+```scala
+trait LogCollector:
+  def log(scenarioId: String, stepId: String, message: String, level: InternalLogLevel): ZIO[Any, Nothing, Unit]
+  def getLogs(scenarioId: String, stepId: String): ZIO[Any, Nothing, CollectedLogs]
+  def getScenarioLogs(scenarioId: String): ZIO[Any, Nothing, CollectedLogs]
+```
+
+Supporting types:
+
+```scala
+enum InternalLogLevel:
+  case Debug, Info, Warning, Error, Fatal
+
+enum LogSource:
+  case Stdout
+  case Stderr
+
+case class LogEntry(
+  message:   String,
+  timestamp: Instant,
+  source:    LogSource,
+  level:     InternalLogLevel,
+  stepId:    String
+)
+
+case class CollectedLogs(entries: List[LogEntry] = Nil):
+  def add(entry: LogEntry): CollectedLogs
+  def toStepResultLogs: List[(String, Instant, InternalLogLevel)]
+
+case class LogLevelConfig(minLevel: InternalLogLevel = InternalLogLevel.Info)
+```
+
+Entries below `minLevel` are dropped at capture time and never stored.
+
+**Entry point:**
+
+```scala
+val layer: ZLayer[Any, Nothing, LogCollector] = LogCollector.live(LogLevelConfig(InternalLogLevel.Debug))
+```
+
+`LogCollector.live` installs a custom `ZLogger` (replacing, not augmenting, the runtime default)
+so `ZIO.log*` calls inside step bodies are captured only by the collector, not also echoed to
+stdout.
+
+**Real consumers:**
+
+- `PrettyReporter` calls `lc.getLogs(scenarioId, stepId)` per step (`PrettyReporter.scala:525`)
+  to render log lines as children of the step's `Doc` branch.
+- `JUnitXMLReporter` calls `logCollector.getScenarioLogs(scenarioId)` per scenario
+  (`JUnitXMLReporter.scala:65`) to embed logs in the generated XML.
+
+**Configuring the minimum level (`@Suite(logLevel)` / `--log-level`):**
+
+Only three strings are recognized (case-insensitive): `"debug"`, `"info"`, `"error"`.
+`"warning"` and `"fatal"` are **not** parseable as a minimum level — passing either falls back
+to `Info`. On the CLI (`--log-level warning`) the fallback is logged as a warning
+(`Unknown log level '...', defaulting to Info`); on the `@Suite(logLevel = "...")` annotation
+path the fallback is silent. See `ZIOBDDFramework.scala:322-343`.
+
+---
+
 ## TestEvent streaming
 
 `StreamingReporter` is a lower-level interface that receives a live `ZStream` of `TestEvent`
 values rather than a batch of results at the end of the run. This enables real-time output,
 incremental file writing, and CI service integrations.
+
+> **Not wired up today.** This is a standalone API you exercise by hand — build a
+> `ZStream[Any, Nothing, TestEvent]` yourself and call `consume` on it. No `@Suite` reporter
+> name or `--reporter` CLI flag selects a `StreamingReporter`; the production pipeline
+> (`ZIOBDDFramework.scala`) only ever builds a `List[Reporter]` (batch). The "fan-out via
+> `ZHub`" idea mentioned on `StreamingReporter` is aspirational — there is no `Hub`/`ZHub`
+> usage anywhere in `core/src/main` today.
 
 ### TestEvent sealed trait
 
@@ -262,8 +365,9 @@ Key points:
 ### BatchReporterAdapter
 
 `BatchReporterAdapter` wraps a batch `Reporter` (one that receives all results at once) as a
-`StreamingReporter`. It accumulates events and calls `reporter.report` when `SuiteFinished`
-arrives:
+`StreamingReporter`. It does **not** accumulate events — it drains the stream with
+`events.runForeach`, ignores every event except `SuiteFinished`, and forwards that event's own
+`results` payload straight to `reporter.report`:
 
 ```scala
 val adapter: StreamingReporter = BatchReporterAdapter(myBatchReporter)
@@ -282,11 +386,16 @@ Running 3 feature(s)...
   ✓ User registration / Valid registration [88ms]
   ○ Shopping cart / Guest checkout [12ms]
   ✗ Payment / Insufficient funds [34ms]
+  ⊗ Legacy API / Deprecated endpoint (expected failure) [9ms]
+  ✗ Legacy API / Fixed endpoint (unexpectedly passed — remove @expectedFailure) (3 attempts) [11ms]
 
 Done. 1/3 passed, 1 failed, 1 ignored
 ```
 
-Icons: `✓` passed, `○` ignored, `✗` failed.
+Icons: `✓` passed, `○` ignored, `✗` failed, `⊗` XFAIL (expected failure). An unexpectedly-passing
+scenario (XPASS) also renders `✗`, with the note
+`(unexpectedly passed — remove @expectedFailure)`. When a scenario ran more than once (retry),
+an `(N attempts)` suffix is appended after the note.
 
 `LiveProgressReporter` is an `object` — reference it directly:
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -17,6 +17,7 @@ public @interface Suite {
     String[] featureDirs()  default {"src/test/resources/features"};
     String[] reporters()    default {"pretty"};
     int      parallelism()  default 1;
+    int      scenarioParallelism() default 0;
     String[] includeTags()  default {};
     String[] excludeTags()  default {};
     String   logLevel()     default "info";
@@ -29,8 +30,9 @@ public @interface Suite {
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `featureDirs` | `String[]` | `{"src/test/resources/features"}` | One or more paths to directories or individual `.feature` files. Filesystem paths are resolved relative to the project root. Prefix with `classpath:` to load from the classpath (e.g. from a shared test-jar): `"classpath:features"` or `"classpath:features/my.feature"`. |
-| `reporters` | `String[]` | `{"pretty"}` | Reporter names to use. Built-in values: `"pretty"` (coloured console output), `"junitxml"` (JUnit 5 XML in `target/test-results/`). |
+| `reporters` | `String[]` | `{"pretty"}` | Reporter names to use. Built-in values: `"pretty"` (coloured console output), `"junitxml"` (JUnit 5 XML in `target/test-reports/`). |
 | `parallelism` | `int` | `1` | Maximum number of features executed concurrently. `1` means sequential. |
+| `scenarioParallelism` | `int` | `0` | Maximum number of scenarios executed concurrently within a single feature. `0` means auto (use available processors); `1` forces sequential. See [Parallelism](#parallelism) below. |
 | `includeTags` | `String[]` | `{}` | When non-empty, only scenarios that carry at least one of these tags are executed. |
 | `excludeTags` | `String[]` | `{}` | Scenarios carrying any of these tags are skipped. |
 | `logLevel` | `String` | `"info"` | Minimum log level captured during step execution: `"debug"`, `"info"`, `"error"`. |
@@ -139,6 +141,7 @@ sbt "testOnly com.example.MySuite -- \
 | `--parallelism` | `<n>` | Maximum number of features executed concurrently. Overrides `parallelism` from the annotation. | `--parallelism 4` |
 | `--scenario-parallelism` | `<n>` | Maximum number of scenarios executed concurrently within a single feature. Independent from feature-level parallelism. Default: `1`. | `--scenario-parallelism 2` |
 | `--dry-run` | _(none)_ | Enable dry-run mode (see below). | `--dry-run` |
+| `--focused` | _(none)_ | Strips scenarios excluded by a name or tag filter from the report entirely, instead of listing them as `IGNORED`. Execution is unaffected — only report output changes. Intended for IDE test runners driving a single scenario/feature. | `--focused` |
 | `--log-level` | `debug\|info\|error` | Minimum log level captured during step execution. Overrides `logLevel` from the annotation. | `--log-level debug` |
 | `--reporter` | `pretty\|junitxml` | Reporter to use. May be repeated. Overrides `reporters` from the annotation when specified. | `--reporter junitxml` |
 
@@ -221,7 +224,9 @@ treated as ignored and produces no step results.
 ## Scenario name filter
 
 The `--scenario-name` flag accepts a glob pattern matched case-insensitively against
-scenario names. `*` matches zero or more characters.
+scenario names. `*` matches zero or more characters. It is the only special character —
+`?` and character classes like `[abc]` are **not** wildcards and are matched literally
+against the scenario name.
 
 ```sh
 # Run all scenarios whose name starts with "Provision"
@@ -393,7 +398,23 @@ When("a very slow operation completes") {
 ## Scenario retry tags
 
 For environmentally flaky acceptance tests, a scenario can be re-run automatically. Tag it in
-Gherkin with an integer argument, or configure it in code via `scenarioAspects`.
+Gherkin with an integer argument, or configure it in code via `scenarioAspects`. Both paths
+resolve to the same `zio.bdd.core.ScenarioAspect` enum:
+
+```scala
+enum ScenarioAspect:
+  case Retry(n: Int)
+  case Flaky(n: Int)
+  case NonFlaky(n: Int)
+  case ExpectedFailure
+```
+
+Gherkin tags are parsed into this enum by `ScenarioAspect.fromTag` (a single tag, with or
+without a leading `@`) and `ScenarioAspect.fromTags` (the first match found among a
+scenario's tags, used by the executor). In both, the `n` argument is clamped with
+`n.max(1)`, so `@retry(0)` behaves like `@retry(1)`. A tag that doesn't match the expected
+shape (unknown name, non-integer argument) is simply not recognised by `fromTag` and falls
+through — the scenario runs once, as if untagged.
 
 | Tag | Semantics |
 |---|---|
@@ -415,6 +436,10 @@ Or, without touching the feature file, override `scenarioAspects` (keyed by scen
 override def scenarioAspects: Map[String, ScenarioAspect] =
   Map("provisions a fresh tenant" -> ScenarioAspect.Retry(3))
 ```
+
+The map key must match the scenario name **exactly** — there is no glob or regex support
+here, unlike `--scenario-name`. A key that doesn't match any scenario name verbatim is
+silently unused.
 
 **Semantics & interactions**
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -91,6 +91,16 @@ Then("the user should be greeted") {
 pure function and replaces the state.  There is no mutable cell exposed — all
 updates are via the ZIO `FiberRef` mechanism.
 
+### Under the hood
+
+`State[S]` is a minimal service (`get: UIO[S]`, `update: (S => S) => UIO[Unit]`).
+`ZIOSteps[R, S]` mixes in the `StateOps[S]` trait, which is what defines the
+`ScenarioContext` object shown above — it is not special-cased per suite, it is
+generated once from `S` by `StateOps`. The `State[S]` layer itself is built
+per-scenario-attempt from a fresh `FiberRef[S]` via `State.layer(fiberRef)`
+(see `ScenarioExecutor`), so `ScenarioContext.get`/`update` always resolve to
+that scenario's own `FiberRef`.
+
 ---
 
 ## 3. `StepIO[+A]` for value-producing helpers
@@ -258,6 +268,12 @@ given HasLens[AppState, ProvisionState] =
   )
 ```
 
+> **Dependency-free by design.** zio-bdd does not depend on Monocle at all —
+> `fromMonocleLike` only *adapts* an existing `monocle.Lens[S, A]` via plain
+> getter/setter functions, for callers whose own project already pulls in
+> `monocle-core`. `HasLens.apply` (above) is a complete, standalone
+> implementation; Monocle is never required to use `HasLens`.
+
 ### `ScenarioLens` ZIO effects
 
 With a `HasLens[S, A]` in implicit scope, the `ScenarioLens` object provides
@@ -419,8 +435,23 @@ When("the order is submitted") {
 | `Stage.getOption[A: ClassTag]` | `UIO[Option[A]]` | Return `Some(a)` if staged, `None` otherwise. |
 | `Stage.modify[A: ClassTag](f)` | `UIO[Unit]` | Apply `f` to the staged value if present; no-op otherwise. |
 | `Stage.remove[A: ClassTag]` | `UIO[Unit]` | Remove the staged value. |
+| `Stage.stepLabel` | `UIO[String]` | The Gherkin pattern of the currently executing step (e.g. `"When a provision request is sent"`); `""` outside a step body. |
 
-`StagingError` variants: `NotFound(typeName)`, `TypeMismatch(typeName, actualType)`.
+`StagingError` variants and their `.message` text:
+
+| Variant | `.message` |
+|---------|------------|
+| `NotFound(typeName)` | `No staged value of type $typeName. Call Stage.put before Stage.get.` |
+| `TypeMismatch(typeName, actualType)` | `Staged value for $typeName was actually $actualType.` |
+
+```scala
+Stage.get[Coupon].catchAll {
+  case StagingError.NotFound(typeName) =>
+    ZIO.fail(new RuntimeException(s"expected a staged $typeName"))
+  case StagingError.TypeMismatch(typeName, actualType) =>
+    ZIO.fail(new RuntimeException(s"staged $typeName was actually $actualType"))
+}
+```
 
 No environment type is required — all `Stage` methods run in `UIO` or `IO[StagingError, _]`
 and are available inside any step body without additional layer wiring.
@@ -462,7 +493,21 @@ When("a transaction is posted") {
 | `FeatureContext.modify[A: ClassTag](f)` | `UIO[Unit]` | Update in place if present. |
 | `FeatureContext.remove[A: ClassTag]` | `UIO[Unit]` | Remove the stored value. |
 
-`FeatureContextError` variants: `NotFound(typeName)`, `TypeMismatch(typeName, actualType)`.
+`FeatureContextError` variants and their `.message` text:
+
+| Variant | `.message` |
+|---------|------------|
+| `NotFound(typeName)` | `No feature-scoped value of type $typeName. Call FeatureContext.put before FeatureContext.get.` |
+| `TypeMismatch(typeName, actualType)` | `Feature-scoped value for $typeName was actually $actualType.` |
+
+```scala
+FeatureContext.get[AccountId].catchAll {
+  case FeatureContextError.NotFound(typeName) =>
+    ZIO.fail(new RuntimeException(s"expected a feature-scoped $typeName"))
+  case FeatureContextError.TypeMismatch(typeName, actualType) =>
+    ZIO.fail(new RuntimeException(s"feature-scoped $typeName was actually $actualType"))
+}
+```
 
 ### Lifetime summary
 
@@ -472,6 +517,50 @@ When("a transaction is posted") {
 | `FeatureContext` | Start of each feature | All scenarios in the same feature |
 | `ScenarioContext[S]` | Start of each scenario | Steps in the same scenario |
 | ZLayer (`R`) | Once per suite run | All steps in all features |
+
+### Implementation note: how clearing actually happens
+
+Both stores are cleared via `Ref.locallyScoped(Map.empty)`, not by an explicit
+"clear at the end" call:
+
+- `ScenarioExecutor` scopes `Stage.ref` (and `Stage.currentStepLabel`) with
+  `Stage.ref.locallyScoped(Map.empty)` at the start of each scenario *attempt*,
+  **before** `beforeScenarioHook` runs.
+- `FeatureExecutor` scopes `FeatureContext.ref` with
+  `FeatureContext.ref.locallyScoped(Map.empty)` at the start of each feature,
+  **before** `beforeFeatureHook` runs.
+
+`locallyScoped` sets the `FiberRef` to the empty map for the lifetime of the
+enclosing `ZIO.scoped` block and restores the previous value when that scope
+closes — this is what guarantees a retried scenario attempt, or the next
+scenario/feature, starts from a clean store even if the previous attempt was
+interrupted mid-step.
+
+The `private[bdd] def reset` method on both `Stage` and `FeatureContext` is
+**test-only** — it exists for unit-testing the stores in isolation and is
+never called by `ScenarioExecutor` or `FeatureExecutor`. Do not rely on it to
+understand production clearing behavior; the `locallyScoped` calls above are
+the actual production clearing path.
+
+### Concurrency warning: `FeatureContext` under `scenarioParallelism > 1`
+
+`FeatureContext.ref` is a plain `FiberRef[Map[String, Any]]`. When a suite runs
+with `scenarioParallelism > 1`, `FeatureExecutor` executes sibling scenarios of
+the same feature as **true parallel fibers** (`ZIO.foreachExec` with
+`ExecutionStrategy.ParallelN`), all forked from the same parent fiber that
+holds the feature's `FiberRef` value.
+
+`FiberRef` fork/join semantics are last-writer-wins on join, not merged: each
+forked scenario fiber gets its own copy of the `FiberRef` value at fork time,
+and whichever sibling's value is observed last silently overwrites the others'
+changes. Concretely, this means `FeatureContext.put`/`modify` calls from
+different scenario fibers in the same feature are **not synchronized** —
+accumulation patterns (e.g. a shared counter incremented by every scenario)
+will silently lose updates under parallel execution.
+
+If a feature needs cross-scenario accumulation under `scenarioParallelism > 1`,
+use a synchronized primitive obtained from a `ZLayer` (a `Ref`, `Ref.Synchronized`,
+or `Queue`/`Hub` provided via `R`) instead of `FeatureContext`.
 
 ---
 
@@ -594,3 +683,18 @@ When("the order is confirmed") {
 
 `withSnapshot(lens)(body)` is defined in `ZIOSteps` — it reads `lens(currentState)`
 once before `body` executes and passes the snapshot to `body`.
+
+```scala
+def withSnapshot[A](lens: S => A)(
+  body: A => ZIO[R & State[S] & Scope, Throwable, Unit]
+): ZIO[R & State[S] & Scope, Throwable, Unit]
+```
+
+Note the `Scope` requirement in both the `body` parameter and the return type.
+Inside an ordinary step body this is satisfied automatically — `ScenarioExecutor`
+already runs each scenario attempt inside a `ZIO.scoped` block — so no extra
+wiring is needed when `withSnapshot` is called from `Given`/`When`/`Then`.
+Calling `withSnapshot` from outside that scoped context (e.g. invoking a step
+helper directly from a unit test) requires providing `Scope` explicitly, such
+as by wrapping the call in `ZIO.scoped { ... }`; otherwise compilation will
+fail with an unsatisfied `Scope` requirement in the environment.

--- a/docs/testing-flags.md
+++ b/docs/testing-flags.md
@@ -138,6 +138,16 @@ val runOn  = results.find(_.scenario.name.contains("rateLimiting=true")).get
 val runOff = results.find(_.scenario.name.contains("rateLimiting=false")).get
 ```
 
+**Stable contract:** the suffix format — `[k=v, k2=v2]`, keys sorted alphabetically
+(`flags.toList.sortBy(_._1)` in `FeatureExecutor.expandFlagScenarios`) — is guaranteed
+stable across runs for a given flag map. Pattern-matching on names (as above) is safe to
+rely on.
+
+**No collision detection:** the framework does not check whether two distinct `@flags(...)`
+tags on the same scenario render to the same suffix (e.g. a duplicated tag, or two tags
+whose maps happen to be equal). If that happens, both runs produce an identically-named
+scenario in the report, and there is no way to distinguish them by name alone.
+
 ---
 
 ## flagLayer — injecting flags into the environment
@@ -219,6 +229,24 @@ Examples:
 The outline expansion happens at parse time (in `GherkinParser`). The flags expansion
 happens at execution time (in `FeatureExecutor.expandFlagScenarios`). Each parsed outline
 scenario is independently flags-expanded.
+
+---
+
+## Interactions with other tags
+
+`expandFlagScenarios` runs *before* scenario execution: it turns one `Scenario` into N
+independent `(Scenario, flags)` pairs, each carrying the original tag list unchanged
+(only `name` is rewritten with the `[k=v]` suffix). Execution-affecting tags
+(`@retry`/`@flaky`/`@nonFlaky`/`@expectedFailure`/`@ignore`) are resolved per expanded
+copy, not once for the whole scenario — so each flag combination is retried,
+inverted, or skipped independently of the others.
+
+| Tag | Applies to | Execution-count implication |
+|-----|------------|------------------------------|
+| `@retry(n)` / `@flaky(n)` | each expanded copy independently | Each of the N flag runs gets its own retry loop (up to n attempts, stops at first pass). Worst case: N × n total attempts. |
+| `@nonFlaky(n)` | each expanded copy independently | Each of the N flag runs gets its own fail-fast loop (up to n attempts, stops at first failure). Worst case: N × n total attempts. |
+| `@expectedFailure` | each expanded copy independently | Each of the N flag runs executes exactly once — retry aspects are ignored (`@expectedFailure` wins over `@retry`/`@flaky`/`@nonFlaky`) — and its outcome is inverted. |
+| `@ignore` | the scenario as a whole, but expansion still happens | `expandFlagScenarios` does not special-case `@ignore`; a scenario with N `@flags(...)` tags is still expanded into N named copies, each of which is then reported as ignored (no steps executed). The report shows N ignored entries, not one. |
 
 ---
 
@@ -437,6 +465,22 @@ object FlagsTag:
 | `"smoke"` | `None` — not a flags tag |
 | `"ignore"` | `None` — not a flags tag |
 | `""` | `None` |
+
+**`FlagsTag.parse` edge cases:**
+
+| Input | Result | Why |
+|-------|--------|-----|
+| `"flags(a=)"` | `Some(Map("a" -> ""))` | empty value is kept as `""`, not treated as missing/boolean |
+| `"flags( =v)"` | `Some(Map())` | blank key is dropped (falls through to `case _ => None` for that pair) |
+| `"flags(key=a=b)"` | `Some(Map("key" -> "a=b"))` | split on `=` with `limit = 2` — only the first `=` splits |
+| `"flags( a = b )"` | `Some(Map("a" -> "b"))` | key and value are trimmed of surrounding whitespace |
+| `"flags(a=\"x\")"` | `Some(Map("a" -> "\"x\""))` | quotes are **not** stripped — `.trim` only removes whitespace |
+| `"flags()"` | `None` | `tagPattern` requires 1+ chars inside the parens (`[^)]+`); empty parens don't match at all |
+
+> **Duplicate keys within one tag last-wins.** `"flags(a=1, a=2)"` parses to
+> `Some(Map("a" -> "2"))` — the trailing pair overwrites the earlier one because the
+> parsed pairs are folded into a `Map` via `.toMap`, which keeps the last occurrence of
+> a repeated key.
 
 **`FlagsTag.extractAll` examples:**
 


### PR DESCRIPTION
Closes #276.

Fills the validated documentation backlog from #276 — one commit per doc file (10 commits, one PR) to keep CI runs down. Every fact was re-verified against source before writing, and an accuracy pass spot-checked the whole diff against `core/`/`mock/`/`gherkin/`/`rift-embedded/` (down to line numbers and literal strings) — no defects.

### Corrections to docs that were actively WRONG
- `hooks.md` — `afterAll` is **not** `.ensuring`-guarded (was "always runs").
- `reporters.md` — `BatchReporterAdapter` does **not** accumulate events; colour/icon table regenerated from the current `Theme`/`StatusColor` model; JUnit XML dir already correct here.
- `running.md` — JUnit XML output dir `target/test-results/` → `target/test-reports/`.

### New documentation
- `mock-dsl.md` `Headers` reference; `mocking.md` `SutClient`; `mock-advanced.md` `MockOverlay`/`MockAspects` + intercept `bindHost` IP-literal rule.
- `state.md` error messages, `locallyScoped` clearing lifecycle, `withSnapshot` `Scope`, and the `FeatureContext` parallelism last-writer-wins caveat.
- `reporters.md` `Reporter` trait, a full `LogCollector` section, valid `logLevel` strings + silent-fallback, `LiveProgressReporter` aspect states, and a "`StreamingReporter` is unwired in production" caveat.
- `running.md` `ScenarioAspect` enum, `scenarioParallelism`, `--focused`, glob-literal note.
- `property-testing.md` `shrink`/`maxShrinks`/`verbose` marked inert; per-sample `@retry`.
- `testing-flags.md` `@flags` × retry-tag interactions, `FlagsTag.parse` edge cases, stable name-suffix contract.
- **New `performance.md`** — parallelism heuristics, whole-run log-memory characteristic, FiberRef state cost, startup/discovery.

Docs-only (no `.scala` touched → `scalafmtCheck`/tests/mima unaffected). The six **behavior questions** #276 surfaced (e.g. `afterAll` not guaranteed, the `FeatureContext` write race, the unwired `StreamingReporter`) are documented here as *current behavior*; whether to change any is left to separate source issues.