### PR TITLE
build(rift): bump pinned Rift to v0.13.1 and prepare 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to zio-bdd are documented here.
 
 ## [Unreleased]
 
+## [1.4.2] — 2026-07-10
+
+### Added
+
+- **`EmbeddedRift.shared`** — a safe cross-suite shared embedded Rift instance, so several suites
+  reuse one native runtime instead of each starting (and tearing down) their own.
+
+### Changed
+
+- **Bumped Rift to v0.13.1** (from v0.11.3, through the v0.12.0 migration). The v0.12.0 migration
+  adopted Rift's **v2 scripting API and removed the Lua injection engine** — mock injection and
+  decoration scripts must now be JavaScript. Rift v0.13.0 additionally brought the `_verify`
+  conformance endpoint, the C-ABI admin long tail, `allowInjection`, the runtime intercept
+  lifecycle, and the packaged sdk-conformance corpus. Rift v0.13.1 is a packaging-only release
+  (it renames Rift's internal `rift-core` crate to `rift-mock-core` to clear a crates.io name
+  collision); the FFI cdylib, container image, and binary are functionally identical to v0.13.0,
+  so the C-ABI (`abi: v2`) and every mock behaviour are unchanged. (#310)
+- Marked the `StreamingReporter` / `TestEvent` streaming API `@experimental`.
+- Renamed the test-only reset helper to `resetForTest`. (#300)
+
+### Fixed
+
+- **runner**: a suite-level failure now surfaces its full cause instead of a truncated message. (#311)
+- **core**: a `pending()` step no longer reddens the sbt build. (#306)
+- **core**: `FeatureContext` is synchronized so parallel scenarios don't lose context.
+- **core**: `afterAll` is guarded with `.ensuring` so suite teardown always runs.
+- **core**: all five log levels are accepted; an unknown level now fails loudly instead of silently.
+- **gherkin**: inert `shrink` / `maxShrinks` / `verbose` property settings are warned/rejected.
+- **rift**: fail fast on an unreachable authored container port. (#305)
+- **rift**: honour the `port` field in a raw `NativeSpec.Rift(json)` imposter document. (#214)
+- **rift**: an in-pool-range authored imposter port is claimed to prevent a later auto-provision collision. (#213)
+- **rift**: honour an authored `recordRequests` flag in a raw imposter document.
+- **rift-embedded**: an actionable error (with remediation docs) when the native library fails to load.
+
 ## [1.4.1] — 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ object AccountSpec extends ZIOSteps[Any, AccountState]:
 
 ```scala
 // build.sbt
-libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.4.1" % Test
+libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.4.2" % Test
 
 Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ import java.security.MessageDigest
 // Single source of truth for the pinned Rift release (#195). Both the FFI natives (riftNativesVersion,
 // downloaded into the embedded-natives jar) and the container image tag (Rift.DefaultImage, via the
 // generated RiftBuildInfo below) derive from it, so a version bump touches exactly one line.
-val riftVersion        = "0.12.0"
+val riftVersion        = "0.13.1"
 val riftNativesVersion = riftVersion
 
 // The (os, arch, ext) cdylibs bundled into the natives jar — linux/macOS × x86_64/aarch64 (#134).

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -37,7 +37,7 @@ Remove:
 Add:
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd" % "1.4.1"
+"io.github.etacassiopeia" %% "zio-bdd" % "1.4.2"
 ```
 
 The `zio-bdd` artifact includes the sbt test framework integration. You do not need a

--- a/docs/mock-adapters.md
+++ b/docs/mock-adapters.md
@@ -9,7 +9,7 @@ pick one.
 
 ## 1. The three backends at a glance
 
-| Adapter | Coordinates (1.4.1) | Docker? | JDK | Isolation default | Capabilities |
+| Adapter | Coordinates (1.4.2) | Docker? | JDK | Isolation default | Capabilities |
 |---|---|---|---|---|---|
 | Rift container | `zio-bdd-rift` | yes (testcontainers) | 11+ | PerInstance | all six core + Intercept opt-in |
 | WireMock | `zio-bdd-wiremock` | no | 11+ | Correlated (via `.correlated`) | Faults, StatefulScenarios, StateInspection only |
@@ -44,7 +44,7 @@ against it fails with `Unsupported` (§3 below, and see
 ## 2. Rift container (`zio-bdd-rift`)
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd-rift" % "1.4.1"
+"io.github.etacassiopeia" %% "zio-bdd-rift" % "1.4.2"
 ```
 
 Two entry points, both requiring a zio-http `Client` and a `Provisioning` in
@@ -64,7 +64,7 @@ the environment:
   ): ZLayer[Client & Provisioning, MockError, MockControl]
   ```
 
-  `DefaultImage` is the pinned Rift image, currently `zainalpour/rift-proxy:v0.12.0`
+  `DefaultImage` is the pinned Rift image, currently `zainalpour/rift-proxy:v0.13.1`
   — derived from the single `riftVersion` in `build.sbt`, so treat it as "the
   pinned Rift image" rather than a hardcoded tag. Pass `interceptPort` to also
   start the container's HTTPS-intercept listener and advertise
@@ -108,7 +108,7 @@ See [layers](layers.md) for how this composes into a suite's `environment`.
 ## 3. WireMock (`zio-bdd-wiremock`)
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.4.1"
+"io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.4.2"
 ```
 
 In-process, no Docker, runs on JDK 11+. Only requires `Provisioning`:
@@ -156,15 +156,15 @@ published as **two variants built from the same source**, and you pick
 exactly one for your build's JDK:
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd-rift-embedded"       % "1.4.1" // JDK 22+ (stable FFM)
-"io.github.etacassiopeia" %% "zio-bdd-rift-embedded-jdk21" % "1.4.1" // JDK 21   (preview FFM)
+"io.github.etacassiopeia" %% "zio-bdd-rift-embedded"       % "1.4.2" // JDK 22+ (stable FFM)
+"io.github.etacassiopeia" %% "zio-bdd-rift-embedded-jdk21" % "1.4.2" // JDK 21   (preview FFM)
 ```
 
 Both additionally need the native library on the classpath (or an explicit
 override), and neither is scala-versioned — note the single `%`, not `%%`:
 
 ```scala
-"io.github.etacassiopeia" % "zio-bdd-rift-embedded-natives" % "1.4.1" % Test
+"io.github.etacassiopeia" % "zio-bdd-rift-embedded-natives" % "1.4.2" % Test
 ```
 
 `zio-bdd-rift-embedded-natives` bundles the per-platform `librift_ffi`

--- a/docs/mock-cookbook.md
+++ b/docs/mock-cookbook.md
@@ -16,8 +16,8 @@ Add the WireMock adapter — it runs fully in-process on JDK 11+, no containers:
 ```scala
 // build.sbt
 libraryDependencies ++= Seq(
-  "io.github.etacassiopeia" %% "zio-bdd"          % "1.4.1",
-  "io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.4.1" % Test
+  "io.github.etacassiopeia" %% "zio-bdd"          % "1.4.2",
+  "io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.4.2" % Test
 )
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,7 +9,7 @@ as a concrete example throughout.
 In `build.sbt`:
 
 ```scala
-libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.4.1" % Test
+libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.4.2" % Test
 
 Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
 ```

--- a/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
+++ b/rift-embedded/src/main/scala/zio/bdd/mock/rift/embedded/EmbeddedRiftMockControl.scala
@@ -349,7 +349,7 @@ private[embedded] final case class EmbeddedRiftMockControl(
 
   // flowId = the imposter port (PerInstance) / the correlation value (Correlated): the slice a
   // request resolves its scenario state to. Scenario state is flow-state keyed by the scenario name,
-  // stored as a JSON string — the same slice `set_scenario_state` writes (rift-core), so pinning via
+  // stored as a JSON string — the same slice `set_scenario_state` writes (rift-mock-core), so pinning via
   // `rift_flow_state_put(name, "\"state\"")` is byte-identical to the admin `/scenarios/:name/state`.
   private def putScenarioState(port: Int, flowId: String, name: String, state: ScenarioState): IO[MockError, Unit] =
     engine.flowStatePut(port, flowId, name, Json.Str(state.value).toJson)

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
@@ -14,9 +14,9 @@ object RiftBuildInfoSpec extends ZIOSpecDefault:
   def spec = suite("RiftBuildInfo")(
     test("DefaultImage is derived from the single rift-version source of truth") {
       assertTrue(
-        RiftBuildInfo.riftVersion == "0.12.0",
+        RiftBuildInfo.riftVersion == "0.13.1",
         Rift.DefaultImage == s"zainalpour/rift-proxy:v${RiftBuildInfo.riftVersion}",
-        Rift.DefaultImage == "zainalpour/rift-proxy:v0.12.0"
+        Rift.DefaultImage == "zainalpour/rift-proxy:v0.13.1"
       )
     }
   )


### PR DESCRIPTION
Bumps the single-source-of-truth `riftVersion` **0.12.0 → 0.13.1** (`build.sbt`), so the FFI natives (embedded provider) and the container image tag both track Rift v0.13.1.

**Rift v0.13.1 is a packaging-only release over v0.13.0** — it renames Rift's internal `rift-core` crate to `rift-mock-core` to clear a crates.io name collision. The FFI cdylib, container image, and binary are functionally identical to v0.13.0, so the C-ABI (`abi: v2`) and every mock behaviour are unchanged. (The v0.13.0 surface — the v2 scripting API and Lua removal from the v0.12.0 migration, plus the `_verify` endpoint, C-ABI admin long tail, `allowInjection`, and runtime intercept — already landed in this repo.)

**Validated the ABI — nothing broken**, against freshly downloaded, checksum-verified **v0.13.1** natives:
- Embedded FFI suite (`EmbeddedRiftFfi` / `EmbeddedRiftCapabilities` / `EmbeddedIntercept` / `NativeLibrary`, **51 tests**) green on JDK 25 (stable FFM path); `riftNativesSelfCheck` downloads + checksum-verifies the 0.13.1 cdylib.
- JDK-17 gate (`scalafmtCheckAll`, `mimaReportBinaryIssues`, `rift/test` **79 tests**) passes — no binary-compat break (only a test-pin, a comment, `build.sbt`, and docs changed).

Also finalizes the **1.4.2** CHANGELOG — the accumulated unreleased set since v1.4.1 (the Rift v0.12.0 migration with the **Lua-engine removal**, `EmbeddedRift.shared`, and the fix tranche #305/#306/#311/#300/#213/#214) — and syncs the install-snippet versions across README/docs to 1.4.2.

Release is cut by tagging `v1.4.2` after merge (per RELEASING.md).