### PR TITLE
refactor(core): mark StreamingReporter/TestEvent API @experimental — unwired in production (#278 item 3)

### DIFF
--- a/core/src/main/scala/zio/bdd/core/report/StreamingReporter.scala
+++ b/core/src/main/scala/zio/bdd/core/report/StreamingReporter.scala
@@ -5,6 +5,8 @@ import zio.bdd.core.{FeatureResult, LogCollector, ScenarioResult, StepResult}
 import zio.bdd.gherkin.{Feature, Scenario, Step}
 import zio.stream.ZStream
 
+import scala.annotation.experimental
+
 /**
  * Events emitted during test execution for streaming reporters.
  *
@@ -16,9 +18,18 @@ import zio.stream.ZStream
  *     events
  *   - Memory-efficient reporting (no need to accumulate all results before
  *     printing)
+ *
+ * '''Experimental / not wired in production.''' No `@Suite` reporter name or
+ * `--reporter` CLI flag builds a `StreamingReporter`; the production pipeline
+ * only assembles the batch `List[Reporter]`, and the "fan-out via `ZHub`"
+ * design is aspirational. This API is exercisable only by hand-driving
+ * `consume` on a `ZStream` you build yourself, so it is marked `@experimental`
+ * — using it requires opting into experimental mode. See issue #278 (item 3).
  */
+@experimental
 sealed trait TestEvent
 
+@experimental
 object TestEvent:
   /** Emitted once before any feature starts. */
   case class SuiteStarted(featureCount: Int, dryRun: Boolean) extends TestEvent
@@ -49,7 +60,10 @@ object TestEvent:
  *   - Print progress in real-time
  *   - Write results incrementally (no memory accumulation)
  *   - Be fan-outed to multiple subscribers via `ZHub`
+ *
+ * '''Experimental''' — see `TestEvent`; not wired into the production pipeline.
  */
+@experimental
 trait StreamingReporter:
   def consume(events: ZStream[Any, Nothing, TestEvent]): ZIO[LogCollector, Throwable, Unit]
 
@@ -57,6 +71,7 @@ trait StreamingReporter:
  * Adapter: wrap a batch `Reporter` as a `StreamingReporter`. Accumulates all
  * events, then calls `reporter.report` on `SuiteFinished`.
  */
+@experimental
 final class BatchReporterAdapter(reporter: Reporter) extends StreamingReporter:
   def consume(events: ZStream[Any, Nothing, TestEvent]): ZIO[LogCollector, Throwable, Unit] =
     events.runForeach {
@@ -68,6 +83,7 @@ final class BatchReporterAdapter(reporter: Reporter) extends StreamingReporter:
  * A streaming reporter that prints live progress to the console. One line per
  * scenario as it completes.
  */
+@experimental
 object LiveProgressReporter extends StreamingReporter:
   def consume(events: ZStream[Any, Nothing, TestEvent]): ZIO[LogCollector, Throwable, Unit] =
     events.runForeach {

--- a/core/src/test/scala/zio/bdd/core/report/ReporterAspectsSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/report/ReporterAspectsSpec.scala
@@ -7,6 +7,7 @@ import zio.bdd.gherkin.StepType
 import zio.stream.ZStream
 
 import java.time.Instant
+import scala.annotation.experimental
 
 /**
  * Gate for issue #238 — JUnit XML and the live streaming reporter must surface
@@ -16,7 +17,11 @@ import java.time.Instant
  * Note (as in JUnitXMLFormatterSpec): a scala.xml.Elem is a self-referential
  * Seq, so every navigation is reduced to a plain String/Boolean BEFORE it
  * reaches assertTrue.
+ *
+ * Marked `@experimental` because the streaming-reporter suite below exercises
+ * the `@experimental` `TestEvent`/`LiveProgressReporter` API (issue #288).
  */
+@experimental
 object ReporterAspectsSpec extends ZIOSpecDefault {
 
   import ResultFixtures.*

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -283,18 +283,27 @@ path the fallback is silent. See `ZIOBDDFramework.scala:322-343`.
 values rather than a batch of results at the end of the run. This enables real-time output,
 incremental file writing, and CI service integrations.
 
-> **Not wired up today.** This is a standalone API you exercise by hand — build a
-> `ZStream[Any, Nothing, TestEvent]` yourself and call `consume` on it. No `@Suite` reporter
-> name or `--reporter` CLI flag selects a `StreamingReporter`; the production pipeline
-> (`ZIOBDDFramework.scala`) only ever builds a `List[Reporter]` (batch). The "fan-out via
-> `ZHub`" idea mentioned on `StreamingReporter` is aspirational — there is no `Hub`/`ZHub`
-> usage anywhere in `core/src/main` today.
+> **`@experimental` — not wired up today.** `TestEvent`, `StreamingReporter`, and its impls
+> (`BatchReporterAdapter`, `LiveProgressReporter`) are annotated
+> [`@experimental`](https://scala-lang.org/api/current/scala/annotation/experimental.html), so
+> referencing them from your own code requires opting into experimental mode (mark the using
+> definition `@experimental`, or compile with `-experimental`). This is deliberate: it's a
+> standalone API you exercise by hand — build a `ZStream[Any, Nothing, TestEvent]` yourself and
+> call `consume` on it. No `@Suite` reporter name or `--reporter` CLI flag selects a
+> `StreamingReporter`; the production pipeline (`ZIOBDDFramework.scala`) only ever builds a
+> `List[Reporter]` (batch). The "fan-out via `ZHub`" idea mentioned on `StreamingReporter` is
+> aspirational — there is no `Hub`/`ZHub` usage anywhere in `core/src/main` today. The API may
+> change or be removed without a deprecation cycle until it is wired into the run pipeline.
 
 ### TestEvent sealed trait
 
 ```scala
+import scala.annotation.experimental
+
+@experimental
 sealed trait TestEvent
 
+@experimental
 object TestEvent:
   /** Emitted once before any feature starts. */
   case class SuiteStarted(featureCount: Int, dryRun: Boolean) extends TestEvent
@@ -326,6 +335,7 @@ object TestEvent:
 ### StreamingReporter trait
 
 ```scala
+@experimental
 trait StreamingReporter:
   def consume(events: ZStream[Any, Nothing, TestEvent]): ZIO[LogCollector, Throwable, Unit]
 ```
@@ -336,6 +346,8 @@ and may produce any side effects.
 ### Implementing a custom StreamingReporter
 
 ```scala
+// A custom StreamingReporter must itself opt into experimental mode.
+@experimental
 object TeamCityReporter extends StreamingReporter:
   def consume(events: ZStream[Any, Nothing, TestEvent]): ZIO[LogCollector, Throwable, Unit] =
     events.runForeach {


### PR DESCRIPTION
Mark the streaming reporter API (TestEvent, StreamingReporter, BatchReporterAdapter, LiveProgressReporter) with @experimental. The API is presented as pluggable but is not wired into the production pipeline — only the batch List[Reporter] path runs. This annotation ensures users must explicitly opt into experimental mode rather than being misled into depending on an unwired path. The batch reporter path is untouched; the one consumer test opts in the same way.

Closes #288
Part of #278 (item 3).