### PR TITLE
docs: compile-guard the mock-adapters §6 conformance example via mdoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -450,7 +450,10 @@ lazy val mock = (project in file("mock"))
 // other docs/*.md stay plain Markdown (mostly illustrative fragments that don't compile standalone).
 lazy val docs = (project in file("docs-mdoc"))
   .enablePlugins(MdocPlugin)
-  .dependsOn(core, mock)
+  // conformance is on the classpath so the third-party-adapter conformance example (#332) compiles
+  // against the real ConformanceHarness/scenario-set API. Its Compile scope is `mock` only (the
+  // bundled adapters are Test-scope), so this pulls in no backend and stays JDK-11-clean (#330).
+  .dependsOn(core, mock, conformance)
   .settings(
     name                  := "zio-bdd-docs",
     publish / skip        := true,

--- a/docs/mock-adapters.md
+++ b/docs/mock-adapters.md
@@ -338,31 +338,16 @@ The artifact ships the portable scenario sets — `CoreConformanceScenarios`,
 `TemplatingScenarios`, `CapStatefulScenarios` (each a
 `lazy val all: List[ConformanceScenario]`) — and the `ConformanceHarness`
 that runs them. Register the adapter as a `MockBackendUnderTest` with the
-capabilities it advertises, and assert the column is conformant:
+capabilities it advertises, run the scenarios through the harness, and assert
+the column is conformant:
 
 ```scala
-import zio.*
-import zio.bdd.mock.*
-import zio.bdd.mock.conformance.*
-import zio.test.*
-
-object MyAdapterConformanceSpec extends ZIOSpecDefault:
-  private val backend = MockBackendUnderTest(
-    name         = "my-adapter",
-    layer        = MyAdapter.layer,               // ZLayer[Any, Throwable, MockControl]
-    capabilities = Set(Capability.Faults),        // what the adapter advertises
-    isolation    = Isolation.PerInstance
-  )
-
-  def spec = suite("MyAdapter conformance")(
-    test("official conformance column is green") {
-      val scenarios = CoreConformanceScenarios.all ++ NegotiationErrorScenarios.all ++ FaultScenarios.all
-      for
-        matrix <- ConformanceHarness.run(List(backend), scenarios)
-        _      <- ZIO.logInfo("conformance matrix:\n" + matrix.render)
-      yield assertTrue(matrix.conformant(backend))
-    }
-  )
+val backend = MockBackendUnderTest(
+  name = "my-adapter", layer = myAdapterLayer,
+  capabilities = Set(Capability.Faults), isolation = Isolation.PerInstance
+)
+for matrix <- ConformanceHarness.run(List(backend), CoreConformanceScenarios.all)
+yield assertTrue(matrix.conformant(backend))
 ```
 
 A scenario that requires a capability the backend does not advertise is
@@ -370,6 +355,12 @@ A scenario that requires a capability the backend does not advertise is
 `conformant` holds as long as no cell fails and every skip is justified by
 the advertised capability set (the same acceptance rule the bundled Rift and
 WireMock adapters are held to).
+
+The complete, compile-checked example (a full `ZIOSpecDefault` running all six
+scenario sets) lives in
+[Verified Examples](verified-examples.md#verifying-a-third-party-adapter-conformance-kit) —
+it is compiled against the real API on every CI run, so it can't silently
+drift the way a hand-written snippet can.
 
 ---
 

--- a/docs/verified-examples.md
+++ b/docs/verified-examples.md
@@ -66,3 +66,51 @@ import zio.bdd.mock.dsl.*
 
 val healthStub = get("/health").respondWith(ok.text("OK"))
 ```
+
+## Verifying a third-party adapter (conformance kit)
+
+An adapter written outside this repo can run the *official* conformance suite — the same one that
+gates the bundled Rift and WireMock adapters — from the published `zio-bdd-mock-conformance`
+artifact. Register the adapter as a `MockBackendUnderTest` with the capabilities it advertises, run
+the portable scenario sets through `ConformanceHarness`, and assert the column is conformant.
+(`myAdapterLayer` stands in for your adapter's own `MockControl` layer.)
+
+```scala
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.conformance.*
+import zio.test.*
+
+object MyAdapterConformanceSpec extends ZIOSpecDefault:
+
+  val myAdapterLayer: ZLayer[Any, Throwable, MockControl] = ???
+
+  val backend = MockBackendUnderTest(
+    name         = "my-adapter",
+    layer        = myAdapterLayer,
+    capabilities = Set(Capability.Faults), // what the adapter advertises
+    isolation    = Isolation.PerInstance
+  )
+
+  val scenarios: List[ConformanceScenario] =
+    CoreConformanceScenarios.all ++
+      NegotiationErrorScenarios.all ++
+      FaultScenarios.all ++
+      ScriptingScenarios.all ++
+      TemplatingScenarios.all ++
+      CapStatefulScenarios.all
+
+  def spec = suite("MyAdapter conformance")(
+    test("the official conformance column is green") {
+      for
+        matrix <- ConformanceHarness.run(List(backend), scenarios)
+        _      <- ZIO.logInfo("conformance matrix:\n" + matrix.render)
+      yield assertTrue(matrix.conformant(backend))
+    }
+  )
+```
+
+A scenario that requires a capability the backend does not advertise is **SKIP**, never **FAIL** —
+a negotiated gap is not a conformance breach. `matrix.conformant(backend)` holds as long as no cell
+fails and every skip is justified by the advertised capability set, the same acceptance rule the
+bundled adapters are held to.

--- a/mdoc-src/verified-examples.md
+++ b/mdoc-src/verified-examples.md
@@ -66,3 +66,51 @@ import zio.bdd.mock.dsl.*
 
 val healthStub = get("/health").respondWith(ok.text("OK"))
 ```
+
+## Verifying a third-party adapter (conformance kit)
+
+An adapter written outside this repo can run the *official* conformance suite — the same one that
+gates the bundled Rift and WireMock adapters — from the published `zio-bdd-mock-conformance`
+artifact. Register the adapter as a `MockBackendUnderTest` with the capabilities it advertises, run
+the portable scenario sets through `ConformanceHarness`, and assert the column is conformant.
+(`myAdapterLayer` stands in for your adapter's own `MockControl` layer.)
+
+```scala mdoc:compile-only
+import zio.*
+import zio.bdd.mock.*
+import zio.bdd.mock.conformance.*
+import zio.test.*
+
+object MyAdapterConformanceSpec extends ZIOSpecDefault:
+
+  val myAdapterLayer: ZLayer[Any, Throwable, MockControl] = ???
+
+  val backend = MockBackendUnderTest(
+    name         = "my-adapter",
+    layer        = myAdapterLayer,
+    capabilities = Set(Capability.Faults), // what the adapter advertises
+    isolation    = Isolation.PerInstance
+  )
+
+  val scenarios: List[ConformanceScenario] =
+    CoreConformanceScenarios.all ++
+      NegotiationErrorScenarios.all ++
+      FaultScenarios.all ++
+      ScriptingScenarios.all ++
+      TemplatingScenarios.all ++
+      CapStatefulScenarios.all
+
+  def spec = suite("MyAdapter conformance")(
+    test("the official conformance column is green") {
+      for
+        matrix <- ConformanceHarness.run(List(backend), scenarios)
+        _      <- ZIO.logInfo("conformance matrix:\n" + matrix.render)
+      yield assertTrue(matrix.conformant(backend))
+    }
+  )
+```
+
+A scenario that requires a capability the backend does not advertise is **SKIP**, never **FAIL** —
+a negotiated gap is not a conformance breach. `matrix.conformant(backend)` holds as long as no cell
+fails and every skip is justified by the advertised capability set, the same acceptance rule the
+bundled adapters are held to.


### PR DESCRIPTION
The §6 conformance example (from #330) was plain Markdown — not compiled, so an API rename would silently break the one example external `MockControl` adapter authors rely on. This moves the full `ZIOSpecDefault` into `mdoc-src/verified-examples.md` as a `scala mdoc:compile-only` block (referencing all six scenario sets so a rename in any breaks the build), and slims §6 in `docs/mock-adapters.md` to coordinates + SKIP-vs-FAIL semantics + a short sketch + a link to the compiled example.

- `docs` module now `.dependsOn(core, mock, conformance)` — conformance's Compile scope is the SPI (`zio-bdd-mock`) only, so no backend reaches the docs classpath; stays JDK-11-clean (`-release:11`, #330). Still unpublished and unaggregated.
- Verified: `sbt docs/mdoc` on JDK 11 compiles the example and regenerates `docs/verified-examples.md`; a negative test (renaming a scenario set's `.all`) makes it fail; `scripts/check-mock-docs.sh` passes.

Closes #332

Milestone: none