### PR TITLE
Honour the "port" field in a raw NativeSpec.Rift(json) imposter document

### DIFF
--- a/conformance/src/test/scala/zio/bdd/mock/conformance/NativeEscapeHatchSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/NativeEscapeHatchSpec.scala
@@ -24,8 +24,12 @@ object NativeEscapeHatchSpec extends ZIOSpecDefault:
   private val upWithin: Schedule[Any, Any, Any] = Schedule.recurs(20) && Schedule.spaced(100.millis)
 
   // Each adapter's own native dialect, both serving GET /native with "native!".
+  // No pinned port: since #214 honours a raw doc's own top-level port, pinning one
+  // here would bind every provision on the same port (and an out-of-pool port is
+  // host-unreachable on the container adapter). Omit it so each provision draws a
+  // fresh mapped/auto port — this suite provisions twice and needs distinct ports.
   private val riftNative =
-    """{"port":9999,"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/native"}}],"responses":[{"is":{"statusCode":200,"body":"native!"}}]}]}"""
+    """{"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/native"}}],"responses":[{"is":{"statusCode":200,"body":"native!"}}]}]}"""
   private val wmNative =
     """{"request":{"method":"GET","url":"/native"},"response":{"status":201,"body":"native!"}}"""
 

--- a/conformance/src/test/scala/zio/bdd/mock/conformance/ParallelIsolationSpec.scala
+++ b/conformance/src/test/scala/zio/bdd/mock/conformance/ParallelIsolationSpec.scala
@@ -16,8 +16,8 @@ import java.net.http.{HttpClient, HttpRequest as JHttpRequest, HttpResponse as J
  * WireMock correlated + perInstance (always, in-process) and Rift perInstance +
  * correlated (gated behind `RIFT_IT`, like
  * [[zio.bdd.mock.rift.RiftContainerSpec]] — the `rift-it` CI job runs this spec
- * under `RIFT_IT`, so the Rift backends + the native fixed-port test execute
- * there, not in the default Docker-free lane).
+ * under `RIFT_IT`, so the Rift backends + the native-source isolation test
+ * execute there, not in the default Docker-free lane).
  *
  * Tests within a backend run sequentially so only one N-space wave is live at a
  * time — Rift PerInstance gives each space its own imposter+port, so a generous
@@ -46,9 +46,13 @@ object ParallelIsolationSpec extends ZIOSpecDefault:
       )
     )
 
-  // A native Rift imposter pinning port 9999 (the "fixed-port" trap) serving `body` at /fp.
-  private def riftFixedPort(body: String): String =
-    s"""{"port":9999,"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/fp"}}],"responses":[{"is":{"statusCode":200,"body":"$body"}}]}]}"""
+  // A native Rift imposter serving `body` at /fp, with no pinned port. Since #214 honours a
+  // raw doc's own top-level port, two provisions must not share one (they'd collide, and an
+  // out-of-pool port is host-unreachable on the container adapter) — omit it so each draws a
+  // distinct auto port. Fixed-port *honouring* is covered by RiftMockControlSpec (container,
+  // hermetic) and EmbeddedRiftCapabilitiesSpec (embedded).
+  private def riftNativeSource(body: String): String =
+    s"""{"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/fp"}}],"responses":[{"is":{"statusCode":200,"body":"$body"}}]}]}"""
 
   // provision -> destroy on scope close (even on failure), so the pool is freed.
   // ignoreLogged (not bare ignore): teardown must not override the verdict, but a
@@ -116,12 +120,12 @@ object ParallelIsolationSpec extends ZIOSpecDefault:
           )
         }
       } @@ TestAspect.nonFlaky(Reps),
-      // RIFT_IT-only: a pinned-port source is a native (Rift) concept; WireMock rejects it.
-      test("a fixed-port source provisioned twice still isolates (the adapter overrides the pinned port)") {
+      // RIFT_IT-only: a raw native source is a Rift concept; WireMock rejects it.
+      test("two native (unpinned) sources provisioned in parallel isolate on distinct ports") {
         ZIO.scoped {
           for
-            a  <- ZIO.service[MockControl].flatMap(servingNative(_, riftFixedPort("A")))
-            b2 <- ZIO.service[MockControl].flatMap(servingNative(_, riftFixedPort("B")))
+            a  <- ZIO.service[MockControl].flatMap(servingNative(_, riftNativeSource("A")))
+            b2 <- ZIO.service[MockControl].flatMap(servingNative(_, riftNativeSource("B")))
             ra <- SutClient.make(a).send(Method.Get, "/fp")
             rb <- SutClient.make(b2).send(Method.Get, "/fp")
           yield assertTrue(a.baseUri != b2.baseUri, ra.body == "A", rb.body == "B")

--- a/docs/mock-advanced.md
+++ b/docs/mock-advanced.md
@@ -302,13 +302,15 @@ need full-fidelity access to a backend's raw feature set (e.g. a Mountebank
 imposter field or a WireMock stub-mapping option the canonical model doesn't
 expose), not for anything you expect to run against a second adapter.
 
-The Rift adapter does rewrite two fields of a raw imposter document so the space
-is manageable: it forces the imposter's `port` to its own managed pool port (so
-the `"port"` you author is ignored — hence the `"port":0` in the example below),
-and it injects `recordRequests: true` **only when the field is absent**, so
-`received()` works out of the box. Author an explicit `"recordRequests": false`
-to opt a raw Rift imposter out of request recording — it is honoured, not
-overridden.
+The Rift adapter honours a raw imposter document's own top-level `"port"` if it
+declares a positive one — the imposter binds on exactly that port (#214), and
+(for the container adapter) an in-pool-range port is claimed from the pool so an
+auto-assigned imposter can't collide with it (#213). A `"port": 0` or an absent
+`port` means "auto-assign" — the adapter picks a free port (hence the `"port":0`
+in the example below). It also injects `recordRequests: true` **only when the
+field is absent**, so `received()` works out of the box; author an explicit
+`"recordRequests": false` to opt a raw Rift imposter out of request recording —
+it is honoured, not overridden.
 
 A malformed `NativeSpec` fails fast at provision-time — invalid JSON syntax is
 rejected locally with `MockError.InvalidDefinition`, and a syntactically valid

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
@@ -105,7 +105,11 @@ private[embedded] final case class EmbeddedRiftMockControl(
     spec match
       // A native imposter always gets its own port (PerInstance), full-fidelity, regardless of mode.
       case NativeSpec.Rift(imposterJson) =>
-        serveImposter(NormalizedSource("native", SourcePayload.Raw(imposterJson), None)).map(List(_))
+        // Honour the document's own top-level "port" as the authored fixed port (#214);
+        // absent/non-numeric → None → an auto-assigned OS port.
+        serveImposter(
+          NormalizedSource("native", SourcePayload.Raw(imposterJson), RiftProtocol.topLevelPort(imposterJson))
+        ).map(List(_))
       case NativeSpec.WireMock(_) =>
         ZIO.fail(MockError.InvalidDefinition("the embedded Rift adapter cannot provision a WireMock native spec"))
 

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftCapabilitiesSpec.scala
@@ -114,6 +114,20 @@ object EmbeddedRiftCapabilitiesSpec extends ZIOSpecDefault:
         yield assertTrue(portFromUri(space.baseUri) > 0, portFromUri(space.baseUri) != 9998)
       }
     },
+    test("#214: a raw imposter document's top-level port is honoured") {
+      withControl() { (control, _) =>
+        val raw = """{"port":9999,"protocol":"http","stubs":[]}"""
+        for space <- control.provisionNative(NativeSpec.Rift(raw)).map(_.head)
+        yield assertTrue(portFromUri(space.baseUri) == 9999, space.baseUri == "http://localhost:9999")
+      }
+    },
+    test("#214: a raw imposter document without a top-level port auto-assigns") {
+      withControl() { (control, _) =>
+        val raw = """{"protocol":"http","stubs":[]}"""
+        for space <- control.provisionNative(NativeSpec.Rift(raw)).map(_.head)
+        yield assertTrue(portFromUri(space.baseUri) > 0, portFromUri(space.baseUri) != 9999)
+      }
+    },
     test("advertises all seven capabilities and every accessor succeeds") {
       withControl() { (control, _) =>
         for

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -96,7 +96,11 @@ private[rift] final case class RiftMockControl(
       // A native imposter always gets its own port (PerInstance), full-fidelity,
       // regardless of the active isolation mode.
       case NativeSpec.Rift(imposterJson) =>
-        serveImposter(NormalizedSource("native", SourcePayload.Raw(imposterJson), None)).map(List(_))
+        // Honour the document's own top-level "port" as the authored fixed port (#214);
+        // absent/non-numeric → None → an auto-assigned pool port.
+        serveImposter(
+          NormalizedSource("native", SourcePayload.Raw(imposterJson), RiftProtocol.topLevelPort(imposterJson))
+        ).map(List(_))
       case NativeSpec.WireMock(_) =>
         ZIO.fail(MockError.InvalidDefinition("the Rift adapter cannot provision a WireMock native spec"))
 

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -278,6 +278,24 @@ private[rift] object RiftProtocol:
     Json.Obj((("is" -> isObj) :: behaviors)*)
 
   /**
+   * A raw imposter document's own top-level `"port"`, if it declares a positive
+   * numeric one — honoured as the authored fixed port (#214). Returns `None`
+   * when the JSON isn't an object, has no `port`, `port` isn't an exact
+   * integer, or is non-positive (`"port": 0` is the auto-assign convention →
+   * `None`), so the caller falls back to an auto-assigned port. Total and pure:
+   * a malformed document simply yields `None` here (it fails loudly later in
+   * `imposterFromRaw`).
+   */
+  def topLevelPort(raw: String): Option[Int] =
+    raw
+      .fromJson[Json]
+      .toOption
+      .collect { case obj: Json.Obj => obj }
+      .flatMap(_.fields.collectFirst { case ("port", Json.Num(n)) => n })
+      .flatMap(n => scala.util.Try(n.intValueExact).toOption)
+      .filter(_ > 0) // "port": 0 is the auto-assign convention → None
+
+  /**
    * Rebuild a raw imposter doc, forcing our pool port; recording defaults on
    * unless the doc opts out.
    */

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftContainerSpec.scala
@@ -19,8 +19,11 @@ object RiftContainerSpec extends ZIOSpecDefault:
   private val pingSource = MockSource.Dsl(MockSpec(List(pingRule)))
 
   // A backend-native Rift imposter document for the escape hatch (#119).
+  // No top-level port: since #214 honours a raw doc's own port, a fixed out-of-pool port
+  // (e.g. 9999) would bind inside the container on a port testcontainers never mapped and
+  // be host-unreachable. Omit it so the imposter draws a mapped pool port.
   private val nativeImposter =
-    """{"port":9999,"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/native"}}],"responses":[{"is":{"statusCode":200,"body":"native!"}}]}]}"""
+    """{"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/native"}}],"responses":[{"is":{"statusCode":200,"body":"native!"}}]}]}"""
 
   // Imposter binds slightly after provision returns; retry the first hit briefly.
   private val upWithin: Schedule[Any, Any, Any] = Schedule.recurs(20) && Schedule.spaced(100.millis)

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -22,6 +22,15 @@ object RiftMockControlSpec extends ZIOSpecDefault:
       |           "responses":[{"is":{"statusCode":200,"body":"native!"}}]}],
       | "_rift":{"script":{"engine":"rhai","code":"200"}}}""".stripMargin
 
+  // Same full-fidelity doc but WITHOUT a top-level port, so each provision gets a
+  // distinct auto-assigned pool port (a fixed-port doc would bind every provision
+  // on the same authored port — #214).
+  private val nativeImposterNoPort =
+    """{"protocol":"http",
+      | "stubs":[{"predicates":[{"equals":{"path":"/native"}}],
+      |           "responses":[{"is":{"statusCode":200,"body":"native!"}}]}],
+      | "_rift":{"script":{"engine":"rhai","code":"200"}}}""".stripMargin
+
   private def portOf(baseUri: String): Int = baseUri.substring(baseUri.lastIndexOf(':') + 1).toInt
 
   /**
@@ -455,10 +464,10 @@ object RiftMockControlSpec extends ZIOSpecDefault:
         )
       }
     },
-    test("provisionNative(Rift) stands up a full-fidelity space (stubs + _rift) on our pooled port") {
+    test("provisionNative(Rift) honours the document's own top-level port (#214)") {
       withAdapter { (control, fake) =>
         for
-          sE     <- control.provisionNative(NativeSpec.Rift(nativeImposter)).either
+          sE     <- control.provisionNative(NativeSpec.Rift(nativeImposter)).either // doc declares "port":9999
           posted <- fake.posted.get
         yield
           val space = sE.toOption.get.head
@@ -466,13 +475,21 @@ object RiftMockControlSpec extends ZIOSpecDefault:
           val req   = HttpRequest(Method.Get, "http://sut/")
           assertTrue(
             sE.isRight,
-            body.contains("\"_rift\""),                            // full-fidelity: _rift extensions preserved
-            body.contains("/native"),                              // the native stub preserved
-            body.contains("\"recordRequests\":true"),              // forced on so received() works
-            FakeRift.portOf(body).contains(portOf(space.baseUri)), // our pool port, not the spec's 9999
-            !body.contains("9999"),
-            space.inject(req) == req // isolation: identity inject like a portable space
+            body.contains("\"_rift\""),               // full-fidelity: _rift extensions preserved
+            body.contains("/native"),                 // the native stub preserved
+            body.contains("\"recordRequests\":true"), // forced on so received() works
+            space.baseUri == "http://localhost:9999", // the document's authored port is honoured (#214)
+            FakeRift.portOf(body).contains(9999),     // imposter created on 9999, not an auto pool port
+            space.inject(req) == req                  // isolation: identity inject like a portable space
           )
+      }
+    },
+    test("provisionNative(Rift) without a top-level port auto-assigns a pool port (#214)") {
+      val noPort = """{"protocol":"http","stubs":[{"predicates":[{"equals":{"path":"/np"}}],
+                     | "responses":[{"is":{"statusCode":200}}]}]}""".stripMargin
+      withAdapterPool(List(4600)) { (control, _) =>
+        for sE <- control.provisionNative(NativeSpec.Rift(noPort)).either
+        yield assertTrue(sE.toOption.get.head.baseUri == "http://localhost:4600")
       }
     },
     test("a natively-provisioned space participates in received and is space-local on destroy") {
@@ -500,8 +517,8 @@ object RiftMockControlSpec extends ZIOSpecDefault:
     test("native spaces isolate: two get distinct ports; destroy(A) leaves B") {
       withAdapter { (control, _) =>
         for
-          aE    <- control.provisionNative(NativeSpec.Rift(nativeImposter)).either
-          bE    <- control.provisionNative(NativeSpec.Rift(nativeImposter)).either
+          aE    <- control.provisionNative(NativeSpec.Rift(nativeImposterNoPort)).either
+          bE    <- control.provisionNative(NativeSpec.Rift(nativeImposterNoPort)).either
           a      = aE.toOption.get.head
           b      = bE.toOption.get.head
           _     <- control.destroy(a).either

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
@@ -284,5 +284,15 @@ object RiftProtocolSpec extends ZIOSpecDefault:
         jOn / "recordRequests" == Json.Bool(true),
         jOn / "port" == Json.Num(4600)
       )
+    },
+    test("topLevelPort reads a document's own numeric port (#214), else None") {
+      assertTrue(
+        RiftProtocol.topLevelPort("""{"port":9999,"protocol":"http","stubs":[]}""").contains(9999),
+        RiftProtocol.topLevelPort("""{"protocol":"http","stubs":[]}""").isEmpty, // no port
+        RiftProtocol.topLevelPort("""{"port":0,"stubs":[]}""").isEmpty,          // 0 = auto-assign convention
+        RiftProtocol.topLevelPort("""{"port":"nope","stubs":[]}""").isEmpty,     // non-numeric
+        RiftProtocol.topLevelPort("[1,2,3]").isEmpty,                            // not an object
+        RiftProtocol.topLevelPort("not json").isEmpty                            // malformed
+      )
     }
   )


### PR DESCRIPTION
Parse and thread the top-level "port" field from a raw imposter JSON document as the authored port in both Rift adapters' provisionNative. The port value must be positive; "port":0 or absent preserves the auto-assign convention. This composed with #213's claimPort seam ensures raw in-pool-range ports are collision-safe.

Closes #214