### PR TITLE
fix(rift): detect out-of-range authored ports in container adapter

### DIFF
--- a/docs/mock-dsl.md
+++ b/docs/mock-dsl.md
@@ -40,6 +40,12 @@ one; when omitted, a fresh free port is chosen. If a fixed port happens to fall
 inside a backend's managed port pool (e.g. the container Rift adapter's pool), it
 is claimed from that pool so an auto-assigned imposter can't collide with it (#213).
 
+The **container** Rift adapter can only reach ports it exposed when the container
+started (its imposter-port pool), so an authored port **outside** that pool is
+host-unreachable and is rejected up front with a clear `MockError.InvalidDefinition`
+(#303) — use a port in the pool range, or omit it to auto-assign. The **embedded**
+adapter binds `localhost` directly and has no such limit: any free port works.
+
 ---
 
 ## 2. Matching requests

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftEndpoint.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftEndpoint.scala
@@ -34,6 +34,17 @@ private[rift] trait RiftEndpoint:
   /** Return a port to the pool after an imposter is destroyed. */
   def releasePort(port: Int): UIO[Unit]
 
+  /**
+   * Fail fast if `imposterPort` can't be reached through this endpoint's host
+   * mapping — e.g. a container authored port outside the pre-exposed pool,
+   * which testcontainers never maps (#303). Auto-assigned pool ports are always
+   * reachable; an identity mapping (host networking / in-process) accepts any
+   * port. Called before standing up an authored-port imposter so an unreachable
+   * port surfaces as a typed `MockError`, not a cryptic `getMappedPort` defect
+   * raised after the imposter has already been created.
+   */
+  def ensureReachable(imposterPort: Int): IO[MockError, Unit]
+
   /** The SUT-reachable base URI for an imposter bound to `imposterPort`. */
   def baseUriFor(imposterPort: Int): String
 
@@ -58,5 +69,16 @@ private[rift] object RiftEndpoint:
       free.modify(list => if list.contains(port) then (true, list.filterNot(_ == port)) else (false, list))
 
     def releasePort(port: Int): UIO[Unit] = free.update(port :: _)
+
+    def ensureReachable(imposterPort: Int): IO[MockError, Unit] =
+      ZIO
+        .attempt(hostFor(imposterPort))
+        .unit
+        .mapError(_ =>
+          MockError.InvalidDefinition(
+            s"authored imposter port $imposterPort is not reachable — it is outside the backend's exposed port pool; " +
+              "use a port in the pool range or omit the port to auto-assign"
+          )
+        )
 
     def baseUriFor(imposterPort: Int): String = hostFor(imposterPort)

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftMockControl.scala
@@ -356,16 +356,19 @@ private[rift] final case class RiftMockControl(
   private def serveImposter(src: NormalizedSource): IO[MockError, MockSpace] =
     src.authoredPort match
       case Some(port) =>
-        // Claim an authored port from the pool free-list if it falls in range, so a
-        // concurrent auto-`provision` can't `acquirePort` the same number and stand up a
-        // second imposter on it (#213). An in-range port is then pool-managed (returns on
+        // Fail fast (before touching the pool or POSTing) if an authored port isn't reachable
+        // through the endpoint's host mapping — e.g. a container port outside the exposed pool,
+        // which testcontainers can't map (#303). Then claim it from the free-list if it falls in
+        // range, so a concurrent auto-`provision` can't `acquirePort` the same number and stand up
+        // a second imposter on it (#213). An in-range port is then pool-managed (returns on
         // destroy); an out-of-range fixed port leaves the pool untouched (#211).
-        endpoint
-          .claimPort(port)
-          .flatMap(claimed =>
-            standImposter(port, src, pooled = claimed)
-              .onError(_ => ZIO.when(claimed)(endpoint.releasePort(port)))
-          )
+        endpoint.ensureReachable(port) *>
+          endpoint
+            .claimPort(port)
+            .flatMap(claimed =>
+              standImposter(port, src, pooled = claimed)
+                .onError(_ => ZIO.when(claimed)(endpoint.releasePort(port)))
+            )
       case None =>
         endpoint.acquirePort.flatMap(port =>
           standImposter(port, src, pooled = true).onError(_ => endpoint.releasePort(port))

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftMockControlSpec.scala
@@ -167,6 +167,46 @@ object RiftMockControlSpec extends ZIOSpecDefault:
         )
       }
     },
+    test(
+      "#303: an authored port outside the container's exposed pool fails fast with a typed MockError (no defect, no leak)"
+    ) {
+      val pool = List(4545, 4546)
+      // Simulate testcontainers: only exposed pool ports are mapped; any other port throws
+      // (getMappedPort) — the crash #303 replaces with a clear, fail-fast error.
+      def containerHostFor(p: Int): String =
+        if pool.contains(p) then s"http://localhost:$p"
+        else throw new IllegalArgumentException(s"Requested port ($p) is not mapped")
+      ZIO.scoped {
+        for
+          adminAndFake <- FakeRift.started
+          (admin, fake) = adminAndFake
+          endpoint     <- RiftEndpoint.pooled(admin, pool)(containerHostFor)
+          control      <- RiftMockControl.make(endpoint, RiftMode.PerInstance)
+          exit         <- control.provision(MockSource.Dsl(MockSpec(List(pingRule), port = Some(9999)))).exit
+          posted       <- fake.posted.get
+        yield assertTrue(
+          exit.causeOption.exists(_.failures.exists { case _: MockError.InvalidDefinition => true; case _ => false }),
+          exit.causeOption.exists(_.defects.isEmpty), // a typed failure, not a cryptic defect
+          exit.causeOption.exists(_.failures.exists(_.toString.contains("9999"))),
+          posted.isEmpty // failed before POSTing — no leaked imposter
+        )
+      }
+    },
+    test("#303: an in-pool authored port is reachable under container mapping and provisions") {
+      val pool = List(4545, 4546)
+      def containerHostFor(p: Int): String =
+        if pool.contains(p) then s"http://localhost:$p"
+        else throw new IllegalArgumentException(s"Requested port ($p) is not mapped")
+      ZIO.scoped {
+        for
+          adminAndFake <- FakeRift.started
+          (admin, _)    = adminAndFake
+          endpoint     <- RiftEndpoint.pooled(admin, pool)(containerHostFor)
+          control      <- RiftMockControl.make(endpoint, RiftMode.PerInstance)
+          sE           <- control.provision(MockSource.Dsl(MockSpec(List(pingRule), port = Some(4545)))).either
+        yield assertTrue(sE.toOption.toList.flatten.head.baseUri == "http://localhost:4545")
+      }
+    },
     test("destroy(A) deletes only A's imposter — never the global reset — and leaves B intact") {
       withAdapter { (control, fake) =>
         for


### PR DESCRIPTION
Fail fast with a clear MockError when an authored port is outside the container's exposed pool, instead of a cryptic testcontainers getMappedPort crash with a leaked imposter. Embedded and identity host mappings remain unaffected. Documentation updated.

Closes #303