### PR TITLE
docs: second-wave audit fixes (quickstart, step-dsl, gherkin, migrating, mock-adapters, mock-gherkin, troubleshooting)

### DIFF
--- a/docs/gherkin.md
+++ b/docs/gherkin.md
@@ -156,8 +156,8 @@ or, when the `Examples:` block has a name:
 ```
 
 If a placeholder used in a step has no matching column header in the `Examples:` table
-the step is skipped (not failed at parse time; the mismatch becomes a step-not-found
-error at runtime).
+the step is silently dropped from the expanded scenario — no step-not-found error or
+warning is raised.
 
 ---
 
@@ -288,8 +288,8 @@ Produces tags: `smoke`, `regression`, `priority-high`.
 
 **Placement:**
 - Before `Feature:` — feature-level tags. These are NOT inherited by scenarios.
-- Before a `Rule:` — rule tags (currently stored only on the rule; not propagated to
-  scenarios).
+- Before a `Rule:` — rule tags are discarded entirely; the parser never stores them
+  (`RawRule` has no tags field) and they are not propagated to scenarios.
 - Before `Scenario:` / `Scenario Outline:` — scenario-level tags.
 - Before `Examples:` — applied to all scenarios expanded from that block.
 
@@ -479,7 +479,7 @@ either be silently ignored or cause a parse failure.
 | Inline comments (`Given a step # comment`) | `#` inside a step line is part of the step text |
 | `@ColumnName` derivation without annotation | Plain case-class mapping requires explicit `@ColumnName` on fields |
 | `DocString` content type hints (`` ```json ``) | The type hint after `` ``` `` is captured as part of the delimiter but not stored separately |
-| Nested `Rule:` blocks | `Rule:` inside `Rule:` is not parsed; the inner `Rule:` line is skipped |
+| Nested `Rule:` blocks | Not parsed as nested; the inner `Rule:` is promoted to a sibling top-level rule, so its scenarios get only the feature's `Background:`, not the outer rule's |
 | Multi-feature files | Not supported; use separate `.feature` files |
 | `Ability:` / `Business Need:` as aliases for `Feature:` | Not recognised |
 | Step argument ordering constraints | The parser places a data table or doc string on the immediately following step; two arguments on one step are not supported |

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -37,10 +37,10 @@ Remove:
 Add:
 
 ```scala
-"dev.zio" %% "zio-bdd-core" % zioBddVersion
+"io.github.etacassiopeia" %% "zio-bdd" % "1.4.1"
 ```
 
-The `zio-bdd-core` artifact includes the sbt test framework integration. You do not need a
+The `zio-bdd` artifact includes the sbt test framework integration. You do not need a
 separate runner or test framework dependency.
 
 In `build.sbt`, register the framework:
@@ -116,6 +116,8 @@ Then("""the balance of "([^"]+)" should be (\d+\.\d+)""") {
 
 **zio-bdd:**
 ```scala
+import zio.bdd.core.Assertions.assertTrue
+
 Then("the balance of " / string / " should be " / double) {
   (account: String, balance: Double) =>
     for {
@@ -178,6 +180,8 @@ created fresh for each scenario. The `ScenarioContext` object (generated via the
 mixin) provides `get` and `update`:
 
 ```scala
+import zio.bdd.core.Assertions.assertTrue
+
 case class AppState(userName: String = "", lastResponse: Option[Response] = None)
 
 object AppState:
@@ -390,7 +394,7 @@ All hook variants:
 | `afterStep { meta => ... }` | After each step |
 
 `ScenarioMetadata` carries: `name: String`, `tags: List[String]`,
-`file: Option[String]`, `line: Option[Int]`.
+`file: Option[String]`, `line: Option[Int]`, `flagValues: Map[String, String] = Map.empty`.
 
 Multiple calls to the same hook method compose — they do not replace each other:
 
@@ -656,6 +660,8 @@ The feature file is unchanged.
 
 `steps/OrderSpec.scala`:
 ```scala
+import zio.bdd.core.Assertions.assertTrue
+
 case class OrderState(productName: String = "", orderId: String = "")
 
 object OrderState:

--- a/docs/mock-adapters.md
+++ b/docs/mock-adapters.md
@@ -9,11 +9,11 @@ pick one.
 
 ## 1. The three backends at a glance
 
-| Adapter | Coordinates (1.3.1) | Docker? | JDK | Isolation default | Capabilities |
+| Adapter | Coordinates (1.4.1) | Docker? | JDK | Isolation default | Capabilities |
 |---|---|---|---|---|---|
-| Rift container | `zio-bdd-rift` | yes (testcontainers) | 11+ | PerInstance | all six |
+| Rift container | `zio-bdd-rift` | yes (testcontainers) | 11+ | PerInstance | all six core + Intercept opt-in |
 | WireMock | `zio-bdd-wiremock` | no | 11+ | Correlated (via `.correlated`) | Faults, StatefulScenarios, StateInspection only |
-| Rift embedded | `zio-bdd-rift-embedded` / `zio-bdd-rift-embedded-jdk21` | no (FFM) | 22+ / 21 | PerInstance (default) / Correlated | all six |
+| Rift embedded | `zio-bdd-rift-embedded` / `zio-bdd-rift-embedded-jdk21` | no (FFM) | 22+ / 21 | PerInstance (default) / Correlated | all seven, always on |
 
 ### Capability × adapter matrix
 
@@ -25,11 +25,17 @@ pick one.
 | Scripting | yes | yes | no |
 | ProxyRecord | yes | yes | no |
 | Templating | yes | yes | no |
+| Intercept | opt-in (`interceptPort`) | yes | no |
 
-Rift container and Rift embedded are **capability-complete** — embedded is a
-pure backend swap for the container adapter, not a reduced subset. WireMock
-implements exactly the three capabilities in the first column; requesting
-`Capability.Scripting`, `Capability.ProxyRecord`, or `Capability.Templating`
+Rift container and Rift embedded are **capability-complete** on the six core
+capabilities — embedded is a pure backend swap for the container adapter, not
+a reduced subset. `Intercept` (built-in HTTPS intercept) is always-on for
+embedded but opt-in for the container adapter: pass `interceptPort` to
+`Rift.managed` (or `interceptProxy` to `Rift.connect`) to advertise it; without
+that, the container adapter's `intercept` accessor fails with `Unsupported`
+just like WireMock's. WireMock implements exactly the three capabilities in
+the first column of the top table; requesting `Capability.Scripting`,
+`Capability.ProxyRecord`, `Capability.Templating`, or `Capability.Intercept`
 against it fails with `Unsupported` (§3 below, and see
 [Mocking overview](mocking.md) for the `MockError`/`Unsupported` model).
 
@@ -53,13 +59,17 @@ the environment:
     poolSize: Int = DefaultPoolSize,
     adminPort: Int = DefaultAdminPort,
     imposterBasePort: Int = DefaultImposterBase,
-    mode: RiftMode = RiftMode.PerInstance
+    mode: RiftMode = RiftMode.PerInstance,
+    interceptPort: Option[Int] = None
   ): ZLayer[Client & Provisioning, MockError, MockControl]
   ```
 
-  `DefaultImage` is the pinned Rift image, currently `zainalpour/rift-proxy:v0.9.0`
+  `DefaultImage` is the pinned Rift image, currently `zainalpour/rift-proxy:v0.11.3`
   — derived from the single `riftVersion` in `build.sbt`, so treat it as "the
-  pinned Rift image" rather than a hardcoded tag.
+  pinned Rift image" rather than a hardcoded tag. Pass `interceptPort` to also
+  start the container's HTTPS-intercept listener and advertise
+  `Capability.Intercept` (§9 of [Advanced mocking](mock-advanced.md)); omitted,
+  the container behaves exactly as before.
 
 - **`Rift.connect(...)`** targets an already-running Rift admin endpoint
   instead of starting a container (used by tests, or when Rift runs
@@ -69,7 +79,8 @@ the environment:
   def connect(
     adminBase: String,
     imposterPorts: List[Int],
-    mode: RiftMode = RiftMode.PerInstance
+    mode: RiftMode = RiftMode.PerInstance,
+    interceptProxy: Option[(String, Int)] = None
   )(hostFor: Int => String): URLayer[Client & Provisioning, MockControl]
   ```
 
@@ -133,9 +144,9 @@ capability negotiation working as intended, not a bug to work around.
 
 The embedded provider drives the Rift engine in-process over `librift_ffi` via
 Project Panama FFM — no container, no external process — while remaining
-**capability-complete** (parity with the container adapter, all six
-capabilities). This is the adapter to reach for when you want full fidelity
-without Docker.
+**capability-complete** (parity with the container adapter's six core
+capabilities, plus `Capability.Intercept` always on — all seven). This is the
+adapter to reach for when you want full fidelity without Docker.
 
 ### Two version-locked artifacts
 
@@ -245,8 +256,8 @@ document is `PerInstance`-only via `provisionNative`.
 
 ## 5. Choosing an adapter
 
-- **No Docker, need all six capabilities, JDK 22+ available** → Rift embedded
-  (`zio-bdd-rift-embedded`). Full fidelity, zero container overhead.
+- **No Docker, need all seven capabilities, JDK 22+ available** → Rift
+  embedded (`zio-bdd-rift-embedded`). Full fidelity, zero container overhead.
 - **No Docker, stuck on JDK 21** → Rift embedded
   (`zio-bdd-rift-embedded-jdk21`) with `--enable-preview`, or fall back to
   WireMock if the three-capability limit is acceptable.
@@ -254,8 +265,9 @@ document is `PerInstance`-only via `provisionNative`.
   (`zio-bdd-wiremock`). Cheapest to stand up; covers Faults,
   StatefulScenarios, StateInspection.
 - **Full fidelity and Docker is available (e.g. CI with testcontainers)** →
-  Rift container (`zio-bdd-rift`). Same capability set as embedded, closer to
-  a production Rift deployment.
+  Rift container (`zio-bdd-rift`). Same six core capabilities as embedded,
+  closer to a production Rift deployment; pass `interceptPort` to also match
+  embedded's `Capability.Intercept`.
 
 The sample corpus's `support/Backends.scala` shows the pattern for switching
 adapters at runtime via an environment variable, so a suite's `environment`

--- a/docs/mock-advanced.md
+++ b/docs/mock-advanced.md
@@ -30,18 +30,23 @@ _  <- sc.define(space, defineRetry(path))
 | `Capability.Scripting` | `scripting: IO[Unsupported, Scripting]` | yes | yes | no |
 | `Capability.ProxyRecord` | `proxyRecord: IO[Unsupported, ProxyRecord]` | yes | yes | no |
 | `Capability.Templating` | `templating: IO[Unsupported, Templating]` | yes | yes | no |
-| `Capability.Intercept` | `intercept: IO[Unsupported, Intercept]` | no | yes | no |
+| `Capability.Intercept` | `intercept: IO[Unsupported, Intercept]` | opt-in¹ | yes | no |
 
 Faults, StatefulScenarios, and StateInspection are portable across all three
 adapters. Scripting, ProxyRecord, and Templating are Rift-only (container or
 embedded — embedded is capability-complete, a pure backend swap for the
 container, not a reduced subset); WireMock does not advertise them. `Intercept`
-(built-in HTTPS intercept, §9) is **embedded-only**: it runs the TLS-MITM
-listener in-process over the FFI; the container and WireMock adapters inherit
-the `Unsupported` fallback. See
+(built-in HTTPS intercept, §9) runs the TLS-MITM listener over the **embedded**
+FFI always-on, and over the **container** adapter opt-in (#253) — only when
+`Rift.managed`/`Rift.connect` is given an `interceptPort`/`interceptProxy`;
+WireMock inherits the `Unsupported` fallback. See
 [Adapters](mock-adapters.md) for the full per-adapter breakdown and
 [Mocking overview](mocking.md) for the `MockControl` port these accessors sit
 on.
+
+¹ The container adapter advertises `Capability.Intercept` only when started with
+an `interceptPort` (`Rift.managed`) or `interceptProxy` (`Rift.connect`); without
+one, `intercept` returns `Unsupported`.
 
 ---
 

--- a/docs/mock-cookbook.md
+++ b/docs/mock-cookbook.md
@@ -45,7 +45,7 @@ shared in-process server and routes requests to the right scenario's stubs via a
 correlation header — no per-scenario process to start or stop.
 
 **Alternatives:** the Rift container adapter (`Rift.managed()`, needs Docker, gives you
-all six capabilities including Faults and Scripting) and embedded Rift
+all seven capabilities including Faults and Scripting) and embedded Rift
 (`EmbeddedRift.layer`, capability-complete, no Docker, but needs a JDK-matched native
 build). See [Adapters](mock-adapters.md) for the full comparison and setup steps for both.
 

--- a/docs/mock-gherkin.md
+++ b/docs/mock-gherkin.md
@@ -135,7 +135,7 @@ provisioning *and* becomes statically discoverable:
 ```scala
 object MySuite extends ZIOSteps[MockControl, S] with MockSteps[MockControl, S]:
   override def mockCatalog: Map[String, MockSource] = Catalog.entries
-  override def scenarioLayer = MockFixtures.scenario(meta, mockCatalog)
+  override def scenarioLayer(meta: ScenarioMetadata) = MockFixtures.scenario(meta, mockCatalog)
 ```
 
 `MockSteps.allMocks` then returns a `List[MockSummary]` (each `name` +

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -131,13 +131,13 @@ sbt "testOnly example.CartSpec"
 The `pretty` reporter prints a colour-coded tree. A passing run looks like this:
 
 ```
-◉ Feature: Shopping cart
-  ◑ Scenario: Adding an item increases the total
-    • Given an empty cart
-    • When the user adds 2 units of "Widget" at price 9.99
-    • Then the cart total should be 19.98
-
-Summary: 1 feature, 1 scenario passed  (47ms)
+◉ Feature: Shopping cart - PASSED [47ms]
+╰─ ✓ Scenario: Adding an item increases the total - PASSED [47ms]
+   ├─ • Given an empty cart [2ms]
+   ├─ • When the user adds 2 units of "Widget" at price 9.99 [3ms]
+   ╰─ • Then the cart total should be 19.98 [1ms]
+      Passed: 3  Failed: 0  Ignored: 0  Pending: 0
+Summary: Passed: 1  Failed: 0  Ignored: 0  Pending: 0
 ```
 
 Icons and colours at a glance:
@@ -146,23 +146,25 @@ Icons and colours at a glance:
 |------|---------|-----------------|
 | `◉`  | green   | feature passed  |
 | `◉`  | red     | feature failed  |
-| `◑`  | yellow  | scenario passed |
-| `◑`  | red     | scenario failed |
+| `✓`  | blue    | scenario passed |
+| `✗`  | red     | scenario failed |
 | `◑`  | grey    | scenario skipped / ignored |
-| `•`  | blue    | step passed     |
-| `•`  | red     | step failed     |
-| `•`  | grey    | step skipped (earlier step in scenario failed) |
-| `•`  | orange  | step pending    |
+| `•`  | mint    | step passed     |
+| `✗`  | red     | step failed     |
+| `○`  | grey    | step skipped (earlier step in scenario failed) |
+| `◌`  | orange  | step pending    |
 
 When a step fails the tree shows the exception message inline:
 
 ```
-◉ Feature: Shopping cart
-  ◑ Scenario: Adding an item increases the total
-    • Given an empty cart
-    • When the user adds 2 units of "Widget" at price 9.99
-    • Then the cart total should be 19.98
-        AssertionError: Expected 19.98, got 19.97
+◉ Feature: Shopping cart - FAILED [47ms]
+╰─ ✗ Scenario: Adding an item increases the total - FAILED [47ms]
+   ├─ • Given an empty cart [2ms]
+   ├─ • When the user adds 2 units of "Widget" at price 9.99 [3ms]
+   ╰─ ✗ Then the cart total should be 19.98 [1ms] [FAILED]
+      AssertionError: Expected 19.98, got 19.97
+      Passed: 2  Failed: 1  Ignored: 0  Pending: 0
+Summary: Passed: 0  Failed: 1  Ignored: 0  Pending: 0
 ```
 
 ## 6. Add a second scenario and a Background
@@ -189,23 +191,23 @@ A `Background` block runs before every scenario in the feature. It uses the same
 definitions — no extra Scala code is needed. The `And` keyword is interchangeable with
 `When` at the matching level; it is purely cosmetic in the feature file.
 
-Running `sbt test` now executes both scenarios. The background step appears in the pretty
-output as a separate group before each scenario's own steps:
+Running `sbt test` now executes both scenarios. The background step is spliced in before each
+scenario's own steps — it renders identically to any other step, with no special marker:
 
 ```
-◉ Feature: Shopping cart
-  ◑ Scenario: Adding one item
-    • Given an empty cart         (Background)
-    • When the user adds 2 units of "Widget" at price 9.99
-    • Then the cart total should be 19.98
-
-  ◑ Scenario: Adding two different items
-    • Given an empty cart         (Background)
-    • When the user adds 1 units of "Widget" at price 9.99
-    • And the user adds 3 units of "Gadget" at price 4.50
-    • Then the cart total should be 23.49
-
-Summary: 1 feature, 2 scenarios passed  (62ms)
+◉ Feature: Shopping cart - PASSED [62ms]
+├─ ✓ Scenario: Adding one item - PASSED [29ms]
+│  ├─ • Given an empty cart [2ms]
+│  ├─ • When the user adds 2 units of "Widget" at price 9.99 [3ms]
+│  ╰─ • Then the cart total should be 19.98 [1ms]
+│     Passed: 3  Failed: 0  Ignored: 0  Pending: 0
+╰─ ✓ Scenario: Adding two different items - PASSED [33ms]
+   ├─ • Given an empty cart [2ms]
+   ├─ • When the user adds 1 units of "Widget" at price 9.99 [3ms]
+   ├─ • And the user adds 3 units of "Gadget" at price 4.50 [3ms]
+   ╰─ • Then the cart total should be 23.49 [1ms]
+      Passed: 4  Failed: 0  Ignored: 0  Pending: 0
+Summary: Passed: 2  Failed: 0  Ignored: 0  Pending: 0
 ```
 
 From here, explore the [concepts document](concepts.md) to understand the execution model, or

--- a/docs/step-dsl.md
+++ b/docs/step-dsl.md
@@ -79,17 +79,20 @@ Extractors are values in scope via `DefaultTypedExtractor` (mixed into
 
 ### `string`
 
-Matches any text, optionally surrounded by double quotes.  Quotes are stripped
-from the captured value.
+Matches any text, optionally surrounded by double quotes. The quoted branch is
+escape-aware and non-spanning — it stops at its own unescaped closing quote
+rather than running greedily to the last quote on the line. Quotes are
+stripped from the captured value, and `\"` / `\\` are unescaped to `"` / `\`.
 
 ```
-pattern: (".*"|.*)
+pattern: ("(?:\\.|[^"\\])*"|.*)
 ```
 
 ```scala
 Given("the account id is " / string) { (id: String) =>
   // id == "abc123"  for step text: the account id is "abc123"
   // id == abc123    for step text: the account id is abc123
+  // id == say "hi"  for step text: the account id is "say \"hi\""
 }
 ```
 
@@ -519,7 +522,7 @@ If two or more steps share an identical expression text and keyword,
 ```
 Ambiguous step definitions detected at suite startup.
 The following step expressions are registered multiple times:
-  GivenStep "the account is initialised" — registered 2 times
+  GivenStep 'the account is initialised' — registered 2 times
 Rename or merge duplicate step definitions.
 ```
 
@@ -643,9 +646,15 @@ Each `*S` method registers a step whose body is:
 `State.get[S].flatMap(s => f(s)(extractedParams...))` — one `FiberRef.get`
 per step invocation, equivalent cost to the manual pattern.
 
-Available arities: 0 (no Gherkin params), 1, 2, and 3 extracted parameters.
-For higher arities, use the manual `ScenarioContext.get` pattern or decompose
-the step into helper methods.
+Available arities: `GivenS` / `WhenS` / `ThenS` / `AndS` support 0 (no Gherkin
+params), 1, 2, and 3 extracted parameters. `ButS` only supports 0 and 1 —
+`ButS[A, B]` / `ButS[A, B, C]` are not defined on `ZIOSteps`. A `But` step
+needing 2+ params must use the code-gen-free `InlineStepMethods` (§6), whose
+`ButS` is arity-unbounded, or fall back to the manual `ScenarioContext.get`
+pattern.
+
+For higher arities on `GivenS` / `WhenS` / `ThenS` / `AndS`, use the manual
+`ScenarioContext.get` pattern or decompose the step into helper methods.
 
 ### Related patterns
 
@@ -885,15 +894,24 @@ Then("charging a declined card raises PaymentError") {
 
 ### API
 
+`assertRaises` is a two-stage builder: first fix the exception type (which
+supplies its own `ClassTag` via a `using` parameter), then apply it to the
+effect to inspect:
+
 ```scala
-Assertions.assertRaises[E <: Throwable : ClassTag, R, A](
+Assertions.assertRaises[E <: Throwable](using ClassTag[E]): AssertRaises[E]
+
+// AssertRaises[E]#apply
+def apply[R, A](
   effect: ZIO[R, Throwable, A],
-  message: String = s"Expected <E> to be raised"
+  message: String = ""
 )(inspect: E => ZIO[Any, Throwable, Unit]): ZIO[R, Throwable, Unit]
 ```
 
 - **Passes** when `effect` raises an `E` and `inspect` succeeds. **Fails** when the effect succeeds
   (nothing raised), raises a *different* type, or when `inspect` fails.
+- `message` defaults to `""`; when left at the default, the failure text ("Expected `<E>` to be
+  raised, but …") is computed from the `ClassTag` at runtime, not from a literal default.
 - The exception is caught whether it surfaces as a typed failure or a defect; **interruption** is
   not treated as a raised exception and propagates (cancellation is honored).
 - `inspect` is a `ZIO[Any, Throwable, Unit]`, so it composes with the other `assert*` helpers.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -46,10 +46,18 @@ trait ProvisionSteps { self: ZIOSteps[AppEnv, AppState] => ... }
 
 ---
 
-### "Cannot derive Default for AppState: field 'id' has no default value"
+### "Cannot derive Default for `<schema class>`: field 'id' has no default value"
+
+```
+java.lang.IllegalStateException: Cannot derive Default for <some Schema-derived class name>: field 'id' has no default value
+Hint: add default values to all fields of your state case class, or provide an explicit Default[T] instance.
+```
 
 **Cause:** `ZIOSteps[R, S]` requires a `Default[S]` instance.  When `Default[S]` is derived
-automatically from `Schema[S]`, every field must have a default value.
+automatically from `Schema[S]`, every field must have a default value.  The message interpolates
+`schema.getClass.getSimpleName` — the runtime class name of the derived `Schema[S]` instance, not
+`S`'s own name — so it will **not** literally say `AppState`; grep for `Cannot derive Default for`
+instead of the state type name.
 
 **Fix:** Add default values to all fields of `S`:
 
@@ -132,7 +140,7 @@ Given("the cache is cleared") { ZIO.attempt(cache.clear()).orDie }
 ```
 Ambiguous step definitions detected at suite startup.
 The following step expressions are registered multiple times:
-  GivenStep "a valid provision request" — registered 2 times
+  GivenStep 'a valid provision request' — registered 2 times
 ```
 
 **Cause:** Two step definitions with identical text and keyword were registered.  This often
@@ -143,11 +151,15 @@ in the same trait.
 
 ---
 
-### "StepLookupError: no matching step definition for …"
+### "No matching step found for …"
 
 ```
 FAILED: Given a valid provision request dated -7 days
-  StepLookupError: no step definition matches "a valid provision request dated -7 days"
+  No matching step found for Given 'a valid provision request dated -7 days'.
+
+  Implement it as:
+
+    Given("a valid provision request dated -7 days") { ZIO.unit }
 ```
 
 **Cause:** The Gherkin step text does not match any registered step expression.  Common reasons:
@@ -192,11 +204,11 @@ object MySuite extends ZIOSteps[AppEnv, AppState]   // ← object, not class
 
 ## Runtime failures
 
-### "StagingError.NotFound: no staged value of type Order"
+### "StagingError.NotFound: No staged value of type Order"
 
 ```
 Failed: When the order is submitted
-  zio.bdd.core.step.StagingError$NotFound: no staged value of type Order
+  No staged value of type Order. Call Stage.put before Stage.get.
 ```
 
 **Cause:** `Stage.get[Order]` was called but no prior step called `Stage.put(order)`.  This
@@ -206,6 +218,10 @@ can happen when:
    scenario structure, or dry-run output).
 2. The type passed to `Stage.put` differs from the type passed to `Stage.get` (e.g. `Stage.put`
    stores an `ProvisionEvent` but `Stage.get[PostEvent]` is called).
+
+`StagingError` is a sealed trait, not a `Throwable` — it cannot surface directly as an exception
+from a step body.  A step that wants to fail the scenario on a missing value must map it
+explicitly, e.g. `Stage.get[Order].mapError(e => new RuntimeException(e.message))`.
 
 **Fix:** Use `Stage.getOrElse(defaultValue)` if the missing value should fall back gracefully,
 or `Stage.getOption[T]` to handle absence explicitly:
@@ -260,7 +276,11 @@ for {
 
 ---
 
-### "FeatureContextError.NotFound: no value of type TestAccountId"
+### "FeatureContextError.NotFound: No feature-scoped value of type TestAccountId"
+
+```
+No feature-scoped value of type TestAccountId. Call FeatureContext.put before FeatureContext.get.
+```
 
 **Cause:** `FeatureContext.get[TestAccountId]` was called in a scenario, but no earlier step
 called `FeatureContext.put(TestAccountId(...))` in the same feature.
@@ -268,6 +288,10 @@ called `FeatureContext.put(TestAccountId(...))` in the same feature.
 This often happens when the `Given` step that populates `FeatureContext` is in a `Background`
 block that runs before each scenario — but the first scenario fails before reaching
 `FeatureContext.put`, and later scenarios also fail when they try to read it.
+
+`FeatureContextError` is a sealed trait, not a `Throwable` — it cannot surface directly as an
+exception from a step body.  A step that wants to fail the scenario on a missing value must map
+it explicitly, e.g. `FeatureContext.get[TestAccountId].mapError(e => new RuntimeException(e.message))`.
 
 **Fix:** Use `FeatureContext.getOrElse` or `FeatureContext.getOption` to handle a missing value,
 or ensure the `Background` step populates the context before other steps depend on it.
@@ -306,7 +330,8 @@ TIMEOUT after 30s: When the request is sent
 ### Reporter produces no output
 
 **Cause:** The reporter name in `@Suite(reporters = ...)` is misspelled.  Unknown reporter
-names fall back to `"pretty"` with a warning, but the warning may be lost in build output.
+names fall back to the pretty reporter with a warning — `Unknown reporter '<name>', defaulting
+to ConsoleReporter` — but the warning may be lost in build output.
 
 **Fix:** Use exactly `"pretty"` or `"junitxml"`:
 


### PR DESCRIPTION
Closes #280.

Fixes the drift found by the second-wave audit — one commit per doc file (9 commits). Each correction was re-verified against source; `concepts.md`, `layers.md`, `cookbook.md`, `index.md` were audited clean and are untouched.

**Won't-compile fixes:** `migrating.md` Maven coordinates (`dev.zio %% zio-bdd-core` → `io.github.etacassiopeia %% zio-bdd`) + 3 missing `assertTrue` imports; `mock-gherkin.md` `scenarioLayer(meta)`; `step-dsl.md` `ButS` arity (0–1, not 0–3).

**Wrong-behavior fixes:** `gherkin.md` nested-`Rule:` (promoted to sibling, not skipped), rule tags (discarded, not stored), outline placeholder-miss (silently dropped, not a runtime error).

**Stale API/output:** `mock-adapters.md` + `mock-advanced.md` Intercept capability (now 7th; container opt-in via `interceptPort`), `Rift.managed/connect` signatures, `DefaultImage` → `v0.11.3`; `quickstart.md` reporter icon table + sample output; `troubleshooting.md` stale error strings (Stage/FeatureContext/Default/no-match, reporter fallback).

Docs-only (no `.scala`) → trivial CI.