### PR TITLE
build(natives): embedded natives <=1.4.1 (rift v0.11.3) require system LuaJIT at runtime on linux-x86_64/darwin-aarch64

### DIFF
--- a/docs/mock-adapters.md
+++ b/docs/mock-adapters.md
@@ -173,6 +173,17 @@ loads it automatically. If you'd rather point at a library you built or
 installed yourself, skip the natives jar and set `-Drift.ffi.lib=<path>`
 instead.
 
+> **Platform note — system LuaJIT (natives ≤ 1.4.1 only).** The `1.4.1` and
+> earlier natives repackage Rift **v0.11.3**, whose `linux-x86_64` and
+> `darwin-aarch64` cdylibs dynamically link **system LuaJIT** — so those hosts
+> needed `libluajit-5.1-2` (apt) / Homebrew `luajit` installed, or the library
+> failed to `dlopen` at engine start (#307). **Natives from `1.4.2` onward
+> (Rift v0.12.0) are self-contained** — Rift dropped the Lua engine, so no host
+> LuaJIT is required on any platform. If you're pinned to an old natives version
+> on a Lua-free host, either upgrade or install system LuaJIT. A bundled library
+> that is present but fails to load surfaces a `MockError.ProvisionFailed` naming
+> the underlying `dlopen` error and this missing-dependency hint.
+
 ### Test-JVM flags
 
 Both variants need `--enable-native-access` to silence the restricted-method

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/RiftFfi.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/RiftFfi.scala
@@ -324,7 +324,19 @@ private[embedded] object RiftFfi:
       .acquireRelease(
         ZIO
           .attemptBlocking(RiftFfiBridge.start(libPath))
-          .mapError(t => MockError.ProvisionFailed(s"loading librift_ffi from '$libPath': ${message(t)}"))
+          .mapError { t =>
+            // If the bundled cdylib is present on disk but still failed to load, it is almost
+            // always a missing transitive native dependency on the host (e.g. natives ≤ 1.4.1 /
+            // Rift v0.11.3 dynamically linked system LuaJIT). Name that explicitly so the consumer
+            // gets an actionable error instead of a bare dlopen line — the same treatment
+            // NativeLibrary.resolveSourceFor gives missing-jar / unsupported-platform (#307).
+            val hint =
+              if (java.nio.file.Files.exists(java.nio.file.Path.of(libPath)))
+                " — the bundled native library is present but failed to load, which usually means a" +
+                  " missing transitive native dependency on the host (see the embedded adapter's platform notes)"
+              else ""
+            MockError.ProvisionFailed(s"loading librift_ffi from '$libPath': ${message(t)}$hint")
+          }
       )(bridge => ZIO.attemptBlocking(bridge.close()).orDie)
       .map(EmbeddedEngine.Live(_))
 


### PR DESCRIPTION
When the bundled librift_ffi fails to dlopen, RiftFfi.start now appends a hint that names the likely root cause (missing transitive native dependency). Document the ≤1.4.1 (Rift v0.11.3) system-LuaJIT requirement on linux-x86_64 and darwin-aarch64, and that 1.4.2+ (Rift v0.12.0) natives are self-contained.

The Rift v0.12.0 bump (#310) resolved the CI LuaJIT apt steps; this adds the actionable error hint and platform note.

Closes #307