### PR TITLE
ci: guard the published conformance POM against compile-scope adapter leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,20 @@ jobs:
           sbt
           "riftEmbedded/test"
           "conformance/testOnly zio.bdd.mock.conformance.EmbeddedConformanceSpec"
+      # Guard #331: the published zio-bdd-mock-conformance POM must stay SPI-only in compile scope
+      # (its bundled adapters are Test-scope). Runs on the JDK-22 job because stableFfm (>= 22) is what
+      # adds the rift-embedded deps — on an older JDK this check is vacuously green for exactly the leak
+      # class it exists to catch (#330 review). MIMA is a no-op here, so this is the only scope guard.
+      - name: Assert the conformance POM compile scope is SPI-only
+        run: |
+          sbt "conformance/makePom"
+          pom=$(find conformance/target -name "zio-bdd-mock-conformance_3-*.pom")
+          count=$(printf '%s' "$pom" | grep -c . || true)
+          if [ "$count" -ne 1 ]; then
+            echo "::error::expected exactly one conformance POM under conformance/target, found $count"
+            exit 1
+          fi
+          bash scripts/assert-pom-compile-scope.sh "$pom" io.github.etacassiopeia zio-bdd-mock
 
   # The JDK-21 preview variant (zio-bdd-rift-embedded-jdk21): same sources, FFM as a preview API, so the
   # forked test JVM runs with --enable-preview + --enable-native-access. On JDK 21 the root aggregates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,20 @@ jobs:
           java-version: 22
           cache: sbt
       - uses: sbt/setup-sbt@v1
+      # Gate the artifact BEFORE publishing (#331): the JDK-22 job is the one that publishes
+      # zio-bdd-mock-conformance, and stableFfm (>= 22) is what adds its rift-embedded deps, so this is
+      # the build where an adapter could leak into the compile scope. MIMA is a no-op for the module, so
+      # this POM inspection is the last line of defense — a leak that lands on master still can't publish.
+      - name: Assert the conformance POM compile scope is SPI-only before publishing
+        run: |
+          sbt "conformance/makePom"
+          pom=$(find conformance/target -name "zio-bdd-mock-conformance_3-*.pom")
+          count=$(printf '%s' "$pom" | grep -c . || true)
+          if [ "$count" -ne 1 ]; then
+            echo "::error::expected exactly one conformance POM under conformance/target, found $count"
+            exit 1
+          fi
+          bash scripts/assert-pom-compile-scope.sh "$pom" io.github.etacassiopeia zio-bdd-mock
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/scripts/assert-pom-compile-scope.sh
+++ b/scripts/assert-pom-compile-scope.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Fail if a published POM exposes a first-party artifact it shouldn't at a consumer-visible scope.
+#
+# Guards issue #331: `zio-bdd-mock-conformance` (#329) publishes with its compile scope deliberately
+# reduced to the SPI (`zio-bdd-mock`) — the bundled adapters (rift, wiremock, rift-embedded, natives)
+# are Test-scope only, so a third-party consumer inherits no backend. Nothing else guards this: MIMA
+# is a no-op for the module (`mimaPreviousArtifacts := Set.empty`) and `sbt test` never inspects a POM,
+# so a future `.dependsOn(<adapter>)` that forgets `% Test` would silently re-leak an adapter into the
+# published POM. This script is wired into the JDK-22 CI job (embedded-stable) and the release publish
+# job — the only builds where `stableFfm` adds the embedded deps, so the leak class is actually present.
+#
+# Rule: every <dependency> whose <groupId> equals <group-id> and whose EFFECTIVE scope is inherited by
+# a downstream consumer (`compile` or `runtime`) must be the SPI itself — <artifactId> exactly
+# <allowed-prefix>, modulo the Scala-version suffix (`zio-bdd-mock_3`). Any other first-party
+# compile/runtime dep is a leak, and a POM that shows no SPI dep at all is treated as malformed.
+#
+# Parsed with xml.etree, not grep/sed: <scope> is optional in Maven and its ABSENCE means `compile`
+# (Maven's default), so a scope-less dependency — exactly what a dropped `% Test` produces — is the
+# leak we most need to catch, and a text match on `<scope>test</scope>` would sail right past it.
+#
+# Usage: assert-pom-compile-scope.sh <pom-file> <group-id> <allowed-artifactId-prefix>
+#   e.g. assert-pom-compile-scope.sh conformance/target/.../zio-bdd-mock-conformance_3-1.4.3.pom \
+#          io.github.etacassiopeia zio-bdd-mock
+#
+# `set -u` is load-bearing: a missing positional arg aborts the run rather than silently checking
+# against an empty group-id / prefix (which would pass everything).
+set -euo pipefail
+
+pom_file=${1:?usage: assert-pom-compile-scope.sh <pom-file> <group-id> <allowed-artifactId-prefix>}
+group_id=${2:?usage: assert-pom-compile-scope.sh <pom-file> <group-id> <allowed-artifactId-prefix>}
+allowed_prefix=${3:?usage: assert-pom-compile-scope.sh <pom-file> <group-id> <allowed-artifactId-prefix>}
+
+if [ ! -f "$pom_file" ]; then
+  echo "::error::POM file not found: $pom_file" >&2
+  exit 2
+fi
+
+POM_FILE="$pom_file" GROUP_ID="$group_id" ALLOWED_PREFIX="$allowed_prefix" python3 - <<'PY'
+import os, sys, xml.etree.ElementTree as ET
+
+pom, group, prefix = os.environ["POM_FILE"], os.environ["GROUP_ID"], os.environ["ALLOWED_PREFIX"]
+
+try:
+    root = ET.parse(pom).getroot()
+except ET.ParseError as e:
+    print(f"::error::{pom} is not valid XML: {e}", file=sys.stderr)
+    sys.exit(2)
+
+# The POM's default namespace is unpredictable across generators; match on the local tag name.
+def local(tag):
+    return tag.rsplit("}", 1)[-1]
+
+def child_text(el, name):
+    for c in el:
+        if local(c.tag) == name:
+            return (c.text or "").strip()
+    return None
+
+# Scopes a downstream consumer transitively inherits. `test`/`provided` never reach a consumer's
+# classpath; `compile` AND `runtime` both do, so both must be free of bundled adapters. An absent
+# <scope> is Maven's default `compile` — exactly what a dropped `% Test` produces.
+INHERITED = ("compile", "runtime")
+
+def is_spi(aid):
+    # The only allowed artifact is the SPI itself, `<prefix>`, modulo its Scala-version suffix
+    # (`zio-bdd-mock_3`). A prefix-*creep* adapter such as `zio-bdd-mock-embedded_3` shares the
+    # leading text but not this shape, so match `<prefix>` or `<prefix>_...` exactly — never a
+    # looser `startswith(prefix)`, since prefix creep is the very failure class this guard exists for.
+    return aid is not None and (aid == prefix or aid.startswith(prefix + "_"))
+
+leaks = []
+saw_spi = False
+for dep in root.iter():
+    if local(dep.tag) != "dependency":
+        continue
+    if child_text(dep, "groupId") != group:
+        continue
+    scope = child_text(dep, "scope") or "compile"
+    if scope not in INHERITED:
+        continue
+    aid = child_text(dep, "artifactId")
+    if is_spi(aid):
+        saw_spi = True
+    else:
+        # A first-party inherited-scope dep with no artifactId is fail-open in a fail-closed guard;
+        # flag it rather than skip it.
+        leaks.append(aid or "<missing artifactId>")
+
+if leaks:
+    joined = ", ".join(sorted(leaks))
+    print(
+        f"::error::{pom}: consumer-visible scope leak — group '{group}' must expose only '{prefix}' "
+        f"(the SPI) at compile/runtime scope, but found: {joined}. "
+        f"Add `% Test` to the offending dependsOn/libraryDependency.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if not saw_spi:
+    # A well-formed but SPI-less POM proves nothing — a wrong-module or truncated makePom. Fail loud
+    # rather than print OK on a POM that never actually demonstrated the invariant.
+    print(
+        f"::error::{pom}: found no '{prefix}' dependency at compile/runtime scope — this is not the "
+        f"expected conformance artifact (wrong module, or a broken makePom?).",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+print(f"OK: {os.path.basename(pom)} exposes only '{prefix}' (the SPI) at compile/runtime scope for '{group}'")
+PY


### PR DESCRIPTION
Adds `scripts/assert-pom-compile-scope.sh` (modeled on `scripts/assert-class-max-version.sh`) and wires it into the JDK-22 CI job (`embedded-stable`) and the release `publish` job — the builds where `stableFfm` adds the rift-embedded deps, so the leak class is actually present (on an older JDK the check would be vacuously green).

The guard fails if the generated `zio-bdd-mock-conformance` POM exposes any first-party (`io.github.etacassiopeia`) dependency other than the SPI `zio-bdd-mock` at a consumer-inherited scope (compile **or** runtime), and also fails if the SPI dependency is absent (a wrong-module / truncated POM can't pass silently). Parsed with `xml.etree`, not grep — an absent `<scope>` is Maven's default `compile`, which is exactly what a dropped `% Test` produces.

Verified: leak / runtime-leak / prefix-creep fixtures → exit 1; SPI-less / missing-file → exit 2; the real POM built under JDK 22 (`stableFfm=true`, embedded deps present at test scope) → exit 0.

Closes #331

Milestone: none
