### PR TITLE
Publish the MockControl conformance scenario sets as a consumable artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to zio-bdd are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **`zio-bdd-mock-conformance` is now a published artifact** (#329). The portable conformance
+  scenario sets (`CoreConformanceScenarios`, `NegotiationErrorScenarios`, `FaultScenarios`,
+  `ScriptingScenarios`, `TemplatingScenarios`, `CapStatefulScenarios`) and the
+  `ConformanceHarness` already lived in the conformance module's main sources — the module was
+  simply publish-skipped. It now publishes with a compile-scope dependency on the SPI
+  (`zio-bdd-mock`) alone, so third-party `MockControl` adapters (e.g. rift-scala's) can run the
+  official conformance suite in their own CI without pulling in any bundled backend; the
+  in-repo Rift/WireMock/embedded matrix runner moved to test scope, unpublished as before.
+  Usage is documented in `docs/mock-adapters.md` §6.
+
 ## [1.4.3] — 2026-07-16
 
 ### Changed

--- a/build.sbt
+++ b/build.sbt
@@ -561,25 +561,32 @@ lazy val wiremock = (project in file("wiremock"))
   )
 
 // Conformance harness + matrix runner (#124): the executable definition of
-// "implements MockControl". The only module that depends on BOTH adapters, so it
-// can run one feature set across Rift + WireMock and emit the pass/skip/fail matrix.
+// "implements MockControl". Main sources are the portable scenario sets + ConformanceHarness,
+// programmed against the neutral SPI alone — published as `zio-bdd-mock-conformance` (#329) so
+// third-party adapters (rift-scala's, and any future ones) can run the official suite in their
+// own CI. Compile scope is deliberately `mock` only: the bundled adapters are Test-scope, needed
+// by the in-repo matrix runner (the only code that depends on BOTH of them) and must never leak
+// into the published POM.
 lazy val conformance = {
   val base = Project("conformance", file("conformance"))
-    .dependsOn(core, rift, wiremock)
+    .dependsOn(mock, rift % Test, wiremock % Test)
     .settings(
-      name := "zio-bdd-conformance",
+      name := "zio-bdd-mock-conformance",
       libraryDependencies ++= commonDependencies,
       testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
-      publish / skip        := true, // a test harness, not a published artifact
+      javaFloorSettings,
+      // Not yet published as a 1.x artifact — no binary-compat baseline to check against.
       mimaPreviousArtifacts := Set.empty
     )
   // On a 22+ JDK the portable conformance suite also runs against the (stable) embedded provider: add
   // the gated test source (EmbeddedConformanceSpec, src/test/jdk22), the native-access test JVM, and
-  // the rift-embedded + natives dependencies. On JDK < 22 none of this is added — the preview variant
-  // is verified by riftEmbedded21's own suite, so conformance stays wired to the stable variant only.
+  // the rift-embedded + natives dependencies — Test-scope so the JDK-22 release job (which
+  // publishes this module) doesn't leak the embedded adapter into the published POM. On JDK < 22
+  // none of this is added — the preview variant is verified by riftEmbedded21's own suite, so
+  // conformance stays wired to the stable variant only.
   if (stableFfm)
     base
-      .dependsOn(riftEmbedded, embeddedNatives % Test)
+      .dependsOn(riftEmbedded % Test, embeddedNatives % Test)
       .settings(
         Test / unmanagedSourceDirectories += (Test / sourceDirectory).value / "jdk22",
         embeddedTestJvmSettings

--- a/docs/mock-adapters.md
+++ b/docs/mock-adapters.md
@@ -319,6 +319,58 @@ never by branching adapter-specific logic into step definitions — code
 written against `MockControl` stays adapter-agnostic (see
 [Mocking overview](mocking.md)).
 
+## 6. Verifying a third-party adapter (`zio-bdd-mock-conformance`)
+
+The conformance suite that gates the bundled adapters is published, so an
+adapter written outside this repo can run the *official* definition of
+"implements `MockControl`" in its own CI instead of hand-rolled contract
+tests:
+
+```scala
+"io.github.etacassiopeia" %% "zio-bdd-mock-conformance" % "1.4.3" % Test
+```
+
+Its compile-scope dependency is the SPI (`zio-bdd-mock`) alone — pulling it
+into a test classpath brings **no** bundled backend along.
+
+The artifact ships the portable scenario sets — `CoreConformanceScenarios`,
+`NegotiationErrorScenarios`, `FaultScenarios`, `ScriptingScenarios`,
+`TemplatingScenarios`, `CapStatefulScenarios` (each a
+`lazy val all: List[ConformanceScenario]`) — and the `ConformanceHarness`
+that runs them. Register the adapter as a `MockBackendUnderTest` with the
+capabilities it advertises, and assert the column is conformant:
+
+```scala
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.conformance.*
+import zio.test.*
+
+object MyAdapterConformanceSpec extends ZIOSpecDefault:
+  private val backend = MockBackendUnderTest(
+    name         = "my-adapter",
+    layer        = MyAdapter.layer,               // ZLayer[Any, Throwable, MockControl]
+    capabilities = Set(Capability.Faults),        // what the adapter advertises
+    isolation    = Isolation.PerInstance
+  )
+
+  def spec = suite("MyAdapter conformance")(
+    test("official conformance column is green") {
+      val scenarios = CoreConformanceScenarios.all ++ NegotiationErrorScenarios.all ++ FaultScenarios.all
+      for
+        matrix <- ConformanceHarness.run(List(backend), scenarios)
+        _      <- ZIO.logInfo("conformance matrix:\n" + matrix.render)
+      yield assertTrue(matrix.conformant(backend))
+    }
+  )
+```
+
+A scenario that requires a capability the backend does not advertise is
+**SKIP**, never **FAIL** — a negotiated gap is not a conformance breach, so
+`conformant` holds as long as no cell fails and every skip is justified by
+the advertised capability set (the same acceptance rule the bundled Rift and
+WireMock adapters are held to).
+
 ---
 
 Next: [Gherkin integration](mock-gherkin.md) · [Cookbook](mock-cookbook.md)


### PR DESCRIPTION
Flips the existing `conformance` module (scenario sets + `ConformanceHarness` were already in its **main** sources — the module was just publish-skipped) to a published artifact **`zio-bdd-mock-conformance`** with an SPI-only compile scope, so third-party `MockControl` adapters (rift-scala's, and future ones) can run the official conformance suite in their own CI.

- Compile scope: `zio-bdd-mock` only — `core` dropped (imported nowhere), `rift`/`wiremock`/`rift-embedded`/natives demoted to `% Test` (the in-repo matrix runner keeps using them, unpublished as before)
- POM verified SPI-only under **both** JDK slices, including `stableFfm=true` — the branch the JDK-22 release job publishes from (embedded deps land at test scope)
- `-release:11` floor (#205) added; MIMA baseline empty until a first release exists; JDK-21 preview job unaffected
- Docs: new §6 in `docs/mock-adapters.md` (API-verified consumption example); CHANGELOG entry

Closes #329

Milestone: none (standalone; filed on behalf of the rift-scala integration, cross-repo follow-up of rift-scala#18)
