### PR TITLE
Concurrent @Suite classes sharing an embedded engine fail with cause-less "Interrupted" under sbt default parallelExecution

### DIFF
--- a/docs/mock-adapters.md
+++ b/docs/mock-adapters.md
@@ -244,6 +244,32 @@ val perInstance = Provisioning.live >>> EmbeddedRift.layer                      
 val correlated  = Provisioning.live >>> EmbeddedRift.layer(RiftMode.correlated)
 ```
 
+#### Sharing one engine across `@Suite` classes — `EmbeddedRift.shared`
+
+Standing up the native engine per suite is expensive, so it's tempting to share
+one across suite classes. Do **not** hand-roll that with a `static val` that runs
+`Runtime.default.unsafe.run(EmbeddedRift.layer.build)` at class-load: under sbt's
+**default** `Test / parallelExecution := true`, each `@Suite` runs on the shared
+runtime concurrently, and a suite's `<clinit>` executing on a runtime worker
+thread while a sibling suite blocks on the JVM class-init lock **deadlocks** —
+surfacing as a cause-less `Interrupted by thread "zio-fiber-N"` with `0 results`.
+
+Use the supported, memoized layer instead:
+
+```scala
+import zio.bdd.mock.rift.embedded.EmbeddedRift
+
+// One engine, built at most once, shared by every suite that uses it, released
+// on JVM shutdown. Concurrent suites are safe — no `parallelExecution := false`.
+val shared = Provisioning.live >>> EmbeddedRift.shared
+```
+
+`EmbeddedRift.shared` memoizes the build behind a semaphore (see
+`SharedLayer.memoize`), so concurrent construction from independent suites builds
+the engine exactly once and hands every caller the same `MockControl`. (You can
+still keep `Test / parallelExecution := false` if you prefer serial suites; it is
+no longer *required* just to share an embedded engine.)
+
 In `Correlated` mode `isolation` reports `Isolation.Correlated`, each space's
 stubs and `received` are scoped by its `flowId`, and `destroy` tears down just
 that space — behaviour identical to the container adapter's Correlated mode. As

--- a/mock/src/main/scala/zio/bdd/mock/SharedLayer.scala
+++ b/mock/src/main/scala/zio/bdd/mock/SharedLayer.scala
@@ -1,0 +1,65 @@
+package zio.bdd.mock
+
+import zio.*
+
+/**
+ * Turn a per-use scoped layer into a process-wide **memoized** one (#309).
+ *
+ * The underlying resource is built **at most once** — even under concurrent
+ * access from independent runtimes / sbt `@Suite` tasks — every caller receives
+ * the same instance, and the resource is **not** released when a caller's scope
+ * closes: it is built on a long-lived scope that survives every consumer and is
+ * finalized on JVM shutdown. This is the supported way to share one expensive
+ * `MockControl` (e.g. an embedded engine) across suite classes, instead of
+ * hand-rolling a `Runtime.default.unsafe.run(layer.build)` in a `static val`,
+ * which deadlocks / interrupts under sbt's default `Test / parallelExecution`
+ * because a suite's `<clinit>` runs on a shared-runtime worker thread while a
+ * sibling suite blocks on the class-init lock.
+ *
+ * Safety: the only `unsafe.run` here creates the guard cell
+ * (`Ref.Synchronized`) — a trivial, non-blocking allocation done once when the
+ * memoized layer value is defined, so it cannot reproduce that class-init
+ * deadlock. The resource build itself runs as an ordinary ZIO effect inside the
+ * caller's runtime, serialized by the cell's semaphore.
+ */
+object SharedLayer:
+
+  /**
+   * A process-wide memoized view of `base`. Each returned `ZLayer` value owns
+   * one memoization cell, so define it once (`val shared =
+   * SharedLayer.memoize(layer)`) and reuse that value everywhere.
+   */
+  def memoize[R: EnvironmentTag, E, A: Tag](base: => ZLayer[R, E, A]): ZLayer[R, E, A] =
+    val cell: Ref.Synchronized[Option[A]] =
+      Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(Ref.Synchronized.make(Option.empty[A])).getOrThrow())
+
+    ZLayer.scoped[R] {
+      ZIO.environment[R].flatMap { env =>
+        cell.modifyZIO {
+          case current @ Some(a) => Exit.succeed((a, current))
+          case None              =>
+            // Build the resource on a long-lived scope (not the caller's), so it survives every
+            // suite; that scope is closed on JVM shutdown — the only well-defined "all suites done"
+            // point (a per-suite / runner `done()` release would couple the runner to the backend
+            // and break sharing across concurrent suites).
+            Scope.make.flatMap { longLived =>
+              longLived
+                .extend[R](base.build)
+                .provideEnvironment(env)
+                .map(_.get[A])
+                .map { a =>
+                  registerShutdown(longLived)
+                  (a, Some(a))
+                }
+                // On a failed/interrupted build, close the long-lived scope so any partially
+                // acquired resource is released; the cell stays `None`, so a later build retries.
+                .onError(_ => longLived.close(Exit.unit))
+            }
+        }
+      }
+    }
+
+  private def registerShutdown(scope: Scope.Closeable): Unit =
+    java.lang.Runtime.getRuntime.addShutdownHook(
+      new Thread(() => Unsafe.unsafe(implicit u => Runtime.default.unsafe.run(scope.close(Exit.unit)).getOrThrow()))
+    )

--- a/mock/src/test/scala/zio/bdd/mock/SharedLayerSpec.scala
+++ b/mock/src/test/scala/zio/bdd/mock/SharedLayerSpec.scala
@@ -1,0 +1,56 @@
+package zio.bdd.mock
+
+import zio.*
+import zio.test.*
+
+/**
+ * Gate for issue #309: `SharedLayer.memoize` must build its resource exactly
+ * once under concurrent access, hand every caller the same instance, and NOT
+ * release it when a caller's scope closes (the shared engine outlives suites).
+ */
+object SharedLayerSpec extends ZIOSpecDefault:
+
+  def spec = suite("SharedLayer.memoize (#309)")(
+    test("builds once under concurrency, shares one instance, and survives caller-scope close") {
+      for
+        acquired <- Ref.make(0)
+        released <- Ref.make(0)
+        base      = ZLayer.scoped[Any](ZIO.acquireRelease(acquired.updateAndGet(_ + 1))(_ => released.update(_ + 1)))
+        shared    = SharedLayer.memoize(base)
+        // 20 concurrent, independent scoped builds — each closes its own caller scope.
+        seen <- ZIO.foreachPar(1 to 20)(_ => ZIO.scoped(shared.build.map(_.get[Int])))
+        acq  <- acquired.get
+        rel  <- released.get
+      yield assertTrue(
+        acq == 1,                 // built exactly once despite 20 concurrent builds
+        seen.distinct == List(1), // every caller received the SAME instance
+        rel == 0                  // caller scopes closed, but the shared resource was NOT released
+      )
+    },
+    test("a failed first build propagates and does not poison the cell — a later build succeeds") {
+      for
+        attempts <- Ref.make(0)
+        base = ZLayer.scoped[Any](
+                 ZIO.acquireRelease(
+                   attempts
+                     .updateAndGet(_ + 1)
+                     .flatMap(n => if n == 1 then ZIO.fail(new RuntimeException("boom")) else ZIO.succeed(n))
+                 )(_ => ZIO.unit)
+               )
+        shared  = SharedLayer.memoize(base)
+        first  <- ZIO.scoped(shared.build.map(_.get[Int])).either // first build fails
+        second <- ZIO.scoped(shared.build.map(_.get[Int])).either // cell still None → rebuilds & succeeds
+        n      <- attempts.get
+      yield assertTrue(first.isLeft, second == Right(2), n == 2)
+    },
+    test("a second, later build still returns the memoized instance without rebuilding") {
+      for
+        acquired <- Ref.make(0)
+        base      = ZLayer.scoped[Any](ZIO.acquireRelease(acquired.updateAndGet(_ + 1))(_ => ZIO.unit))
+        shared    = SharedLayer.memoize(base)
+        a        <- ZIO.scoped(shared.build.map(_.get[Int]))
+        b        <- ZIO.scoped(shared.build.map(_.get[Int])) // separate, sequential scope
+        n        <- acquired.get
+      yield assertTrue(a == 1, b == 1, n == 1)
+    }
+  )

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRift.scala
@@ -1,7 +1,7 @@
 package zio.bdd.mock.rift.embedded
 
 import zio.*
-import zio.bdd.mock.{MockControl, MockError, Provisioning}
+import zio.bdd.mock.{MockControl, MockError, Provisioning, SharedLayer}
 import zio.bdd.mock.rift.RiftMode
 
 import java.nio.file.{Files, Path, StandardCopyOption}
@@ -121,6 +121,22 @@ object EmbeddedRift:
         control <- EmbeddedRiftMockControl.make(engine, prov, mode, intercept)
       yield control
     }
+
+  /**
+   * A **process-wide shared** embedded [[MockControl]] (PerInstance): the engine
+   * is started at most once and every `@Suite` that uses `shared` gets the same
+   * instance, released on JVM shutdown. This is the supported way to share one
+   * expensive embedded engine across suite classes (#309).
+   *
+   * Prefer this over a hand-rolled static `val` that runs
+   * `Runtime.default.unsafe.run(layer.build)` at class-load: under sbt's default
+   * `Test / parallelExecution := true`, that pattern runs a suite's `<clinit>` on
+   * a shared-runtime worker thread while a sibling suite blocks on the class-init
+   * lock, which deadlocks and surfaces as a cause-less `Interrupted`. `shared`
+   * memoizes the build with a semaphore instead (see [[SharedLayer.memoize]]), so
+   * concurrent suites are safe without setting `parallelExecution := false`.
+   */
+  val shared: ZLayer[Provisioning, MockError, MockControl] = SharedLayer.memoize(layer)
 
   // Resolve the native library and start the engine, scoped (rift_start on acquire, rift_stop on
   // close). Shared by `layer` and the live FFI spec (which drives the engine's admin plane directly).

--- a/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftFfiSpec.scala
+++ b/rift-embedded/src/test/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftFfiSpec.scala
@@ -158,6 +158,17 @@ object EmbeddedRiftFfiSpec extends ZIOSpecDefault:
           case _                                    => false
         )).provide(Provisioning.live, EmbeddedRift.layer.mapError(asT))
     },
+    test("#309: EmbeddedRift.shared serves a provisioned space (the memoized engine works)") {
+      if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
+      else
+        (for
+          control <- ZIO.service[MockControl]
+          space   <- control.provision(pingSource).mapError(asT).map(_.head)
+          resp    <- SutClient.make(space).send(Method.Get, "/ping")
+          _       <- control.destroy(space).mapError(asT)
+        yield assertTrue(resp.status == 200, resp.body == "pong"))
+          .provide(Provisioning.live, EmbeddedRift.shared.mapError(asT))
+    },
     test("provision is atomic: a failed source in a multi-source Dir rolls back the served spaces") {
       if !EmbeddedRift.available then ZIO.succeed(assertCompletes)
       else


### PR DESCRIPTION
Add SharedLayer.memoize — a process-wide memoized scoped-layer, tested in the mock module — and EmbeddedRift.shared over it, so concurrent suites can share one engine without the class-init deadlock or parallelExecution := false. Documentation updated.

Closes #309