### PR TITLE
build: automate release docs-prep — sync install snippets to the published tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,3 +86,39 @@ jobs:
             *) flags="$flags --latest" ;;
           esac
           gh release create "${GITHUB_REF_NAME}" $flags
+
+  # Keep the docs/README install snippets from lagging a published tag: bump them to the released version
+  # and open a PR. A PR (not a direct push) respects branch protection; the change is docs-only. No-op when
+  # the docs already carry this version. Note: a bot-opened PR does not re-trigger CI, so a maintainer merges
+  # it (admin merge is fine — docs-only). Skipped for pre-releases, which don't move the "current version".
+  docs-version-bump:
+    needs: github-release
+    if: ${{ !contains(github.ref_name, '-') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+          fetch-depth: 0
+      - name: Open a docs version-bump PR for this release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          bash scripts/bump-doc-versions.sh "$version"
+          if git diff --quiet; then
+            echo "docs already at $version — nothing to bump"
+            exit 0
+          fi
+          branch="docs/bump-${version}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git commit -am "docs: bump install snippets to ${version}"
+          git push -u origin "$branch"
+          gh pr create --base master --head "$branch" \
+            --title "docs: bump install snippets to ${version}" \
+            --body "Automated by the release workflow — sync the README/docs install snippets to the freshly-published \`${version}\`. Docs-only; safe to admin-merge (a bot-opened PR does not re-trigger CI)."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,8 +17,10 @@ This document describes how to publish a new release of zio-bdd to Maven Central
 1. All tests pass: `sbt clean test`
 2. No scalafmt violations: `sbt scalafmtCheckAll`
 3. No compilation warnings: `sbt compile` (check output for `-Wunused:imports` warnings)
-4. `CHANGELOG.md` updated with the new version entry.
-5. `README.md` version badge reflects the new version.
+4. `CHANGELOG.md` updated with the new version entry (move `[Unreleased]` → `[X.Y.Z] — <date>`).
+5. Docs install snippets bumped to the new version — run `./scripts/bump-doc-versions.sh X.Y.Z`
+   (idempotent; only touches `io.github.etacassiopeia` coordinates). Optional: the release workflow
+   opens this bump as a PR afterward if you skip it here (see step 4 below).
 6. All new public APIs are documented.
 
 ## Versioning
@@ -39,13 +41,20 @@ zio-bdd follows [Semantic Versioning](https://semver.org/):
    ```bash
    git push origin v1.0.0
    ```
-   The GitHub Actions workflow (`.github/workflows/release.yml`) runs `sbt ci-release`,
-   which signs and publishes the artifacts to Sonatype Central.
+   The GitHub Actions workflow (`.github/workflows/release.yml`) runs three jobs on the tag:
+   - **publish** / **publish-preview** — `sbt ci-release` signs and publishes the stable bundle
+     (JDK 22) and the JDK 21 preview variant to Sonatype Central.
+   - **github-release** — creates the GitHub Release with auto-generated notes; `--latest` for a
+     plain `vX.Y.Z`, `--prerelease` for a hyphenated `vX.Y.Z-RCn`. (#275)
+   - **docs-version-bump** — opens a `docs/bump-X.Y.Z` PR syncing the README/docs install snippets
+     to the new version (skipped for pre-releases). (#282)
 
 3. **Verify on Maven Central** (can take 10-30 minutes to propagate):
    - `https://search.maven.org/artifact/io.github.etacassiopeia/zio-bdd_3`
 
-4. **Create a GitHub release** from the tag with the CHANGELOG entry as description.
+4. **Merge the docs-bump PR** if step 5 of the checklist was skipped — it's docs-only, so a repo
+   admin can merge it directly (a bot-opened PR does not re-trigger CI, which is expected). The
+   GitHub Release is already created by the workflow — no manual step.
 
 ## Local test publish
 

--- a/scripts/bump-doc-versions.sh
+++ b/scripts/bump-doc-versions.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Bump the zio-bdd install-snippet version across README + docs to <version>.
+#
+# Only lines that declare an `io.github.etacassiopeia` coordinate are touched, so a
+# free-form version mention in prose is never disturbed. Idempotent: running it with
+# the version the docs already carry produces no change.
+#
+# Usage: scripts/bump-doc-versions.sh <version>   (e.g. 1.5.0, or 1.5.0-RC1)
+set -euo pipefail
+
+version="${1:?usage: scripts/bump-doc-versions.sh <version> (e.g. 1.5.0)}"
+if ! printf '%s' "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$'; then
+  echo "error: '$version' is not a semantic version" >&2
+  exit 2
+fi
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+files=(README.md docs/quickstart.md docs/mock-adapters.md docs/mock-cookbook.md docs/migrating.md)
+
+changed=0
+for rel in "${files[@]}"; do
+  f="$root/$rel"
+  [ -f "$f" ] || continue
+  # On any line carrying an io.github.etacassiopeia coordinate, bump the `% "x.y.z"` literal.
+  # `/ge` builds the replacement as an expression, so the version needs no regex-escaping.
+  VERSION="$version" perl -i -pe \
+    'if (/io\.github\.etacassiopeia/) { s/(%\s*)"[0-9]+\.[0-9]+\.[0-9]+(?:[-.][0-9A-Za-z.]+)?"/$1 . q{"} . $ENV{VERSION} . q{"}/ge }' \
+    "$f"
+  if ! git -C "$root" diff --quiet -- "$rel" 2>/dev/null; then
+    echo "  bumped $rel"
+    changed=1
+  fi
+done
+
+if [ "$changed" -eq 0 ]; then
+  echo "docs already at $version — no changes"
+fi


### PR DESCRIPTION
Follow-up to #275 (which automated the GitHub Release object). Stops the README/docs install snippets from lagging a published tag — the staleness fixed by hand in #279 for 1.4.0/1.4.1.

- **`scripts/bump-doc-versions.sh <version>`** — bumps the `% "x.y.z"` literal on every line declaring an `io.github.etacassiopeia` coordinate (README + quickstart/mock-adapters/mock-cookbook/migrating). Only coordinate lines, so prose is never touched; idempotent; rejects non-semver. Tested: no-op at 1.4.1, bumps all 10 refs on a dry run.
- **`release.yml` → `docs-version-bump` job** — after the release publishes, runs the script for the tag version and opens a `docs/bump-X.Y.Z` PR (a PR, not a direct push, so branch protection is respected). No-op when docs already match; skipped for `-RCn` pre-releases.
- **`RELEASING.md`** — updated to describe the three automated jobs (publish → GitHub Release → docs bump) and the one remaining manual step (curate the CHANGELOG, merge the bump PR).

Note: a bot-opened PR does not re-trigger CI, so the docs-bump PR is admin-merged (docs-only). This is documented in the job comment and RELEASING.md.