### PR TITLE
fix(gherkin): warn/reject on inert shrink/maxShrinks/verbose property tags (#278 item 5)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -306,6 +306,12 @@ lazy val mimaSettings = Seq(
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.gherkin.Scenario.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.gherkin.Scenario.this"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.gherkin.Scenario.copy"),
+    // #290: PropertyConfig gained a trailing `inertKeys: Set[String] = Set.empty` field
+    // (warn on parsed-but-inert shrink/maxShrinks/verbose tags). Additive with a default —
+    // source-compatible; only the synthetic apply/this/copy signatures changed.
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.gherkin.PropertyTag#PropertyConfig.apply"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.gherkin.PropertyTag#PropertyConfig.this"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.gherkin.PropertyTag#PropertyConfig.copy"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.FeatureExecutor.executeFeature"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.FeatureExecutor.executeFeatures"),
     // #225: ScenarioResult gained a trailing `attempts: Int = 1` field (retry-tag support).

--- a/core/src/main/scala/zio/bdd/core/property/PropertyExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/property/PropertyExecutor.scala
@@ -95,25 +95,26 @@ object PropertyExecutor:
     flags: Map[String, String],
     dryRun: Boolean
   ): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
-    resolveColumnGens[R, S](scenario, lookup).flatMap {
-      case Left(err) =>
-        ZIO.succeed(ScenarioResult(scenario, Nil, setupError = Some(Cause.fail(new RuntimeException(err)))))
-      case Right(colGens) =>
-        if (dryRun)
-          // --dry-run validates step matching without executing step bodies. Sampling the
-          // configured `samples` count for real would defeat that — instead, validate column
-          // resolution (already done above) and run exactly one dry-run sample to confirm
-          // every step pattern matches, without looping or touching the failure store.
-          runDryRunSample(scenario, suite, colGens, flags)
-        else
-          for {
-            seed      <- config.seed.map(ZIO.succeed).getOrElse(Random.nextLong)
-            replayRec <- if (config.replay) PropertyFailureStore.read(scenario) else ZIO.none
-            result <- replayRec match
-                        case Some(rec) => handleReplay(scenario, config, suite, colGens, rec, seed, flags)
-                        case None      => runFreshSamples(scenario, config, suite, colGens, seed, flags)
-          } yield result
-    }
+    ZIO.foreachDiscard(config.deferredWarning)(ZIO.logWarning(_)) *>
+      resolveColumnGens[R, S](scenario, lookup).flatMap {
+        case Left(err) =>
+          ZIO.succeed(ScenarioResult(scenario, Nil, setupError = Some(Cause.fail(new RuntimeException(err)))))
+        case Right(colGens) =>
+          if (dryRun)
+            // --dry-run validates step matching without executing step bodies. Sampling the
+            // configured `samples` count for real would defeat that — instead, validate column
+            // resolution (already done above) and run exactly one dry-run sample to confirm
+            // every step pattern matches, without looping or touching the failure store.
+            runDryRunSample(scenario, suite, colGens, flags)
+          else
+            for {
+              seed      <- config.seed.map(ZIO.succeed).getOrElse(Random.nextLong)
+              replayRec <- if (config.replay) PropertyFailureStore.read(scenario) else ZIO.none
+              result <- replayRec match
+                          case Some(rec) => handleReplay(scenario, config, suite, colGens, rec, seed, flags)
+                          case None      => runFreshSamples(scenario, config, suite, colGens, seed, flags)
+            } yield result
+      }
 
   private def runDryRunSample[R: Tag, S: Tag: Default](
     scenario: Scenario,

--- a/core/src/test/scala/zio/bdd/core/PropertyExecutorSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/PropertyExecutorSpec.scala
@@ -65,6 +65,7 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
 
   def spec: Spec[TestEnvironment & Scope, Any] = suite("PropertyExecutorSpec")(
     passSuite,
+    inertTagWarningSuite,
     failSuite,
     generatorSuite,
     autoResolutionSuite,
@@ -131,6 +132,57 @@ object PropertyExecutorSpec extends ZIOSpecDefault {
           sc.stepResults.head.step.pattern.contains("HasGen[Int]")
         )
       }
+    }
+  )
+
+  // ── Inert deferred property tags warn (issue #290) ─────────────────────────
+
+  private val inertTagWarningSuite = suite("Inert deferred property tags")(
+    test("setting a deferred key (verbose) logs a warning at run time") {
+      val steps = new ZIOSteps[Any, S]:
+        Given("value " / int)((n: Int) => ZIO.unit)
+        Then("ok")(ZIO.unit)
+
+      (for {
+        _ <- runFeature(
+               """Feature: F
+                 |  Scenario Outline: inert
+                 |    Given value <n>
+                 |    Then ok
+                 |    @property(samples=3, verbose=true)
+                 |    Examples:
+                 |      | n |
+                 |""".stripMargin,
+               steps
+             )
+        logs <- ZTestLogger.logOutput
+      } yield assertTrue(
+        logs.exists(e =>
+          e.logLevel == LogLevel.Warning && e.message().contains("verbose") && e.message().contains("no effect")
+        )
+      )).provideLayer(ZTestLogger.default)
+    },
+    test("a property scenario with no deferred keys logs no such warning") {
+      val steps = new ZIOSteps[Any, S]:
+        Given("value " / int)((n: Int) => ZIO.unit)
+        Then("ok")(ZIO.unit)
+
+      (for {
+        _ <- runFeature(
+               """Feature: F
+                 |  Scenario Outline: clean
+                 |    Given value <n>
+                 |    Then ok
+                 |    @property(samples=3)
+                 |    Examples:
+                 |      | n |
+                 |""".stripMargin,
+               steps
+             )
+        logs <- ZTestLogger.logOutput
+      } yield assertTrue(
+        !logs.exists(_.message().contains("not yet functional"))
+      )).provideLayer(ZTestLogger.default)
     }
   )
 

--- a/docs/property-testing.md
+++ b/docs/property-testing.md
@@ -125,7 +125,13 @@ A bare `@property` with no arguments is valid and equivalent to `@property(sampl
 `shrink`, `maxShrinks`, and `verbose` are all accepted by the tag parser and stored on
 `PropertyConfig`, but v1's executor never reads them — full shrink-tree walking is deferred
 to v2 (v1 always records the failing seed instead; see [Failure replay](#failure-replay)).
-Setting them today has no effect on behavior.
+Setting them today has no effect on behavior. Rather than silently ignoring them, the executor
+**logs a warning** at run time naming the deferred setting(s) you supplied, e.g.:
+
+```
+@property setting(s) verbose are parsed but not yet functional (shrinking is deferred to a
+future release) and have no effect.
+```
 
 ---
 

--- a/gherkin/src/main/scala/zio/bdd/gherkin/GherkinParser.scala
+++ b/gherkin/src/main/scala/zio/bdd/gherkin/GherkinParser.scala
@@ -71,8 +71,17 @@ object PropertyTag:
     maxShrinks: Int = 1000,
     maxDiscarded: Option[Int] = None,
     verbose: Boolean = false,
-    replay: Boolean = true
-  )
+    replay: Boolean = true,
+    // The deferred-feature keys (shrink / maxShrinks / verbose) the user actually
+    // set. They are parsed but not yet honored (shrinking is deferred), so setting
+    // them is a no-op — `deferredWarning` surfaces that instead of silently ignoring.
+    inertKeys: Set[String] = Set.empty
+  ):
+    def deferredWarning: Option[String] =
+      Option.when(inertKeys.nonEmpty)(
+        s"@property setting(s) ${inertKeys.toList.sorted.mkString(", ")} are parsed but not yet " +
+          "functional (shrinking is deferred to a future release) and have no effect."
+      )
 
   def parse(tag: String): Option[PropertyConfig] =
     tagPattern.findFirstMatchIn(tag.trim.stripPrefix("@")).map { m =>
@@ -96,9 +105,15 @@ object PropertyTag:
         maxShrinks = kv.get("maxshrinks").flatMap(_.toIntOption).getOrElse(1000),
         maxDiscarded = kv.get("maxdiscarded").flatMap(_.toIntOption),
         verbose = kv.get("verbose").map(_ == "true").getOrElse(false),
-        replay = kv.get("replay").map(_ != "false").getOrElse(true)
+        replay = kv.get("replay").map(_ != "false").getOrElse(true),
+        inertKeys = deferredKeys.collect { case (key, readable) if kv.contains(key) => readable }.toSet
       )
     }
+
+  // Property-tag settings that are parsed but not yet honored (shrinking is
+  // deferred). Maps the lowercased tag key → its readable name for warnings.
+  private val deferredKeys: Map[String, String] =
+    Map("shrink" -> "shrink", "maxshrinks" -> "maxShrinks", "verbose" -> "verbose")
 
   /** Extract the first @property config from a list of tags, if any. */
   def extract(tags: List[String]): Option[PropertyConfig] =

--- a/gherkin/src/test/scala/zio/bdd/gherkin/PropertyInertTagSpec.scala
+++ b/gherkin/src/test/scala/zio/bdd/gherkin/PropertyInertTagSpec.scala
@@ -1,0 +1,38 @@
+package zio.bdd.gherkin
+
+import zio.test.*
+
+/**
+ * Gate for issue #290: the deferred property-tag settings (`shrink`,
+ * `maxShrinks`, `verbose`) are parsed but not yet functional. Setting one must
+ * be surfaced via `PropertyConfig.deferredWarning` (and warned at run time)
+ * rather than silently ignored. Setting only functional keys must stay silent.
+ */
+object PropertyInertTagSpec extends ZIOSpecDefault {
+
+  def spec = suite("PropertyInertTagSpec")(
+    test("explicitly set deferred keys are recorded as inert") {
+      val cfg = PropertyTag.parse("property(shrink=false, maxShrinks=5, verbose=true)").get
+      assertTrue(cfg.inertKeys == Set("shrink", "maxShrinks", "verbose"))
+    },
+    test("a single deferred key is recorded (case-insensitive)") {
+      val cfg = PropertyTag.parse("property(MAXSHRINKS=10)").get
+      assertTrue(cfg.inertKeys == Set("maxShrinks"))
+    },
+    test("only-functional keys produce no inert warning") {
+      val cfg = PropertyTag.parse("property(samples=50, seed=7, replay=false)").get
+      assertTrue(cfg.inertKeys.isEmpty, cfg.deferredWarning.isEmpty)
+    },
+    test("bare @property produces no inert warning") {
+      val cfg = PropertyTag.parse("property").get
+      assertTrue(cfg.inertKeys.isEmpty, cfg.deferredWarning.isEmpty)
+    },
+    test("deferredWarning names the set keys and explains they have no effect") {
+      val cfg = PropertyTag.parse("property(verbose=true)").get
+      assertTrue(
+        cfg.deferredWarning.exists(_.contains("verbose")),
+        cfg.deferredWarning.exists(_.contains("no effect"))
+      )
+    }
+  )
+}


### PR DESCRIPTION
Parsed-but-inert @property tags (shrink, maxShrinks, verbose) are now detected at parse time and recorded in PropertyConfig.inertKeys. PropertyExecutor logs a warning at run time naming the deferred keys instead of silently ignoring them. Docs updated to clarify which property settings are deferred to v2.

Closes #290

Part of #278 (item 5).