### PR TITLE
Bump the pinned Rift release to v0.14.0 (embedded natives lag at 0.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to zio-bdd are documented here.
 
 ## [Unreleased]
 
+### Changed
+
+- **Bumped Rift to v0.14.0** (from v0.13.1). Realigns the embedded leg — which loads `librift_ffi`
+  from `zio-bdd-rift-embedded-natives` — with the container and external legs, which
+  `rift-conformance` already moved to 0.14.0. The bump is ABI-safe: Rift v0.14.0 ships no
+  C-ABI/FFI change (`abi: v2` unchanged), so the single-source-of-truth `riftVersion` in
+  `build.sbt` drives it — the embedded natives, `Rift.DefaultImage`, and the generated
+  `RiftBuildInfo` all track 0.14.0. v0.14.0 brings decision-cache key completeness fixes, a
+  unified imposter error-response envelope, and `--allowInjection` gating on the runtime intercept
+  path, all now exercised through the embedded serve plane. (#324)
+
 ### Fixed
 
 - **report**: the `pretty` reporter's feature-level header no longer renders a pending-only

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ import java.security.MessageDigest
 // Single source of truth for the pinned Rift release (#195). Both the FFI natives (riftNativesVersion,
 // downloaded into the embedded-natives jar) and the container image tag (Rift.DefaultImage, via the
 // generated RiftBuildInfo below) derive from it, so a version bump touches exactly one line.
-val riftVersion        = "0.13.1"
+val riftVersion        = "0.14.0"
 val riftNativesVersion = riftVersion
 
 // The (os, arch, ext) cdylibs bundled into the natives jar — linux/macOS × x86_64/aarch64 (#134).

--- a/docs/mock-adapters.md
+++ b/docs/mock-adapters.md
@@ -64,7 +64,7 @@ the environment:
   ): ZLayer[Client & Provisioning, MockError, MockControl]
   ```
 
-  `DefaultImage` is the pinned Rift image, currently `zainalpour/rift-proxy:v0.13.1`
+  `DefaultImage` is the pinned Rift image, currently `zainalpour/rift-proxy:v0.14.0`
   — derived from the single `riftVersion` in `build.sbt`, so treat it as "the
   pinned Rift image" rather than a hardcoded tag. Pass `interceptPort` to also
   start the container's HTTPS-intercept listener and advertise

--- a/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
+++ b/rift/src/test/scala/zio/bdd/mock/rift/RiftBuildInfoSpec.scala
@@ -14,9 +14,9 @@ object RiftBuildInfoSpec extends ZIOSpecDefault:
   def spec = suite("RiftBuildInfo")(
     test("DefaultImage is derived from the single rift-version source of truth") {
       assertTrue(
-        RiftBuildInfo.riftVersion == "0.13.1",
+        RiftBuildInfo.riftVersion == "0.14.0",
         Rift.DefaultImage == s"zainalpour/rift-proxy:v${RiftBuildInfo.riftVersion}",
-        Rift.DefaultImage == "zainalpour/rift-proxy:v0.13.1"
+        Rift.DefaultImage == "zainalpour/rift-proxy:v0.14.0"
       )
     }
   )


### PR DESCRIPTION
Realigns the embedded Rift natives with the container and external adapter legs, both of which moved to Rift v0.14.0 in rift-conformance. The upgrade is ABI-safe (no C-ABI or FFI changes); a single-source `riftVersion` now drives the natives build, DefaultImage tag, and RiftBuildInfo assertions.

Closes #324
