### PR TITLE
fix(core): FeatureContext loses writes under scenarioParallelism>1 — back with a synchronized Ref (#278 item 2)

### DIFF
--- a/core/src/main/scala/zio/bdd/core/FeatureContext.scala
+++ b/core/src/main/scala/zio/bdd/core/FeatureContext.scala
@@ -27,20 +27,35 @@ import scala.reflect.ClassTag
  */
 object FeatureContext {
 
-  // The feature store is a FiberRef[Map[String, Any]] keyed by class name.
-  // Reset by FeatureExecutor at the start of each feature.
-  private[bdd] val ref: FiberRef[Map[String, Any]] =
+  // The feature store is a FiberRef holding a *reference* to a per-feature
+  // synchronized cell (not the Map itself). This is deliberate: a plain
+  // FiberRef[Map] copies its value on fork and merges last-writer-wins on join,
+  // so parallel scenario fibers (scenarioParallelism > 1) silently clobber each
+  // other's writes. By holding a Ref.Synchronized, `freshScope` installs a fresh
+  // cell per feature (isolation across parallel features, via locallyScoped)
+  // while forked scenario fibers inherit the *same cell instance* — their atomic
+  // updates compose instead of being lost.
+  private[bdd] val ref: FiberRef[Ref.Synchronized[Map[String, Any]]] =
     Unsafe.unsafe { implicit u =>
-      FiberRef.unsafe.make(Map.empty[String, Any])
+      val initial = Runtime.default.unsafe.run(Ref.Synchronized.make(Map.empty[String, Any])).getOrThrow()
+      FiberRef.unsafe.make(initial)
     }
+
+  /**
+   * Install a fresh, empty per-feature store scoped to the current fiber.
+   * Parallel features each get their own cell; scenario fibers forked within a
+   * feature share it. Called by FeatureExecutor at the start of each feature.
+   */
+  private[bdd] def freshScope: ZIO[Scope, Nothing, Unit] =
+    Ref.Synchronized.make(Map.empty[String, Any]).flatMap(cell => ref.locallyScoped(cell))
 
   /** Store a value. Overwrites any previously stored value of the same type. */
   def put[A: ClassTag](value: A): UIO[Unit] =
-    ref.update(m => m + (key[A] -> value))
+    ref.get.flatMap(_.update(m => m + (key[A] -> value)))
 
   /** Retrieve a stored value. Fails with FeatureContextError if not present. */
   def get[A: ClassTag]: IO[FeatureContextError, A] =
-    ref.get.flatMap { m =>
+    ref.get.flatMap(_.get).flatMap { m =>
       m.get(key[A]) match {
         case Some(v: A) => ZIO.succeed(v)
         case Some(v)    => ZIO.fail(FeatureContextError.TypeMismatch(key[A], v.getClass.getSimpleName))
@@ -54,28 +69,28 @@ object FeatureContext {
 
   /** Retrieve an Option — None if not stored. */
   def getOption[A: ClassTag]: UIO[Option[A]] =
-    ref.get.map { m =>
+    ref.get.flatMap(_.get).map { m =>
       m.get(key[A]).collect { case v: A => v }
     }
 
   /** Update a stored value if present, no-op otherwise. */
   def modify[A: ClassTag](f: A => A): UIO[Unit] =
-    ref.update { m =>
+    ref.get.flatMap(_.update { m =>
       m.get(key[A]) match {
         case Some(v: A) => m + (key[A] -> f(v))
         case _          => m
       }
-    }
+    })
 
   /** Set a stored value unconditionally. */
   def set[A: ClassTag](value: A): UIO[Unit] = put(value)
 
   /** Remove a stored value. */
   def remove[A: ClassTag]: UIO[Unit] =
-    ref.update(m => m - key[A])
+    ref.get.flatMap(_.update(m => m - key[A]))
 
   /** Reset all stored values. Called by FeatureExecutor between features. */
-  private[bdd] def reset: UIO[Unit] = ref.set(Map.empty)
+  private[bdd] def reset: UIO[Unit] = ref.get.flatMap(_.set(Map.empty))
 
   private def key[A: ClassTag]: String = implicitly[ClassTag[A]].runtimeClass.getName
 }

--- a/core/src/main/scala/zio/bdd/core/FeatureExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/FeatureExecutor.scala
@@ -45,7 +45,8 @@ object FeatureExecutor {
           for {
             startNanos <- nowNanos
             // Per-feature staging scoped to the feature and auto-restored on scope close.
-            _ <- FeatureContext.ref.locallyScoped(Map.empty)
+            // Installs a fresh synchronized cell so parallel scenario fibers share it.
+            _ <- FeatureContext.freshScope
             featureResult <- (for {
                                _       <- suite.beforeFeatureHook
                                expanded = expandFlagScenarios(feature.scenarios)

--- a/core/src/test/scala/zio/bdd/core/FeatureContextSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/FeatureContextSpec.scala
@@ -198,6 +198,47 @@ object FeatureContextSpec extends ZIOSpecDefault {
     }
   )
 
+  // ── Concurrent writes from parallel scenarios accumulate ──────────────────
+  //
+  // Under scenarioParallelism > 1 the scenarios run on true parallel fibers that
+  // share one feature store. Each scenario increments the same counter; with the
+  // old FiberRef (last-writer-wins fork/join) the siblings clobber each other and
+  // the counter ends at 1. A synchronized cell must accumulate all N updates.
+
+  final case class Counter(n: Int)
+
+  private val concurrentAccumulation =
+    suite("FeatureContext accumulates concurrent writes across parallel scenarios")(
+      test("N parallel scenarios each incrementing the shared counter reach N (no lost updates)") {
+        val n        = 8
+        val observed = new java.util.concurrent.atomic.AtomicInteger(-1)
+
+        val stepsImpl = new ZIOSteps[Any, S] {
+          beforeFeature(FeatureContext.put(Counter(0)))
+          afterFeature(
+            FeatureContext.getOption[Counter].flatMap(o => ZIO.succeed(observed.set(o.map(_.n).getOrElse(-1))))
+          )
+          Given("increment the feature counter") {
+            FeatureContext.modify[Counter](c => Counter(c.n + 1))
+          }
+        }
+
+        val scenarios =
+          (1 to n).map(i => s"  Scenario: increment $i\n    Given increment the feature counter\n").mkString
+        val featureText = s"Feature: concurrent counter\n$scenarios"
+
+        for {
+          feature <- GherkinParser.parseFeature(featureText, "fc-concurrent.feature")
+          _ <- FeatureExecutor.executeFeatures[Any, S](
+                 List(feature),
+                 stepsImpl.getSteps,
+                 stepsImpl,
+                 scenarioParallelism = n
+               )
+        } yield assertTrue(observed.get() == n)
+      } @@ TestAspect.withLiveClock
+    )
+
   def spec: Spec[TestEnvironment & Scope, Any] = suite("FeatureContext")(
     putGet,
     getOrElseOps,
@@ -205,6 +246,10 @@ object FeatureContextSpec extends ZIOSpecDefault {
     modifyOps,
     setRemoveOps,
     persistsAcrossScenarios,
-    resetBetweenFeatures
-  )
+    resetBetweenFeatures,
+    concurrentAccumulation
+    // Run sequentially: the direct-API tests operate on the shared out-of-feature
+    // default store (production always runs inside a per-feature scope via
+    // freshScope, so it never shares this cell — only these tests do).
+  ) @@ TestAspect.sequential
 }

--- a/docs/state.md
+++ b/docs/state.md
@@ -526,15 +526,17 @@ Both stores are cleared via `Ref.locallyScoped(Map.empty)`, not by an explicit
 - `ScenarioExecutor` scopes `Stage.ref` (and `Stage.currentStepLabel`) with
   `Stage.ref.locallyScoped(Map.empty)` at the start of each scenario *attempt*,
   **before** `beforeScenarioHook` runs.
-- `FeatureExecutor` scopes `FeatureContext.ref` with
-  `FeatureContext.ref.locallyScoped(Map.empty)` at the start of each feature,
-  **before** `beforeFeatureHook` runs.
+- `FeatureExecutor` installs a fresh per-feature store with
+  `FeatureContext.freshScope` at the start of each feature, **before**
+  `beforeFeatureHook` runs.
 
-`locallyScoped` sets the `FiberRef` to the empty map for the lifetime of the
-enclosing `ZIO.scoped` block and restores the previous value when that scope
-closes — this is what guarantees a retried scenario attempt, or the next
-scenario/feature, starts from a clean store even if the previous attempt was
-interrupted mid-step.
+`locallyScoped` sets the `FiberRef` for the lifetime of the enclosing
+`ZIO.scoped` block and restores the previous value when that scope closes — this
+is what guarantees a retried scenario attempt, or the next scenario/feature,
+starts from a clean store even if the previous attempt was interrupted
+mid-step. `FeatureContext.freshScope` allocates a new synchronized cell and
+`locallyScoped`s *that*, so each feature — including parallel features — is
+isolated while the scenarios within one feature share a single cell.
 
 The `private[bdd] def reset` method on both `Stage` and `FeatureContext` is
 **test-only** — it exists for unit-testing the stores in isolation and is
@@ -542,25 +544,23 @@ never called by `ScenarioExecutor` or `FeatureExecutor`. Do not rely on it to
 understand production clearing behavior; the `locallyScoped` calls above are
 the actual production clearing path.
 
-### Concurrency warning: `FeatureContext` under `scenarioParallelism > 1`
+### Concurrency: `FeatureContext` under `scenarioParallelism > 1`
 
-`FeatureContext.ref` is a plain `FiberRef[Map[String, Any]]`. When a suite runs
-with `scenarioParallelism > 1`, `FeatureExecutor` executes sibling scenarios of
-the same feature as **true parallel fibers** (`ZIO.foreachExec` with
-`ExecutionStrategy.ParallelN`), all forked from the same parent fiber that
-holds the feature's `FiberRef` value.
+`FeatureContext.ref` is a `FiberRef[Ref.Synchronized[Map[String, Any]]]` — the
+`FiberRef` holds a *reference* to a per-feature synchronized cell, not the map
+itself. When a suite runs with `scenarioParallelism > 1`, `FeatureExecutor`
+executes sibling scenarios of the same feature as **true parallel fibers**
+(`ZIO.foreachExec` with `ExecutionStrategy.ParallelN`), all forked from the same
+parent fiber.
 
-`FiberRef` fork/join semantics are last-writer-wins on join, not merged: each
-forked scenario fiber gets its own copy of the `FiberRef` value at fork time,
-and whichever sibling's value is observed last silently overwrites the others'
-changes. Concretely, this means `FeatureContext.put`/`modify` calls from
-different scenario fibers in the same feature are **not synchronized** —
-accumulation patterns (e.g. a shared counter incremented by every scenario)
-will silently lose updates under parallel execution.
+Because the fibers share the same underlying `Ref.Synchronized` instance (fork
+copies the reference, not the cell), `FeatureContext.put`/`modify` from different
+scenario fibers are **synchronized and compose** rather than clobbering each
+other. Accumulation patterns — e.g. a shared counter incremented by every
+scenario in the feature — work correctly under parallel execution.
 
-If a feature needs cross-scenario accumulation under `scenarioParallelism > 1`,
-use a synchronized primitive obtained from a `ZLayer` (a `Ref`, `Ref.Synchronized`,
-or `Queue`/`Hub` provided via `R`) instead of `FeatureContext`.
+Cross-feature isolation is preserved: `FeatureContext.freshScope` installs a
+*new* cell per feature, so parallel features never share state.
 
 ---
 


### PR DESCRIPTION
FiberRef[Map] fork/join is last-writer-wins; under scenarioParallelism > 1, sibling scenarios clobbered each other's updates. Fixed with FiberRef[Ref.Synchronized[Map]]: fresh synchronized cell per feature, shared across scenario fibers. Adds parallel-accumulation regression test.

Closes #287
Part of #278 (item 2).