### PR TITLE
docs: release hygiene — version snippets, CHANGELOG 1.4.0/1.4.1, performance nav link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to zio-bdd are documented here.
 
 ## [Unreleased]
 
+## [1.4.1] — 2026-07-08
+
+### Added
+
+- **Caller-provided persistent CA for the embedded intercept proxy** — `EmbeddedRift.InterceptConfig`
+  now accepts `caCert` / `caKey` (PEM file paths, both-or-neither). When set, the built-in TLS-MITM
+  proxy loads that committed CA instead of minting a fresh ephemeral one each start, so a long-lived
+  containerized SUT can trust a pre-committed truststore at JVM startup — before the test starts the
+  proxy. Absent → ephemeral CA, unchanged. (#273)
+
+### Changed
+
+- Bumped Rift to **v0.11.3** — adds `caCertPath` / `caKeyPath` to the intercept FFI. (#273)
+
+## [1.4.0] — 2026-07-07
+
+### Added
+
+- **Built-in HTTPS intercept — a mitmproxy replacement.** The `MockControl.Intercept` capability + DSL:
+  a TLS-MITM forward proxy that redirects a hard-coded external host to a mock imposter space, with an
+  exported CA truststore for the SUT to trust. (#249)
+  - Embedded (no-Docker) intercept driven entirely over the `librift_ffi` FFI. (#246)
+  - Configurable intercept bind host + optional fixed port, reachable from another container/host. (#257)
+  - Intercept over the containerized Rift adapter (`Rift.managed`). (#253)
+  - Merged intercept truststore (intercept CA **+** the JVM default anchors). (#261)
+  - `bindHost` validated as an IP literal, with a clear error for a hostname. (#269)
+  - Optional caller-specified export path for the intercept truststore. (#270)
+  - `EmbeddedRift.requireAvailable` — fail loudly (vs SKIP) when no native resolves. (#272)
+- **New assertions & combinators** — `eventually` / `eventuallyAssert` (#221), `during` (#226),
+  collection quantifiers (#227), `assertChange` (#228), `assertSatisfies` (#239), `assertRaises` (#240),
+  `poll` (#241), `assertApproxEquals` (#243).
+- **Scenario control** — `@retry(n)` / `@flaky(n)` / `@nonFlaky(n)` retry tags (#229),
+  `@expectedFailure` / `@failing` (#237), and env-aware, suite-overridable parallelism.
+- Scenario-aspect states surfaced in the JUnit XML and the streaming reporter. (#248)
+
+### Changed
+
+- Bumped Rift to **v0.11.2** (through 0.10.0 → 0.11.0 → 0.11.1). (#242, #245, #251, #267)
+- The rift-natives fetch now works behind a proxy / mirror / offline, with an optional credentialed
+  `RIFT_NATIVES_BASE_URL` mirror host. (#260, #266)
+
+### Fixed
+
+- Propagate step/hook interruption instead of retrying it. (#231)
+- Guard that the JDK-21 embedded FFM bridge class stays within the method-count limit. (#252)
+
 ## [1.3.1] — 2026-07-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ object AccountSpec extends ZIOSteps[Any, AccountState]:
 
 ```scala
 // build.sbt
-libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.3.1" % Test
+libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.4.1" % Test
 
 Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@ New to zio-bdd?  Read in this order:
 | [Running Tests](running.md) | `@Suite` annotation, sbt commands, CLI flags, dry-run, tag filtering, parallelism, step timeout, IDE integration |
 | [Feature Flag Testing](testing-flags.md) | `@flags(k=v)` matrix expansion, `flagLayer`, `ScenarioMetadata.flagValues`, OpenFeature / Optimizely patterns |
 | [Reporters](reporters.md) | `pretty` (console tree), `junitxml` (CI reports), `StreamingReporter`, `LiveProgressReporter`, custom reporters |
+| [Performance](performance.md) | Parallelism tuning heuristics, log-capture memory characteristics, state-mechanism cost, startup & discovery |
 
 ---
 

--- a/docs/mock-adapters.md
+++ b/docs/mock-adapters.md
@@ -38,7 +38,7 @@ against it fails with `Unsupported` (§3 below, and see
 ## 2. Rift container (`zio-bdd-rift`)
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd-rift" % "1.3.1"
+"io.github.etacassiopeia" %% "zio-bdd-rift" % "1.4.1"
 ```
 
 Two entry points, both requiring a zio-http `Client` and a `Provisioning` in
@@ -97,7 +97,7 @@ See [layers](layers.md) for how this composes into a suite's `environment`.
 ## 3. WireMock (`zio-bdd-wiremock`)
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.3.1"
+"io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.4.1"
 ```
 
 In-process, no Docker, runs on JDK 11+. Only requires `Provisioning`:
@@ -145,15 +145,15 @@ published as **two variants built from the same source**, and you pick
 exactly one for your build's JDK:
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd-rift-embedded"       % "1.3.1" // JDK 22+ (stable FFM)
-"io.github.etacassiopeia" %% "zio-bdd-rift-embedded-jdk21" % "1.3.1" // JDK 21   (preview FFM)
+"io.github.etacassiopeia" %% "zio-bdd-rift-embedded"       % "1.4.1" // JDK 22+ (stable FFM)
+"io.github.etacassiopeia" %% "zio-bdd-rift-embedded-jdk21" % "1.4.1" // JDK 21   (preview FFM)
 ```
 
 Both additionally need the native library on the classpath (or an explicit
 override), and neither is scala-versioned — note the single `%`, not `%%`:
 
 ```scala
-"io.github.etacassiopeia" % "zio-bdd-rift-embedded-natives" % "1.3.1" % Test
+"io.github.etacassiopeia" % "zio-bdd-rift-embedded-natives" % "1.4.1" % Test
 ```
 
 `zio-bdd-rift-embedded-natives` bundles the per-platform `librift_ffi`

--- a/docs/mock-cookbook.md
+++ b/docs/mock-cookbook.md
@@ -16,8 +16,8 @@ Add the WireMock adapter — it runs fully in-process on JDK 11+, no containers:
 ```scala
 // build.sbt
 libraryDependencies ++= Seq(
-  "io.github.etacassiopeia" %% "zio-bdd"          % "1.3.1",
-  "io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.3.1" % Test
+  "io.github.etacassiopeia" %% "zio-bdd"          % "1.4.1",
+  "io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.4.1" % Test
 )
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,7 +9,7 @@ as a concrete example throughout.
 In `build.sbt`:
 
 ```scala
-libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.3.1" % Test
+libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.4.1" % Test
 
 Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
 ```


### PR DESCRIPTION
Tidies the doc loose ends left after cutting 1.4.0/1.4.1:

- **Install snippets** bumped `1.3.1` → `1.4.1` (README + `quickstart.md`, `mock-adapters.md`, `mock-cookbook.md` — 9 refs).
- **CHANGELOG** gains the missing `[1.4.0]` and `[1.4.1]` entries (they were only in the GitHub Releases).
- **`performance.md`** (added in #277) is now linked from the index "Core reference" table — it was an orphan page.

Docs-only; no `.scala` touched.