### PR TITLE
fix(rift): honor an authored recordRequests in a raw imposter document

### DIFF
--- a/docs/mock-advanced.md
+++ b/docs/mock-advanced.md
@@ -302,6 +302,14 @@ need full-fidelity access to a backend's raw feature set (e.g. a Mountebank
 imposter field or a WireMock stub-mapping option the canonical model doesn't
 expose), not for anything you expect to run against a second adapter.
 
+The Rift adapter does rewrite two fields of a raw imposter document so the space
+is manageable: it forces the imposter's `port` to its own managed pool port (so
+the `"port"` you author is ignored — hence the `"port":0` in the example below),
+and it injects `recordRequests: true` **only when the field is absent**, so
+`received()` works out of the box. Author an explicit `"recordRequests": false`
+to opt a raw Rift imposter out of request recording — it is honoured, not
+overridden.
+
 A malformed `NativeSpec` fails fast at provision-time — invalid JSON syntax is
 rejected locally with `MockError.InvalidDefinition`, and a syntactically valid
 document the backend itself refuses surfaces as `MockError.CommunicationError`

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -277,7 +277,10 @@ private[rift] object RiftProtocol:
       r.delay.map(d => "_behaviors" -> Json.Obj("wait" -> Json.Num(d.toMillis.toInt))).toList
     Json.Obj((("is" -> isObj) :: behaviors)*)
 
-  /** Rebuild a raw imposter doc, forcing our pool port and recording on. */
+  /**
+   * Rebuild a raw imposter doc, forcing our pool port; recording defaults on
+   * unless the doc opts out.
+   */
   def imposterFromRaw(port: Int, name: String, raw: String): Either[String, (Json, Int)] =
     raw.fromJson[Json].flatMap {
       case obj: Json.Obj =>
@@ -288,7 +291,7 @@ private[rift] object RiftProtocol:
           "port"           -> Json.Num(port),
           "protocol"       -> fields.getOrElse("protocol", Json.Str("http")),
           "name"           -> fields.getOrElse("name", Json.Str(name)),
-          "recordRequests" -> Json.Bool(true)
+          "recordRequests" -> fields.getOrElse("recordRequests", Json.Bool(true))
         )
         Right((forced, stubCount))
       case _ => Left("raw Rift source must be a JSON object (an imposter document)")

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
@@ -264,13 +264,25 @@ object RiftProtocolSpec extends ZIOSpecDefault:
         RiftProtocol.imposterFromRaw(1, "x", "[1,2,3]").isLeft
       )
     },
-    test("imposterFromRaw forces our port and recordRequests while keeping stubs") {
+    test("imposterFromRaw forces our port and defaults recordRequests on when the doc omits it") {
       val raw           = """{"port":9999,"protocol":"http","stubs":[{"predicates":[],"responses":[]}]}"""
       val Right((j, n)) = RiftProtocol.imposterFromRaw(4600, "json", raw): @unchecked
       assertTrue(
         j / "port" == Json.Num(4600),
         j / "recordRequests" == Json.Bool(true),
         n == 1
+      )
+    },
+    test("imposterFromRaw honors an authored recordRequests, still forcing our port (#294)") {
+      val off              = """{"port":9999,"recordRequests":false,"stubs":[]}"""
+      val on               = """{"port":9999,"recordRequests":true,"stubs":[]}"""
+      val Right((jOff, _)) = RiftProtocol.imposterFromRaw(4600, "json", off): @unchecked
+      val Right((jOn, _))  = RiftProtocol.imposterFromRaw(4600, "json", on): @unchecked
+      assertTrue(
+        jOff / "recordRequests" == Json.Bool(false), // authored false preserved, not overridden
+        jOff / "port" == Json.Num(4600),             // port still forced
+        jOn / "recordRequests" == Json.Bool(true),
+        jOn / "port" == Json.Num(4600)
       )
     }
   )


### PR DESCRIPTION
Honor an author's explicit \`recordRequests\` in a raw imposter document routed through \`RiftProtocol.imposterFromRaw\` (both container and embedded Rift adapters). The adapter now injects the default \`recordRequests: true\` only when the field is absent, so an authored \`recordRequests: false\` opts a raw Rift source out of request recording instead of being silently overridden. Adds a gate test and documents the behavior in docs/mock-advanced.md §7.

Closes #294