### PR TITLE
pending() step reddens the sbt build — Task gates on isPassed, not the documented isComplete

### DIFF
--- a/core/src/main/scala/zio/bdd/ZIOBDDFramework.scala
+++ b/core/src/main/scala/zio/bdd/ZIOBDDFramework.scala
@@ -473,7 +473,7 @@ class ZIOBDDTask(
           override def fullyQualifiedName(): String = taskDef.fullyQualifiedName()
           override def fingerprint(): Fingerprint   = taskDef.fingerprint()
           override def selector(): Selector         = new TestSelector(result.feature.name)
-          override def status(): Status             = if (result.isPassed) Status.Success else Status.Failure
+          override def status(): Status             = ZIOBDDTask.statusOf(result)
           override def throwable(): OptionalThrowable = result.error match {
             case Some(t) => new OptionalThrowable(new Exception(t.getMessage, t.getCause))
             case None    => new OptionalThrowable()
@@ -487,6 +487,15 @@ class ZIOBDDTask(
 }
 
 object ZIOBDDTask {
+
+  /**
+   * The sbt build status for one feature. A `PENDING` scenario is a first-class
+   * "not built yet" status that must NOT fail the build, so this gates on
+   * `isComplete` (pending-tolerant), not `isPassed` — see `FeatureResult` in
+   * Result.scala. Issue #304.
+   */
+  def statusOf(result: FeatureResult): Status =
+    if (result.isComplete) Status.Success else Status.Failure
 
   /**
    * Parse a log-level name (case-insensitive) into an `InternalLogLevel`,

--- a/core/src/test/scala/zio/bdd/core/FeatureExecutorSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/FeatureExecutorSpec.scala
@@ -5,7 +5,9 @@ import zio.test.*
 import zio.test.Assertion.*
 import zio.bdd.gherkin.*
 import zio.bdd.core.step.{ZIOSteps, StepRegistry}
+import zio.bdd.ZIOBDDTask
 import zio.schema.{DeriveSchema, Schema}
+import _root_.sbt.testing.Status
 
 /**
  * Tests for FeatureExecutor and ScenarioExecutor:
@@ -358,6 +360,47 @@ object FeatureExecutorSpec extends ZIOSpecDefault {
     }
   )
 
+  private val buildGate = suite("#304: sbt build status gates on isComplete (pending-tolerant)")(
+    test("a pending-only feature maps to Status.Success — pending does not redden the build") {
+      given steps: ZIOSteps[Any, SystemState] = new UserSteps {
+        Given("a pending step")(pending("not built yet"))
+      }
+      run("Feature: P\n  Scenario: s\n    Given a pending step\n").map { r =>
+        val fr = r.head
+        assertTrue(
+          fr.hasPending,
+          !fr.isPassed,                             // the bug's trigger: isPassed is false when a scenario is pending
+          fr.isComplete,                            // isComplete tolerates pending
+          ZIOBDDTask.statusOf(fr) == Status.Success // the build gate must stay green
+        )
+      }
+    },
+    test("a passing feature maps to Status.Success") {
+      given steps: ZIOSteps[Any, SystemState] = new UserSteps {}
+      run("Feature: Ok\n  Scenario: s\n    Given a system is running\n")
+        .map(r => assertTrue(ZIOBDDTask.statusOf(r.head) == Status.Success))
+    },
+    test("a hard-failing feature maps to Status.Failure") {
+      given steps: ZIOSteps[Any, SystemState] = new UserSteps {}
+      run("Feature: Bad\n  Scenario: s\n    Given a system is running\n    Then an error occurs\n")
+        .map(r => assertTrue(ZIOBDDTask.statusOf(r.head) == Status.Failure))
+    },
+    test("a feature mixing a pending scenario and a failing scenario maps to Status.Failure") {
+      given steps: ZIOSteps[Any, SystemState] = new UserSteps {
+        Given("a pending step")(pending("not built yet"))
+      }
+      run(
+        """Feature: Mix
+          |  Scenario: pend
+          |    Given a pending step
+          |  Scenario: bad
+          |    Given a system is running
+          |    Then an error occurs
+          |""".stripMargin
+      ).map(r => assertTrue(r.head.hasPending, ZIOBDDTask.statusOf(r.head) == Status.Failure))
+    }
+  )
+
   private val duration = suite("Duration tracking")(
     test("ScenarioResult.duration is non-negative after execution") {
       given steps: ZIOSteps[Any, SystemState] = new UserSteps {}
@@ -489,6 +532,7 @@ object FeatureExecutorSpec extends ZIOSpecDefault {
     outlineExec,
     failureAndSkipped,
     pendingStatus,
+    buildGate,
     hooks,
     duration,
     resultStatus,

--- a/docs/step-dsl.md
+++ b/docs/step-dsl.md
@@ -465,7 +465,10 @@ mixing them is supported.
 
 Mark a step as intentionally unimplemented.  A pending step is reported
 distinctly from a failed step — it does not cause subsequent steps to be
-skipped, and it will not fail the suite.
+skipped, and it does **not** redden the build: a scenario whose only issue is a
+pending step keeps the sbt task green (`Status.Success`), surfacing the
+`Pending: N` count without failing. The build gate is `FeatureResult.isComplete`
+(pending-tolerant), not `isPassed`.
 
 ```scala
 Given("a complex precondition exists") { pending("not yet implemented") }


### PR DESCRIPTION
The per-feature sbt Event.status() was gated on FeatureResult.isPassed, which
is false when a scenario is pending. This caused a pending() step to fail the
build even though the result model documents pending as a first-class "not built
yet" status that does not block the build. Now gates on the pending-tolerant
isComplete instead, with the status logic extracted to ZIOBDDTask.statusOf for
testability. Hard failures still map to Status.Failure.

Closes #304