### PR TITLE
chore(core): remove or mark test-only the dead private[bdd] reset methods (#278 item 6)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -314,6 +314,12 @@ lazy val mimaSettings = Seq(
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.gherkin.PropertyTag#PropertyConfig.copy"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.FeatureExecutor.executeFeature"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.FeatureExecutor.executeFeatures"),
+    // #291: the test-only `reset` on FeatureContext/Stage was renamed `resetForTest` to
+    // stop it reading as a production reset path (it never was — clearing is via
+    // freshScope/locallyScoped). `private[bdd]` compiles to public bytecode, so the rename
+    // drops the old name from the binary API.
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.FeatureContext.reset"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.step.Stage.reset"),
     // #225: ScenarioResult gained a trailing `attempts: Int = 1` field (retry-tag support).
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.ScenarioResult.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("zio.bdd.core.ScenarioResult.this"),

--- a/core/src/main/scala/zio/bdd/core/FeatureContext.scala
+++ b/core/src/main/scala/zio/bdd/core/FeatureContext.scala
@@ -89,8 +89,12 @@ object FeatureContext {
   def remove[A: ClassTag]: UIO[Unit] =
     ref.get.flatMap(_.update(m => m - key[A]))
 
-  /** Reset all stored values. Called by FeatureExecutor between features. */
-  private[bdd] def reset: UIO[Unit] = ref.get.flatMap(_.set(Map.empty))
+  /**
+   * Test-only: clear the store. Production per-feature clearing is done by
+   * `FeatureExecutor` via `freshScope` (a fresh scoped cell), NOT this method —
+   * it exists only so unit tests can reset the shared out-of-feature store.
+   */
+  private[bdd] def resetForTest: UIO[Unit] = ref.get.flatMap(_.set(Map.empty))
 
   private def key[A: ClassTag]: String = implicitly[ClassTag[A]].runtimeClass.getName
 }

--- a/core/src/main/scala/zio/bdd/core/step/Stage.scala
+++ b/core/src/main/scala/zio/bdd/core/step/Stage.scala
@@ -82,8 +82,12 @@ object Stage {
   def remove[A: ClassTag]: UIO[Unit] =
     ref.update(m => m - key[A])
 
-  /** Reset all staged values. Called by ScenarioExecutor between scenarios. */
-  private[bdd] def reset: UIO[Unit] = ref.set(Map.empty)
+  /**
+   * Test-only: clear the staged values. Production per-scenario clearing is
+   * done by `ScenarioExecutor` via `ref.locallyScoped(Map.empty)`, NOT this
+   * method — it exists only so unit tests can reset the store in isolation.
+   */
+  private[bdd] def resetForTest: UIO[Unit] = ref.set(Map.empty)
 
   private def key[A: ClassTag]: String = implicitly[ClassTag[A]].runtimeClass.getName
 }

--- a/core/src/test/scala/zio/bdd/core/FeatureContextSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/FeatureContextSpec.scala
@@ -22,20 +22,20 @@ object FeatureContextSpec extends ZIOSpecDefault {
   private val putGet = suite("FeatureContext.put / FeatureContext.get")(
     test("put then get returns the stored value") {
       for {
-        _      <- FeatureContext.reset
+        _      <- FeatureContext.resetForTest
         _      <- FeatureContext.put(FeatureToken("hello"))
         result <- FeatureContext.get[FeatureToken]
       } yield assertTrue(result == FeatureToken("hello"))
     },
     test("get on missing type returns FeatureContextError.NotFound") {
       for {
-        _      <- FeatureContext.reset
+        _      <- FeatureContext.resetForTest
         result <- FeatureContext.get[FeatureToken].either
       } yield assert(result)(isLeft(isSubtype[FeatureContextError.NotFound](anything)))
     },
     test("second put overwrites the first") {
       for {
-        _      <- FeatureContext.reset
+        _      <- FeatureContext.resetForTest
         _      <- FeatureContext.put(FeatureToken("first"))
         _      <- FeatureContext.put(FeatureToken("second"))
         result <- FeatureContext.get[FeatureToken]
@@ -48,13 +48,13 @@ object FeatureContextSpec extends ZIOSpecDefault {
   private val getOrElseOps = suite("FeatureContext.getOrElse")(
     test("returns default when not stored") {
       for {
-        _      <- FeatureContext.reset
+        _      <- FeatureContext.resetForTest
         result <- FeatureContext.getOrElse(FeatureToken("default"))
       } yield assertTrue(result == FeatureToken("default"))
     },
     test("returns stored value when present") {
       for {
-        _      <- FeatureContext.reset
+        _      <- FeatureContext.resetForTest
         _      <- FeatureContext.put(FeatureToken("stored"))
         result <- FeatureContext.getOrElse(FeatureToken("default"))
       } yield assertTrue(result == FeatureToken("stored"))
@@ -66,13 +66,13 @@ object FeatureContextSpec extends ZIOSpecDefault {
   private val getOptionOps = suite("FeatureContext.getOption")(
     test("returns None when not stored") {
       for {
-        _      <- FeatureContext.reset
+        _      <- FeatureContext.resetForTest
         result <- FeatureContext.getOption[FeatureToken]
       } yield assertTrue(result.isEmpty)
     },
     test("returns Some when stored") {
       for {
-        _      <- FeatureContext.reset
+        _      <- FeatureContext.resetForTest
         _      <- FeatureContext.put(FeatureToken("present"))
         result <- FeatureContext.getOption[FeatureToken]
       } yield assertTrue(result.contains(FeatureToken("present")))
@@ -84,7 +84,7 @@ object FeatureContextSpec extends ZIOSpecDefault {
   private val modifyOps = suite("FeatureContext.modify")(
     test("modify updates the stored value") {
       for {
-        _      <- FeatureContext.reset
+        _      <- FeatureContext.resetForTest
         _      <- FeatureContext.put(FeatureToken("lower"))
         _      <- FeatureContext.modify[FeatureToken](t => t.copy(value = t.value.toUpperCase))
         result <- FeatureContext.get[FeatureToken]
@@ -92,7 +92,7 @@ object FeatureContextSpec extends ZIOSpecDefault {
     },
     test("modify is a no-op when value is not stored") {
       for {
-        _      <- FeatureContext.reset
+        _      <- FeatureContext.resetForTest
         _      <- FeatureContext.modify[FeatureToken](t => t.copy(value = "should not appear"))
         result <- FeatureContext.getOption[FeatureToken]
       } yield assertTrue(result.isEmpty)
@@ -104,14 +104,14 @@ object FeatureContextSpec extends ZIOSpecDefault {
   private val setRemoveOps = suite("FeatureContext.set / remove")(
     test("set stores a value") {
       for {
-        _      <- FeatureContext.reset
+        _      <- FeatureContext.resetForTest
         _      <- FeatureContext.set(FeatureToken("via-set"))
         result <- FeatureContext.get[FeatureToken]
       } yield assertTrue(result == FeatureToken("via-set"))
     },
     test("remove removes the stored value") {
       for {
-        _      <- FeatureContext.reset
+        _      <- FeatureContext.resetForTest
         _      <- FeatureContext.put(FeatureToken("to-remove"))
         _      <- FeatureContext.remove[FeatureToken]
         result <- FeatureContext.getOption[FeatureToken]
@@ -156,7 +156,7 @@ object FeatureContextSpec extends ZIOSpecDefault {
 
   // ── Values are reset between features ────────────────────────────────────
   //
-  // FeatureExecutor calls FeatureContext.reset at the start of each feature.
+  // FeatureExecutor clears the store per feature via freshScope (not resetForTest).
   // We run two sequential features: the first stores a value, the second checks
   // that the value is no longer present.
 

--- a/core/src/test/scala/zio/bdd/core/step/StageSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/step/StageSpec.scala
@@ -20,20 +20,20 @@ object StageSpec extends ZIOSpecDefault {
   private val putGet = suite("Stage.put / Stage.get")(
     test("put then get returns the stored value") {
       for {
-        _      <- Stage.reset
+        _      <- Stage.resetForTest
         _      <- Stage.put(Payload("hello"))
         result <- Stage.get[Payload]
       } yield assertTrue(result == Payload("hello"))
     },
     test("get on missing type returns StagingError.NotFound") {
       for {
-        _      <- Stage.reset
+        _      <- Stage.resetForTest
         result <- Stage.get[Payload].either
       } yield assert(result)(isLeft(isSubtype[StagingError.NotFound](anything)))
     },
     test("second put overwrites the first") {
       for {
-        _      <- Stage.reset
+        _      <- Stage.resetForTest
         _      <- Stage.put(Payload("first"))
         _      <- Stage.put(Payload("second"))
         result <- Stage.get[Payload]
@@ -46,13 +46,13 @@ object StageSpec extends ZIOSpecDefault {
   private val getOrElseOps = suite("Stage.getOrElse")(
     test("returns default when not staged") {
       for {
-        _      <- Stage.reset
+        _      <- Stage.resetForTest
         result <- Stage.getOrElse(Payload("default"))
       } yield assertTrue(result == Payload("default"))
     },
     test("returns staged value when present") {
       for {
-        _      <- Stage.reset
+        _      <- Stage.resetForTest
         _      <- Stage.put(Payload("staged"))
         result <- Stage.getOrElse(Payload("default"))
       } yield assertTrue(result == Payload("staged"))
@@ -64,13 +64,13 @@ object StageSpec extends ZIOSpecDefault {
   private val getOptionOps = suite("Stage.getOption")(
     test("returns None when not staged") {
       for {
-        _      <- Stage.reset
+        _      <- Stage.resetForTest
         result <- Stage.getOption[Payload]
       } yield assertTrue(result.isEmpty)
     },
     test("returns Some when staged") {
       for {
-        _      <- Stage.reset
+        _      <- Stage.resetForTest
         _      <- Stage.put(Payload("present"))
         result <- Stage.getOption[Payload]
       } yield assertTrue(result.contains(Payload("present")))
@@ -82,7 +82,7 @@ object StageSpec extends ZIOSpecDefault {
   private val modifyOps = suite("Stage.modify")(
     test("modify updates the staged value") {
       for {
-        _      <- Stage.reset
+        _      <- Stage.resetForTest
         _      <- Stage.put(Payload("original"))
         _      <- Stage.modify[Payload](p => p.copy(value = p.value.toUpperCase))
         result <- Stage.get[Payload]
@@ -90,7 +90,7 @@ object StageSpec extends ZIOSpecDefault {
     },
     test("modify is a no-op when value is not staged") {
       for {
-        _      <- Stage.reset
+        _      <- Stage.resetForTest
         _      <- Stage.modify[Payload](p => p.copy(value = "should not appear"))
         result <- Stage.getOption[Payload]
       } yield assertTrue(result.isEmpty)
@@ -102,7 +102,7 @@ object StageSpec extends ZIOSpecDefault {
   private val removeOps = suite("Stage.remove")(
     test("remove removes the staged value") {
       for {
-        _      <- Stage.reset
+        _      <- Stage.resetForTest
         _      <- Stage.put(Payload("to-remove"))
         _      <- Stage.remove[Payload]
         result <- Stage.getOption[Payload]
@@ -110,7 +110,7 @@ object StageSpec extends ZIOSpecDefault {
     },
     test("remove on absent key is a no-op") {
       for {
-        _ <- Stage.reset
+        _ <- Stage.resetForTest
         _ <- Stage.remove[Payload]
       } yield assertCompletes
     }
@@ -118,7 +118,7 @@ object StageSpec extends ZIOSpecDefault {
 
   // ── Reset between scenarios ───────────────────────────────────────────────
   //
-  // ScenarioExecutor calls Stage.reset at the start of each scenario.
+  // ScenarioExecutor clears the store per scenario via locallyScoped (not resetForTest).
   // We verify this by running two sequential scenarios: the first stages a
   // value, and the second checks that it is no longer present.
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -538,8 +538,8 @@ mid-step. `FeatureContext.freshScope` allocates a new synchronized cell and
 `locallyScoped`s *that*, so each feature — including parallel features — is
 isolated while the scenarios within one feature share a single cell.
 
-The `private[bdd] def reset` method on both `Stage` and `FeatureContext` is
-**test-only** — it exists for unit-testing the stores in isolation and is
+The `private[bdd] def resetForTest` method on both `Stage` and `FeatureContext`
+is **test-only** — it exists for unit-testing the stores in isolation and is
 never called by `ScenarioExecutor` or `FeatureExecutor`. Do not rely on it to
 understand production clearing behavior; the `locallyScoped` calls above are
 the actual production clearing path.


### PR DESCRIPTION
Rename the misleading test-only reset → resetForTest, fix false scaladocs claiming production use, no behavior change, add MIMA exclusions.

Closes #291
Part of #278 (item 6).