### PR TITLE
fix(core): guard afterAll with .ensuring so suite cleanup runs on defect (#278 item 1)

### DIFF
--- a/core/src/main/scala/zio/bdd/core/FeatureExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/FeatureExecutor.scala
@@ -133,7 +133,11 @@ object FeatureExecutor {
     dryRun: Boolean = false,
     genLookup: ColumnGenLookup = ColumnGenLookup.empty
   ): ZIO[R, Nothing, List[FeatureResult]] =
-    for {
+    // beforeAll is inside the .ensuring so afterAll suite-level teardown always
+    // runs — even if beforeAll dies or a feature body dies — matching the
+    // afterFeature/afterScenario contract. Otherwise cleanup (containers, temp
+    // dirs, external resources) leaks on an upstream defect.
+    (for {
       _ <- suite.beforeAllHook
       results <- if (featureParallelism <= 1)
                    ZIO.foreach(features)(executeFeature(_, steps, suite, scenarioParallelism, dryRun, genLookup))
@@ -141,6 +145,5 @@ object FeatureExecutor {
                    ZIO.foreachExec(features)(ExecutionStrategy.ParallelN(featureParallelism.max(1)))(
                      executeFeature(_, steps, suite, scenarioParallelism, dryRun, genLookup)
                    )
-      _ <- suite.afterAllHook
-    } yield results
+    } yield results).ensuring(suite.afterAllHook)
 }

--- a/core/src/test/scala/zio/bdd/core/FeatureExecutorSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/FeatureExecutorSpec.scala
@@ -283,6 +283,47 @@ object FeatureExecutorSpec extends ZIOSpecDefault {
         _  <- FeatureExecutor.executeFeatures[Any, SystemState](List(f1, f2), suiteSteps.getSteps, suiteSteps)
       } yield assertTrue(counter.get() == 1)
     },
+    test("afterAll runs even when beforeAll dies (ensuring-guarded)") {
+      val afterAllRan = new java.util.concurrent.atomic.AtomicInteger(0)
+      val suiteSteps = new UserSteps {
+        beforeAll(ZIO.dieMessage("beforeAll boom"))
+        afterAll(ZIO.succeed(afterAllRan.incrementAndGet()).unit)
+      }
+      for {
+        f    <- GherkinParser.parseFeature("Feature: F\n  Scenario: s\n    Given a system is running\n", F)
+        exit <- FeatureExecutor.executeFeatures[Any, SystemState](List(f), suiteSteps.getSteps, suiteSteps).exit
+      } yield assertTrue(
+        afterAllRan.get() == 1,
+        exit.causeOption.exists(_.defects.exists(_.getMessage.contains("beforeAll boom")))
+      )
+    },
+    test("afterAll runs even when a feature dies (ensuring-guarded)") {
+      val afterAllRan = new java.util.concurrent.atomic.AtomicInteger(0)
+      val suiteSteps = new UserSteps {
+        beforeFeature(ZIO.dieMessage("feature boom"))
+        afterAll(ZIO.succeed(afterAllRan.incrementAndGet()).unit)
+      }
+      for {
+        f    <- GherkinParser.parseFeature("Feature: F\n  Scenario: s\n    Given a system is running\n", F)
+        exit <- FeatureExecutor.executeFeatures[Any, SystemState](List(f), suiteSteps.getSteps, suiteSteps).exit
+      } yield assertTrue(
+        afterAllRan.get() == 1,
+        exit.causeOption.exists(_.defects.exists(_.getMessage.contains("feature boom")))
+      )
+    },
+    test("hook order is beforeAll → feature → afterAll on the happy path") {
+      val log                          = scala.collection.mutable.ListBuffer.empty[String]
+      def record(s: String): UIO[Unit] = ZIO.succeed(log.synchronized { log += s; () })
+      val suiteSteps = new UserSteps {
+        beforeAll(record("beforeAll"))
+        beforeFeature(record("feature"))
+        afterAll(record("afterAll"))
+      }
+      for {
+        f <- GherkinParser.parseFeature("Feature: F\n  Scenario: s\n    Given a system is running\n", F)
+        _ <- FeatureExecutor.executeFeatures[Any, SystemState](List(f), suiteSteps.getSteps, suiteSteps)
+      } yield assertTrue(log.toList == List("beforeAll", "feature", "afterAll"))
+    },
     test("beforeScenario receives ScenarioMetadata with the scenario name") {
       var capturedName = ""
       val suiteSteps = new UserSteps {

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -183,10 +183,10 @@ Within each tier, hooks registered earlier run before hooks registered later.
   The state still contains whatever the last step left behind.
 - `beforeStep` / `afterStep` fire around **each individual step**, including Background steps
   that are prepended to a scenario.
-- `afterAll` runs after all features have completed, provided nothing upstream died. Unlike
-  `afterScenario`/`afterFeature`, the `beforeAll → features → afterAll` sequence is a plain
-  for-comprehension with no `.ensuring` guard — a defect in `beforeAll` or an unrecovered
-  feature-level defect skips `afterAll`.
+- `afterAll` **always** runs after all features have completed. Like
+  `afterScenario`/`afterFeature`, the `beforeAll → features → afterAll` sequence is
+  `.ensuring`-guarded (with `beforeAll` inside the guard), so `afterAll` runs even when
+  `beforeAll` dies or a feature body dies — suite-level cleanup never leaks on an upstream defect.
 
 ---
 
@@ -213,8 +213,8 @@ How that defect is handled differs by hook:
 | `afterScenario` | Fails the scenario (even if all steps passed) | Yes — always runs |
 | `beforeFeature` | Propagates as a defect, skipping the feature's scenarios | No |
 | `afterFeature` | Propagates as a defect after teardown | Yes — always runs |
-| `beforeAll` | Propagates as a defect, skipping all features and `afterAll` | No |
-| `afterAll` | Propagates as a defect | No |
+| `beforeAll` | Propagates as a defect, skipping all features (but `afterAll` still runs) | Inside the guard |
+| `afterAll` | Propagates as a defect after teardown | Yes — always runs |
 
 A genuine interruption (fiber cancellation / shutdown), as opposed to a hook failure, is never
 treated as a retryable error — an interrupt-only `Cause` always propagates rather than being


### PR DESCRIPTION
Wrap the beforeAll→features→afterAll sequence in .ensuring(afterAllHook) so suite teardown always runs even when beforeAll or features emit a defect.

Updated hooks.md docs to reflect this behavior.

Closes #286
Part of #278 (item 1).