### PR TITLE
fix(report): pretty feature header reads PENDING for a pending-only feature (#319)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to zio-bdd are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **report**: the `pretty` reporter's feature-level header no longer renders a pending-only
+  feature as red `FAILED`. Following #306 (a pending step doesn't redden the build), the
+  feature header now reads `PENDING` (orange) when a feature has a pending scenario and no
+  hard failure — consistent with the scenario line, the summary, the JUnit XML, and the
+  green build. (#319)
+
 ## [1.4.2] — 2026-07-10
 
 ### Added

--- a/core/src/main/scala/zio/bdd/core/report/PrettyReporter.scala
+++ b/core/src/main/scala/zio/bdd/core/report/PrettyReporter.scala
@@ -155,7 +155,8 @@ object StatusColor:
 
   given StatusColor[FeatureResult] = from { f =>
     if (f.isIgnored) Style(Color.Gray, "◉")
-    else if (f.isPassed) Style(Color.Green, "◉") // bright green — feature-level pass
+    else if (f.hasPending && f.isComplete) Style(Color.Orange, "◉") // pending, no hard failure — not red
+    else if (f.isPassed) Style(Color.Green, "◉")                    // bright green — feature-level pass
     else Style(Color.Red, "◉")
   }
 
@@ -488,6 +489,7 @@ object DocBuilder:
 
   private def statusText(f: FeatureResult): String =
     if (f.isIgnored) "IGNORED"
+    else if (f.hasPending && f.isComplete) "PENDING"
     else if (f.isPassed) "PASSED"
     else "FAILED"
 

--- a/core/src/test/scala/zio/bdd/core/report/PrettyReporterSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/report/PrettyReporterSpec.scala
@@ -106,6 +106,25 @@ object PrettyReporterSpec extends ZIOSpecDefault {
       val fr = mkFeatureResult("F", List(sc))
       val s  = summon[StatusColor[FeatureResult]].style(fr)
       assertTrue(s.color == Color.Red)
+    },
+    test("pending-only FeatureResult (pending, no hard failure) → Orange, not Red") {
+      // Regression for #319: a feature whose only non-passing scenario is pending must not
+      // render as red FAILED — pending does not redden the build (see #306), so the feature
+      // header mirrors the scenario level (Orange), consistent with the summary and JUnit XML.
+      val sc = mkScenarioResult("s", List((StepType.GivenStep, "a step", StepStatus.Pending("todo"))))
+      val fr = mkFeatureResult("F", List(sc))
+      val s  = summon[StatusColor[FeatureResult]].style(fr)
+      assertTrue(s.color == Color.Orange, s.icon == "◉")
+    },
+    test("pending + failed FeatureResult stays Red (a hard failure is not masked by pending) (#319)") {
+      // A feature carrying both a pending scenario and a failed one has a hard failure, so it must
+      // remain red FAILED — the pending branch fires only when isComplete (no hard failure).
+      val pending = mkScenarioResult("p", List((StepType.GivenStep, "a", StepStatus.Pending("todo"))))
+      val failed =
+        mkScenarioResult("f", List((StepType.GivenStep, "b", StepStatus.Failed(Cause.fail(new Exception())))))
+      val fr = mkFeatureResult("F", List(pending, failed))
+      val s  = summon[StatusColor[FeatureResult]].style(fr)
+      assertTrue(s.color == Color.Red)
     }
   )
 
@@ -285,6 +304,14 @@ object PrettyReporterSpec extends ZIOSpecDefault {
       DocBuilder.featureBranch(fr, isLast = false, (_, _) => emptyLogs) match
         case Doc.Branch(header, _, _) =>
           assertTrue(header.text.contains("MyFeature"), header.text.contains("PASSED"))
+        case _ => assertTrue(false)
+    },
+    test("featureBranch header for a pending-only feature reads PENDING, not FAILED (#319)") {
+      val sc = mkScenarioResult("s", List((StepType.GivenStep, "a", StepStatus.Pending("todo"))))
+      val fr = mkFeatureResult("MyFeature", List(sc))
+      DocBuilder.featureBranch(fr, isLast = false, (_, _) => emptyLogs) match
+        case Doc.Branch(header, _, _) =>
+          assertTrue(header.text.contains("PENDING"), !header.text.contains("FAILED"))
         case _ => assertTrue(false)
     },
     test("featureBranch children include one branch per scenario plus summary") {


### PR DESCRIPTION
Fixes #319.

## Problem

After #306 (a `pending()` step no longer reddens the sbt build — the Task gates on `FeatureResult.isComplete`), the `pretty` reporter's **feature-level** header still rendered a pending-only feature as red `FAILED`. `StatusColor[FeatureResult]` and `statusText(FeatureResult)` lacked the PENDING branch their scenario-level counterparts already have, so a feature whose only non-passing scenario was pending fell through to the red `else` — contradicting the scenario line (`PENDING`), the summary (`Failed: 0`), the JUnit XML (`failures="0"`), and the now-green build.

```
╰─ ◉ Feature: Pending steps ... - FAILED      <- red, wrong
   ╰─ ◑ Scenario: ...          - PENDING      <- orange, correct
    Summary: Passed: 0  Failed: 0  Ignored: 0  Pending: 1   (sbt exit 0)
```

## Fix

Add the `f.hasPending && f.isComplete → orange "PENDING"` branch to both `StatusColor[FeatureResult]` and `statusText(FeatureResult)` in `PrettyReporter.scala`, mirroring the scenario-level logic. `FeatureResult.isComplete` is `false` when any scenario has a hard failure, so a feature with **both** a pending and a failed scenario correctly stays red `FAILED` — pending never masks a real failure.

## Tests

Three `PrettyReporterSpec` regressions:
- pending-only `FeatureResult` → `Orange` (not Red)
- rendered `featureBranch` header → contains `PENDING`, not `FAILED`
- pending **+** failed `FeatureResult` → stays `Red` (hard failure not masked)

All 52 reporter tests pass; `core/scalafmtCheckAll` clean.

## Notes

Found by the standing black-box conformance suite ([zio-bdd-conformance](https://github.com/EtaCassiopeia/zio-bdd-conformance)) while verifying the #306 fix on 1.4.2. Residual of #306; ref epic #192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)