### PR TITLE
chore: prepare 1.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to zio-bdd are documented here.
 
 ## [Unreleased]
 
+## [1.4.3] — 2026-07-16
+
 ### Changed
 
 - **Bumped Rift to v0.14.0** (from v0.13.1). Realigns the embedded leg — which loads `librift_ffi`


### PR DESCRIPTION
Finalize the changelog for the 1.4.3 release: promote the `[Unreleased]` section to `[1.4.3] — 2026-07-16`.

Both shipped changes already landed on master:
- **Rift bumped to v0.14.0** (ABI-safe, single-source `riftVersion`) — #324 / #325
- **report**: pretty feature header reads `PENDING` for a pending-only feature — #319

Verification: `scalafmtCheckAll`, `compile`, full `test` all green.

Milestone: release cut (tag `v1.4.3` follows merge).