### PR TITLE
fix(core): @Suite/--log-level silently accepts only 3 of 5 levels (#278 item 4)

### DIFF
--- a/core/src/main/scala/zio/bdd/ZIOBDDFramework.scala
+++ b/core/src/main/scala/zio/bdd/ZIOBDDFramework.scala
@@ -286,7 +286,7 @@ class ZIOBDDTask(
       scenarioParallelism = parseScenarioParallelism(args),
       includeTags = parseIncludeTags(args),
       excludeTags = parseExcludeTags(args),
-      logLevel = parseLogLevel(args, loggers),
+      logLevel = parseLogLevel(args),
       scenarioNameFilter = parseScenarioName(args),
       dryRun = args.contains("--dry-run"),
       focused = args.contains("--focused")
@@ -319,28 +319,14 @@ class ZIOBDDTask(
     )
   }
 
-  private def parseLogLevel(args: Array[String], loggers: Array[Logger]): InternalLogLevel =
+  private def parseLogLevel(args: Array[String]): InternalLogLevel =
     args
       .sliding(2)
-      .collectFirst { case Array("--log-level", level) =>
-        level.toLowerCase match {
-          case "debug" => InternalLogLevel.Debug
-          case "info"  => InternalLogLevel.Info
-          case "error" => InternalLogLevel.Error
-          case _ =>
-            loggers.foreach(_.warn(s"Unknown log level '$level', defaulting to Info"))
-            InternalLogLevel.Info
-        }
-      }
+      .collectFirst { case Array("--log-level", level) => ZIOBDDTask.parseLogLevelOrThrow(level) }
       .getOrElse(InternalLogLevel.Info)
 
   private def parseLogLevelFromAnnotation(level: String): InternalLogLevel =
-    level.toLowerCase match {
-      case "debug" => InternalLogLevel.Debug
-      case "info"  => InternalLogLevel.Info
-      case "error" => InternalLogLevel.Error
-      case _       => InternalLogLevel.Info // Default if annotation value is invalid
-    }
+    ZIOBDDTask.parseLogLevelOrThrow(level)
 
   private def parseIncludeTags(args: Array[String]): Set[String] =
     args
@@ -501,6 +487,30 @@ class ZIOBDDTask(
 }
 
 object ZIOBDDTask {
+
+  /**
+   * Parse a log-level name (case-insensitive) into an `InternalLogLevel`,
+   * accepting all five levels. `Left` names the offending value and the valid
+   * set. Shared by the `--log-level` CLI flag and the `@Suite(logLevel)`
+   * annotation so both accept the same strings — issue #278 item 4.
+   */
+  def parseLogLevelString(level: String): Either[String, InternalLogLevel] =
+    level.toLowerCase match {
+      case "debug"   => Right(InternalLogLevel.Debug)
+      case "info"    => Right(InternalLogLevel.Info)
+      case "warning" => Right(InternalLogLevel.Warning)
+      case "error"   => Right(InternalLogLevel.Error)
+      case "fatal"   => Right(InternalLogLevel.Fatal)
+      case other =>
+        Left(s"Unknown log level '$other'. Valid values: debug, info, warning, error, fatal.")
+    }
+
+  /**
+   * Parse a log-level name, failing loud (throwing) on an unknown value rather
+   * than silently falling back to Info. Used by both config paths.
+   */
+  def parseLogLevelOrThrow(level: String): InternalLogLevel =
+    parseLogLevelString(level).fold(msg => throw new IllegalArgumentException(msg), identity)
 
   /**
    * Parse a `ZIO_BDD_*_PARALLELISM` env value: `"auto"` → `Some(0)`, a valid

--- a/core/src/test/scala/zio/bdd/core/LogLevelParsingSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/LogLevelParsingSpec.scala
@@ -1,0 +1,46 @@
+package zio.bdd.core
+
+import zio.ZIO
+import zio.bdd.ZIOBDDTask
+import zio.test.*
+
+/**
+ * Gate for issue #289: `@Suite(logLevel)` / `--log-level` must accept all five
+ * `InternalLogLevel` names and reject an unknown value loudly instead of
+ * silently falling back to Info.
+ */
+object LogLevelParsingSpec extends ZIOSpecDefault {
+
+  def spec = suite("log-level parsing")(
+    test("accepts all five level names (case-insensitive)") {
+      assertTrue(
+        ZIOBDDTask.parseLogLevelString("debug") == Right(InternalLogLevel.Debug),
+        ZIOBDDTask.parseLogLevelString("info") == Right(InternalLogLevel.Info),
+        ZIOBDDTask.parseLogLevelString("warning") == Right(InternalLogLevel.Warning),
+        ZIOBDDTask.parseLogLevelString("error") == Right(InternalLogLevel.Error),
+        ZIOBDDTask.parseLogLevelString("fatal") == Right(InternalLogLevel.Fatal),
+        ZIOBDDTask.parseLogLevelString("WARNING") == Right(InternalLogLevel.Warning),
+        ZIOBDDTask.parseLogLevelString("Fatal") == Right(InternalLogLevel.Fatal)
+      )
+    },
+    test("rejects an unknown value with a message naming the valid set") {
+      val result = ZIOBDDTask.parseLogLevelString("verbose")
+      assertTrue(
+        result.isLeft,
+        result.swap.exists(_.contains("verbose")),
+        result.swap.exists(m => m.contains("warning") && m.contains("fatal"))
+      )
+    },
+    test("throwing wrapper fails loud on an unknown value") {
+      for {
+        exit <- ZIO.attempt(ZIOBDDTask.parseLogLevelOrThrow("nope")).exit
+      } yield assertTrue(
+        exit.isFailure,
+        exit.causeOption.exists(_.failures.exists(_.isInstanceOf[IllegalArgumentException]))
+      )
+    },
+    test("throwing wrapper returns the level for a valid value") {
+      assertTrue(ZIOBDDTask.parseLogLevelOrThrow("fatal") == InternalLogLevel.Fatal)
+    }
+  )
+}

--- a/docs/reporters.md
+++ b/docs/reporters.md
@@ -269,11 +269,11 @@ stdout.
 
 **Configuring the minimum level (`@Suite(logLevel)` / `--log-level`):**
 
-Only three strings are recognized (case-insensitive): `"debug"`, `"info"`, `"error"`.
-`"warning"` and `"fatal"` are **not** parseable as a minimum level — passing either falls back
-to `Info`. On the CLI (`--log-level warning`) the fallback is logged as a warning
-(`Unknown log level '...', defaulting to Info`); on the `@Suite(logLevel = "...")` annotation
-path the fallback is silent. See `ZIOBDDFramework.scala:322-343`.
+All five levels are recognized (case-insensitive): `"debug"`, `"info"`, `"warning"`, `"error"`,
+`"fatal"`. An unrecognised value **fails loud** — both `--log-level` and `@Suite(logLevel = "...")`
+throw `IllegalArgumentException("Unknown log level '...'. Valid values: debug, info, warning,
+error, fatal.")` rather than silently falling back to `Info`. See
+`ZIOBDDTask.parseLogLevelString` / `parseLogLevelOrThrow`.
 
 ---
 

--- a/docs/running.md
+++ b/docs/running.md
@@ -35,7 +35,7 @@ public @interface Suite {
 | `scenarioParallelism` | `int` | `0` | Maximum number of scenarios executed concurrently within a single feature. `0` means auto (use available processors); `1` forces sequential. See [Parallelism](#parallelism) below. |
 | `includeTags` | `String[]` | `{}` | When non-empty, only scenarios that carry at least one of these tags are executed. |
 | `excludeTags` | `String[]` | `{}` | Scenarios carrying any of these tags are skipped. |
-| `logLevel` | `String` | `"info"` | Minimum log level captured during step execution: `"debug"`, `"info"`, `"error"`. |
+| `logLevel` | `String` | `"info"` | Minimum log level captured during step execution: `"debug"`, `"info"`, `"warning"`, `"error"`, `"fatal"` (case-insensitive). An unrecognised value fails the run loudly rather than silently defaulting. |
 | `stepTimeout` | `int` | `0` | Maximum wall-clock time in **seconds** for a single step. `0` means no timeout. Applies to every step in the suite unless overridden in the suite class — see [Step timeout](#step-timeout) below. |
 
 **Deprecated field:** `featureDir` (singular, `String`) is still accepted for backward
@@ -142,7 +142,7 @@ sbt "testOnly com.example.MySuite -- \
 | `--scenario-parallelism` | `<n>` | Maximum number of scenarios executed concurrently within a single feature. Independent from feature-level parallelism. Default: `1`. | `--scenario-parallelism 2` |
 | `--dry-run` | _(none)_ | Enable dry-run mode (see below). | `--dry-run` |
 | `--focused` | _(none)_ | Strips scenarios excluded by a name or tag filter from the report entirely, instead of listing them as `IGNORED`. Execution is unaffected — only report output changes. Intended for IDE test runners driving a single scenario/feature. | `--focused` |
-| `--log-level` | `debug\|info\|error` | Minimum log level captured during step execution. Overrides `logLevel` from the annotation. | `--log-level debug` |
+| `--log-level` | `debug\|info\|warning\|error\|fatal` | Minimum log level captured during step execution (case-insensitive). An unrecognised value fails the run loudly. Overrides `logLevel` from the annotation. | `--log-level debug` |
 | `--reporter` | `pretty\|junitxml` | Reporter to use. May be repeated. Overrides `reporters` from the annotation when specified. | `--reporter junitxml` |
 
 **Precedence:** CLI flags take precedence over `@Suite` annotation fields. When a CLI


### PR DESCRIPTION
## Summary

Accept all five log levels (case-insensitive) via a shared parseLogLevelString utility. Reject unknown values loudly on both CLI and annotation paths (previously silent fallback to Info).

Updates docs for reporters and running sections to reflect the fix.

Closes #289

Part of #278 (item 4).