### PR TITLE
Container Rift adapter: authored fixed port in pool range can collide with auto-assigned imposter

### DIFF
--- a/docs/mock-dsl.md
+++ b/docs/mock-dsl.md
@@ -34,8 +34,11 @@ mock(rule1, rule2).source    // MockSource.Dsl(spec)
 dslSource(rule1, rule2)      // shorthand for mock(rules*).source
 ```
 
-`MockSpec` also carries an *advisory* `port` (`.onPort(8080)`) — it's always
-stripped on provisioning; the backend assigns a fresh free port regardless.
+`MockSpec` also carries an opt-in fixed `port` (`.onPort(8080)`, #211): when set,
+the backend binds the imposter on exactly that port instead of an auto-assigned
+one; when omitted, a fresh free port is chosen. If a fixed port happens to fall
+inside a backend's managed port pool (e.g. the container Rift adapter's pool), it
+is claimed from that pool so an auto-assigned imposter can't collide with it (#213).
 
 ---
 

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftEndpoint.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftEndpoint.scala
@@ -22,6 +22,15 @@ private[rift] trait RiftEndpoint:
   /** Take an imposter port from the pool, or fail if the pool is exhausted. */
   def acquirePort: IO[MockError, Int]
 
+  /**
+   * Claim a specific (caller-authored) port from the pool's free-list. Returns
+   * `true` if the port was in the pool (and is now removed, so `acquirePort`
+   * can't hand it out concurrently), `false` if it was out of range (pool
+   * untouched). `true` means the port is pool-managed and should be released on
+   * destroy; `false` means it's a fixed out-of-pool port the pool never owns.
+   */
+  def claimPort(port: Int): UIO[Boolean]
+
   /** Return a port to the pool after an imposter is destroyed. */
   def releasePort(port: Int): UIO[Unit]
 
@@ -44,6 +53,9 @@ private[rift] object RiftEndpoint:
         case head :: tail => (ZIO.succeed(head), tail)
         case Nil          => (ZIO.fail(MockError.ProvisionFailed("Rift imposter port pool exhausted")), Nil)
       }.flatten
+
+    def claimPort(port: Int): UIO[Boolean] =
+      free.modify(list => if list.contains(port) then (true, list.filterNot(_ == port)) else (false, list))
 
     def releasePort(port: Int): UIO[Unit] = free.update(port :: _)
 

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -351,7 +351,17 @@ private[rift] final case class RiftMockControl(
   // port the share-nothing default holds: take a pool port and return it to the pool on failure.
   private def serveImposter(src: NormalizedSource): IO[MockError, MockSpace] =
     src.authoredPort match
-      case Some(port) => standImposter(port, src, pooled = false)
+      case Some(port) =>
+        // Claim an authored port from the pool free-list if it falls in range, so a
+        // concurrent auto-`provision` can't `acquirePort` the same number and stand up a
+        // second imposter on it (#213). An in-range port is then pool-managed (returns on
+        // destroy); an out-of-range fixed port leaves the pool untouched (#211).
+        endpoint
+          .claimPort(port)
+          .flatMap(claimed =>
+            standImposter(port, src, pooled = claimed)
+              .onError(_ => ZIO.when(claimed)(endpoint.releasePort(port)))
+          )
       case None =>
         endpoint.acquirePort.flatMap(port =>
           standImposter(port, src, pooled = true).onError(_ => endpoint.releasePort(port))
@@ -412,8 +422,10 @@ private[rift] final case class RiftMockControl(
       u   <- url(s"/imposters/${imp.port}")
       res <- send(Request(method = HttpMethod.DELETE, url = u))
       _   <- ZIO.unless(res._1 == 404)(expectSuccess(s"destroy imposter ${imp.port}", res))
-      _   <- ZIO.when(imp.pooled)(endpoint.releasePort(imp.port)) // never return an authored fixed port (#211)
-      _   <- spaces.update(_ - space.id)
+      _ <- ZIO.when(imp.pooled)(
+             endpoint.releasePort(imp.port)
+           ) // return only pool-managed ports; never an out-of-pool fixed port (#211, #213)
+      _ <- spaces.update(_ - space.id)
     yield ()
 
   private def piReceived(imp: Imposter): IO[MockError, List[RecordedRequest]] =
@@ -619,7 +631,7 @@ private[rift] object RiftMockControl:
     port: Int,
     stubs: Ref[Vector[RuleId]],
     scenarios: Ref[Map[String, ScenarioState]], // defined scenario name -> initial state (for reset)
-    pooled: Boolean                             // port drawn from the endpoint pool (vs. a caller-authored fixed port, #211)
+    pooled: Boolean                             // port is pool-managed → return on destroy: auto-acquired, or an in-range authored port claimed from the pool (#211, #213). An out-of-pool fixed port is false.
   )
   final case class CorrSpace(
     port: Int,

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -128,6 +128,36 @@ object RiftMockControlSpec extends ZIOSpecDefault:
         )
       }
     },
+    test("#213: an in-pool-range authored port is claimed so a later auto-provision cannot collide") {
+      withAdapterPool(List(4550, 4551)) { (control, _) =>
+        for
+          authoredE <- control.provision(MockSource.Dsl(MockSpec(List(pingRule), port = Some(4550)))).either
+          autoE     <- control.provision(pingSource).either
+        yield
+          val authored = authoredE.toOption.toList.flatten.head
+          val auto     = autoE.toOption.toList.flatten.head
+          assertTrue(
+            authored.baseUri == "http://localhost:4550",
+            // The authored port was removed from the free-list, so the auto-assigned
+            // imposter draws 4551 — never a second imposter on 4550.
+            auto.baseUri == "http://localhost:4551",
+            auto.baseUri != authored.baseUri
+          )
+      }
+    },
+    test("#213: an in-pool-range authored port returns to the pool on destroy (no depletion)") {
+      withAdapterPool(List(4550)) { (control, _) => // pool holds exactly the port we author
+        for
+          authoredE <- control.provision(MockSource.Dsl(MockSpec(List(pingRule), port = Some(4550)))).either
+          authored   = authoredE.toOption.toList.flatten.head
+          _         <- control.destroy(authored).either
+          autoE     <- control.provision(pingSource).either // 4550 must have come back to the pool
+        yield assertTrue(
+          authoredE.isRight,
+          autoE.toOption.toList.flatten.head.baseUri == "http://localhost:4550"
+        )
+      }
+    },
     test("destroy(A) deletes only A's imposter — never the global reset — and leaves B intact") {
       withAdapter { (control, fake) =>
         for


### PR DESCRIPTION
The container Rift adapter never removed an authored fixed port from the endpoint's port pool free-list. If the authored port was within the pool range, a concurrent auto-provision's acquirePort could hand it out again, causing two imposters to bind to the same port. This fix adds RiftEndpoint.claimPort to atomically reserve authored ports from the pool. Out-of-pool ports remain untouched and unrecycled. Docs corrected per onPort usage.

Closes #213