### PR TITLE
Migrate to Rift v0.12.0 (bump + v2 scripting API + remove Lua)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
   # (validating the minimum supported JDK). No Docker: the in-process engine binds localhost ports.
   # The librift_ffi cdylibs are bundled by the zio-bdd-rift-embedded-natives jar (a test dep of the
   # embedded suites), downloaded + checksum-verified by its resourceGenerator; the loader extracts +
-  # loads the host's lib from the classpath out-of-the-box — no -Drift.ffi.lib. librift_ffi dynamically
-  # links LuaJIT, so it must be installed to dlopen the library (matches Rift's own FFI CI).
+  # loads the host's lib from the classpath out-of-the-box — no -Drift.ffi.lib. (Rift ≥ 0.12.0
+  # dropped the Lua engine, so librift_ffi is self-contained — no system LuaJIT needed, rift #451.)
   embedded-stable:
     name: Embedded FFM provider — stable (JDK 22)
     runs-on: ubuntu-latest
@@ -89,8 +89,6 @@ jobs:
           java-version: 22
           cache: sbt
       - uses: sbt/setup-sbt@v1
-      - name: Install LuaJIT
-        run: sudo apt-get update && sudo apt-get install -y libluajit-5.1-dev
       # Stable FFM needs no --enable-preview; the forked test JVM runs with --enable-native-access only.
       - name: Stable embedded tests + portable conformance
         run: >-
@@ -114,8 +112,6 @@ jobs:
           java-version: 21
           cache: sbt
       - uses: sbt/setup-sbt@v1
-      - name: Install LuaJIT
-        run: sudo apt-get update && sudo apt-get install -y libluajit-5.1-dev
       - name: Preview embedded tests
         run: sbt "riftEmbedded21/test"
       # The point of the -jdk21 cut is to load on JDK 21, where FFM is preview (class <= 65). Guard

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ import java.security.MessageDigest
 // Single source of truth for the pinned Rift release (#195). Both the FFI natives (riftNativesVersion,
 // downloaded into the embedded-natives jar) and the container image tag (Rift.DefaultImage, via the
 // generated RiftBuildInfo below) derive from it, so a version bump touches exactly one line.
-val riftVersion        = "0.11.3"
+val riftVersion        = "0.12.0"
 val riftNativesVersion = riftVersion
 
 // The (os, arch, ext) cdylibs bundled into the natives jar — linux/macOS × x86_64/aarch64 (#134).

--- a/conformance/src/main/scala/zio/bdd/mock/conformance/ScriptingScenarios.scala
+++ b/conformance/src/main/scala/zio/bdd/mock/conformance/ScriptingScenarios.scala
@@ -26,14 +26,13 @@ object ScriptingScenarios:
 
   // A Rhai script that computes the body from the request method — so a passing
   // round-trip proves the backend ran the script (a static stub couldn't echo it).
-  // Rift's script API returns a decision map; `fault: "error"` is its token for "return this
-  // computed { status, body, headers } response" (not an actual error). Here the body is derived
-  // from request.method, so a passing round-trip proves the engine ran the script.
+  // Rift's v2 script API (#357): the `respond(ctx)` entrypoint returns a result constructor —
+  // `http(status, body)` serves that response (`.header(k, v)` chains). The body is derived from
+  // `ctx.request.method`, so a green round-trip proves the engine actually executed the script.
   private val rhaiEchoMethod =
     Script(
       ScriptEngine.Rhai,
-      "fn should_inject(request, flow_store) { #{inject: true, fault: \"error\", status: 200, " +
-        "body: `scripted-${request.method}`, headers: #{\"Content-Type\": \"text/plain\"}} }"
+      "fn respond(ctx) { http(200, `scripted-${ctx.request.method}`).header(\"Content-Type\", \"text/plain\") }"
     )
 
   private val scriptedResponse =

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ embedded FFM) and WireMock, negotiating capabilities per backend.
 |----------|----------------|
 | [Mocking Overview](mocking.md) | The portable `MockControl` SPI, `MockSpace` + isolation (PerInstance/Correlated), the request/response model, `MockSource` variants |
 | [Mock DSL](mock-dsl.md) | The `zio.bdd.mock.dsl.*` builder — matching requests, building responses, rule precedence, the stateful-scenario builder, raw JSON sources |
-| [Mock Adapters](mock-adapters.md) | Rift (`managed`/`connect`), WireMock, and the **embedded FFM** provider (JDK 21/22 matrix + artifacts, LuaJIT); the capability × adapter matrix; choosing one |
+| [Mock Adapters](mock-adapters.md) | Rift (`managed`/`connect`), WireMock, and the **embedded FFM** provider (JDK 21/22 matrix + artifacts); the capability × adapter matrix; choosing one |
 | [Mock Gherkin Integration](mock-gherkin.md) | `MockSteps` mixin, the `@mock(name)` tag + `MockFixtures`, the catalog pattern, `Stage` |
 | [Mock Advanced](mock-advanced.md) | Capability accessors (faults, scenarios, state inspection, scripting, proxy/record, templating), the `provisionNative` escape hatch, capability negotiation |
 

--- a/docs/mock-adapters.md
+++ b/docs/mock-adapters.md
@@ -173,19 +173,6 @@ loads it automatically. If you'd rather point at a library you built or
 installed yourself, skip the natives jar and set `-Drift.ffi.lib=<path>`
 instead.
 
-### Host prerequisite: LuaJIT
-
-The embedded engine's Scripting capability needs LuaJIT installed on the host
-running the tests:
-
-```bash
-# Debian/Ubuntu
-apt install libluajit-5.1-dev
-
-# macOS
-brew install luajit
-```
-
 ### Test-JVM flags
 
 Both variants need `--enable-native-access` to silence the restricted-method

--- a/docs/mock-adapters.md
+++ b/docs/mock-adapters.md
@@ -64,7 +64,7 @@ the environment:
   ): ZLayer[Client & Provisioning, MockError, MockControl]
   ```
 
-  `DefaultImage` is the pinned Rift image, currently `zainalpour/rift-proxy:v0.11.3`
+  `DefaultImage` is the pinned Rift image, currently `zainalpour/rift-proxy:v0.12.0`
   — derived from the single `riftVersion` in `build.sbt`, so treat it as "the
   pinned Rift image" rather than a hardcoded tag. Pass `interceptPort` to also
   start the container's HTTPS-intercept listener and advertise

--- a/docs/mock-advanced.md
+++ b/docs/mock-advanced.md
@@ -183,8 +183,7 @@ engine actually ran the script):
 
 ```scala
 private val rhaiEchoMethod =
-  "fn should_inject(request, flow_store) { #{inject: true, fault: \"error\", status: 200, " +
-    "body: `scripted-${request.method}`, headers: #{\"Content-Type\": \"text/plain\"}} }"
+  "fn respond(ctx) { http(200, `scripted-${ctx.request.method}`).header(\"Content-Type\", \"text/plain\") }"
 
 Given("the backend supports scripting") {
   requiring(Capability.Scripting)

--- a/docs/mock-advanced.md
+++ b/docs/mock-advanced.md
@@ -174,7 +174,7 @@ the matched request. Rift only:
 final case class Script(engine: ScriptEngine, code: String)
 
 enum ScriptEngine:
-  case Rhai, Lua, JavaScript
+  case Rhai, JavaScript
 ```
 
 From `Scripting14Suite` — a Rhai script that echoes the request method into
@@ -192,7 +192,6 @@ Given("the backend supports scripting") {
 Given("a " / string / " script echoing the method for GET " / string) { (engine: String, path: String) =>
   val eng = engine match
     case "Rhai"       => ScriptEngine.Rhai
-    case "Lua"        => ScriptEngine.Lua
     case "JavaScript" => ScriptEngine.JavaScript
     case other        => throw new IllegalArgumentException(s"unknown engine '$other'")
   for

--- a/mock/src/main/scala/zio/bdd/mock/model.scala
+++ b/mock/src/main/scala/zio/bdd/mock/model.scala
@@ -195,9 +195,12 @@ enum FaultKind:
   case RandomThenClose
   case LatencySpike(delay: Duration)
 
-/** The engine a [[Scripting]] script runs on (#132). */
+/**
+ * The engine a [[Scripting]] script runs on (#132). Rift consolidated on Rhai +
+ * JavaScript in v0.12.0 (the Lua engine was removed, rift #451).
+ */
 enum ScriptEngine:
-  case Rhai, Lua, JavaScript
+  case Rhai, JavaScript
 
 /** A backend script that computes the response for matching requests (#132). */
 final case class Script(engine: ScriptEngine, code: String)

--- a/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/Rift.scala
@@ -104,7 +104,11 @@ object Rift:
       // command override, and expose it alongside the admin + imposter ports so it maps to a host
       // port. Unlike the embedded adapter's lazy start, the container's listener binds at boot —
       // there is no separate "start" downcall to make on first use.
-      val command = interceptPort.fold(Seq.empty[String])(p => Seq("--intercept-port", p.toString))
+      // `--allowInjection` enables the script surface (`_rift.script`) the `Scripting` capability
+      // drives — Rift ≥ 0.12.0 gates it behind this flag (rift #438). The embedded adapter's FFI
+      // engine has no such admin gate.
+      val command =
+        "--allowInjection" +: interceptPort.fold(Seq.empty[String])(p => Seq("--intercept-port", p.toString))
       for
         container <- ZIO.acquireRelease(
                        ZIO.attemptBlocking {

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -180,7 +180,9 @@ private[rift] object RiftProtocol:
 
   /**
    * A stub whose response is computed by `script` via the `_rift.script`
-   * extension — the script's `should_inject` decides the response.
+   * extension — the script's `respond(ctx)` entrypoint decides the response
+   * (Rift v2 script API). The container backend gates this surface behind
+   * `--allowInjection` (see `Rift.managed`).
    */
   def scriptStub(m: RequestMatch, script: Script, id: RuleId): Json =
     capStub(

--- a/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
+++ b/rift/src/main/scala/zio/bdd/mock/rift/RiftProtocol.scala
@@ -175,7 +175,6 @@ private[rift] object RiftProtocol:
   /** The Rift script-engine token. */
   def scriptEngineName(engine: ScriptEngine): String = engine match
     case ScriptEngine.Rhai       => "rhai"
-    case ScriptEngine.Lua        => "lua"
     case ScriptEngine.JavaScript => "javascript"
 
   /**

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
@@ -14,9 +14,9 @@ object RiftBuildInfoSpec extends ZIOSpecDefault:
   def spec = suite("RiftBuildInfo")(
     test("DefaultImage is derived from the single rift-version source of truth") {
       assertTrue(
-        RiftBuildInfo.riftVersion == "0.11.3",
+        RiftBuildInfo.riftVersion == "0.12.0",
         Rift.DefaultImage == s"zainalpour/rift-proxy:v${RiftBuildInfo.riftVersion}",
-        Rift.DefaultImage == "zainalpour/rift-proxy:v0.11.3"
+        Rift.DefaultImage == "zainalpour/rift-proxy:v0.12.0"
       )
     }
   )

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
@@ -150,13 +150,13 @@ object RiftProtocolSpec extends ZIOSpecDefault:
     test("scriptStub carries predicates and a _rift.script response (engine + code) (#132)") {
       val m = RequestMatch(path = PathMatch.Exact("/s"))
       val stub =
-        RiftProtocol.scriptStub(m, Script(ScriptEngine.Rhai, "fn should_inject(r,f){#{inject:false}}"), RuleId("s1"))
+        RiftProtocol.scriptStub(m, Script(ScriptEngine.Rhai, "fn respond(ctx){pass()}"), RuleId("s1"))
       val resp = arr(stub / "responses").head
       assertTrue(
         stub / "id" == Json.Str("s1"),
         arr(stub / "predicates").exists(p => p / "equals" / "path" == Json.Str("/s")),
         resp / "_rift" / "script" / "engine" == Json.Str("rhai"),
-        resp / "_rift" / "script" / "code" == Json.Str("fn should_inject(r,f){#{inject:false}}")
+        resp / "_rift" / "script" / "code" == Json.Str("fn respond(ctx){pass()}")
       )
     },
     test("script engine tokens map to rhai/lua/javascript (#132)") {

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftProtocolSpec.scala
@@ -159,10 +159,9 @@ object RiftProtocolSpec extends ZIOSpecDefault:
         resp / "_rift" / "script" / "code" == Json.Str("fn respond(ctx){pass()}")
       )
     },
-    test("script engine tokens map to rhai/lua/javascript (#132)") {
+    test("script engine tokens map to rhai/javascript (#132)") {
       assertTrue(
         RiftProtocol.scriptEngineName(ScriptEngine.Rhai) == "rhai",
-        RiftProtocol.scriptEngineName(ScriptEngine.Lua) == "lua",
         RiftProtocol.scriptEngineName(ScriptEngine.JavaScript) == "javascript"
       )
     },

--- a/scripts/check-mock-docs.sh
+++ b/scripts/check-mock-docs.sh
@@ -41,13 +41,12 @@ if grep -RnE 'rift-proxy:v0\.8\.0' docs/mock-adapters.md; then err "stale Rift i
 if grep -RniE 'embedded[^.]{0,40}(no capabilit|four capabilit|only four)' $MOCK_MD; then err "stale 'embedded has no/four capabilities' claim"; fi
 grep -Rq 'StateInspection' docs/mock-adapters.md || err "capability matrix missing StateInspection in mock-adapters.md"
 
-# 7. Embedded JDK story: both artifacts + both JDKs + LuaJIT + native-access, in mock-adapters.md
+# 7. Embedded JDK story: both artifacts + both JDKs + native-access, in mock-adapters.md
 A=docs/mock-adapters.md
 grep -q 'zio-bdd-rift-embedded-jdk21' "$A" || err "mock-adapters.md missing the JDK-21 embedded artifact"
 grep -q 'zio-bdd-rift-embedded-natives' "$A" || err "mock-adapters.md missing the embedded-natives artifact"
 grep -qE 'JDK ?21' "$A" && grep -qE 'JDK ?22' "$A" || err "mock-adapters.md missing the JDK 21/22 split"
 grep -q 'enable-native-access' "$A" || err "mock-adapters.md missing --enable-native-access"
-grep -qiE 'luajit' "$A" || err "mock-adapters.md missing the LuaJIT prerequisite"
 
 # 8. Used By section seeded with Rift (README or docs landing)
 grep -RqiE 'used by' README.md docs/index.md && grep -RqiE '\[?rift\]?\(https://github.com/EtaCassiopeia/rift' README.md docs/index.md \


### PR DESCRIPTION
Migrate zio-bdd to Rift **v0.12.0**.

- **Bump** the single `riftVersion` source of truth 0.11.3 → 0.12.0 (natives, `RiftBuildInfo`, `Rift.DefaultImage` derive from it).
- **Scripting API v2** (rift #357/#454): rewrite the conformance script from the removed v1 `should_inject` to the v2 `respond(ctx)` entrypoint + result constructors (`http(200, …)`), and start the managed container with `--allowInjection` (rift #438) so `_rift.script` stubs are accepted. The embedded FFI path needs no flag — it bypasses the admin gate.
- **Remove the Lua engine** (rift #451, breaking): drop `ScriptEngine.Lua`, its Rift token, the LuaJIT host prerequisite + both CI LuaJIT install steps, and the doc-check assertion (v0.12.0's librift_ffi is self-contained).

No FFI-bridge change needed: every C-ABI function zio-bdd binds is present unchanged in v0.12.0's header.

BREAKING: `ScriptEngine.Lua` removed — use Rhai or JavaScript.