### PR TITLE
docs: bump install snippets to 1.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ object AccountSpec extends ZIOSteps[Any, AccountState]:
 
 ```scala
 // build.sbt
-libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.4.2" % Test
+libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.4.3" % Test
 
 Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
 ```

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -37,7 +37,7 @@ Remove:
 Add:
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd" % "1.4.2"
+"io.github.etacassiopeia" %% "zio-bdd" % "1.4.3"
 ```
 
 The `zio-bdd` artifact includes the sbt test framework integration. You do not need a

--- a/docs/mock-adapters.md
+++ b/docs/mock-adapters.md
@@ -44,7 +44,7 @@ against it fails with `Unsupported` (§3 below, and see
 ## 2. Rift container (`zio-bdd-rift`)
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd-rift" % "1.4.2"
+"io.github.etacassiopeia" %% "zio-bdd-rift" % "1.4.3"
 ```
 
 Two entry points, both requiring a zio-http `Client` and a `Provisioning` in
@@ -108,7 +108,7 @@ See [layers](layers.md) for how this composes into a suite's `environment`.
 ## 3. WireMock (`zio-bdd-wiremock`)
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.4.2"
+"io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.4.3"
 ```
 
 In-process, no Docker, runs on JDK 11+. Only requires `Provisioning`:
@@ -156,15 +156,15 @@ published as **two variants built from the same source**, and you pick
 exactly one for your build's JDK:
 
 ```scala
-"io.github.etacassiopeia" %% "zio-bdd-rift-embedded"       % "1.4.2" // JDK 22+ (stable FFM)
-"io.github.etacassiopeia" %% "zio-bdd-rift-embedded-jdk21" % "1.4.2" // JDK 21   (preview FFM)
+"io.github.etacassiopeia" %% "zio-bdd-rift-embedded"       % "1.4.3" // JDK 22+ (stable FFM)
+"io.github.etacassiopeia" %% "zio-bdd-rift-embedded-jdk21" % "1.4.3" // JDK 21   (preview FFM)
 ```
 
 Both additionally need the native library on the classpath (or an explicit
 override), and neither is scala-versioned — note the single `%`, not `%%`:
 
 ```scala
-"io.github.etacassiopeia" % "zio-bdd-rift-embedded-natives" % "1.4.2" % Test
+"io.github.etacassiopeia" % "zio-bdd-rift-embedded-natives" % "1.4.3" % Test
 ```
 
 `zio-bdd-rift-embedded-natives` bundles the per-platform `librift_ffi`

--- a/docs/mock-cookbook.md
+++ b/docs/mock-cookbook.md
@@ -16,8 +16,8 @@ Add the WireMock adapter — it runs fully in-process on JDK 11+, no containers:
 ```scala
 // build.sbt
 libraryDependencies ++= Seq(
-  "io.github.etacassiopeia" %% "zio-bdd"          % "1.4.2",
-  "io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.4.2" % Test
+  "io.github.etacassiopeia" %% "zio-bdd"          % "1.4.3",
+  "io.github.etacassiopeia" %% "zio-bdd-wiremock" % "1.4.3" % Test
 )
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,7 +9,7 @@ as a concrete example throughout.
 In `build.sbt`:
 
 ```scala
-libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.4.2" % Test
+libraryDependencies += "io.github.etacassiopeia" %% "zio-bdd" % "1.4.3" % Test
 
 Test / testFrameworks += new TestFramework("zio.bdd.ZIOBDDFramework")
 ```


### PR DESCRIPTION
Sync the README/docs install snippets to **1.4.3** (`1.4.2` → `1.4.3`, `io.github.etacassiopeia` coordinates only — no prose changes).

The release workflow pushed this branch but could **not** open the PR:
```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests
```
so the `docs-version-bump` job went red even though `publish`, `publish-preview`, and `github-release` all succeeded. Opening it by hand per RELEASING.md step 4. This branch is the bot's own commit, unmodified.

Durable fix: enable *Settings → Actions → General → Allow GitHub Actions to create and approve pull requests*, otherwise this job fails on every release.