### PR TITLE
ci: make the preview-republish dispatch actually release (GITHUB_REF)

### DIFF
--- a/.github/workflows/republish-preview.yml
+++ b/.github/workflows/republish-preview.yml
@@ -53,8 +53,15 @@ jobs:
             exit 1
           fi
           bash scripts/assert-class-max-version.sh "$bridges" 65
+      # sbt-ci-release decides "is this a real release" from GITHUB_REF (it must start with refs/tags).
+      # On a workflow_dispatch that's refs/heads/master, so ci-release would abort with "No tag published"
+      # even though we checked out the tag's content (dynver already derives the version, e.g. 1.4.2, from
+      # it). Point GITHUB_REF at the tag being recovered so ci-release proceeds to publishSigned +
+      # sonatypeBundleRelease. The verify-tag-signature step above already proved the tag is a real,
+      # trusted, signed tag, so this override can't turn a branch build into a spurious release.
       - run: sbt ci-release
         env:
+          GITHUB_REF: refs/tags/${{ inputs.tag }}
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}


### PR DESCRIPTION
Follow-up to #318. The recovery workflow ran green but **published nothing** — sbt-ci-release detects a release from `GITHUB_REF` (must start with `refs/tags`), and on a `workflow_dispatch` that's `refs/heads/master`, so it aborted with *"No tag published"* (a non-error, hence the false green).

Fix: set `GITHUB_REF: refs/tags/${{ inputs.tag }}` on the `ci-release` step so it proceeds to `publishSigned` + `sonatypeBundleRelease`. `dynver` already derives the version (1.4.2) from the checked-out tag, and the `verify-tag-signature` step guarantees the tag is a real signed release before this runs — so the override can't turn a branch build into a spurious release.

After merge: re-trigger *Republish preview variant* with `tag: v1.4.2` to finally publish `zio-bdd-rift-embedded-jdk21_3` 1.4.2.