### PR TITLE
--exclude-tags does not exclude a scenario that also carries a parameterized @mock(...) tag; its fixture is still provisioned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,17 @@ All notable changes to zio-bdd are documented here.
   - Update every call site accordingly: drop the `Client` requirement/import, and — for
     `Rift.managed`/`Rift.connect` — drop `Client.default` from the provided environment.
 
+### Fixed
+
+- **`--exclude-tags` no longer provisions an excluded scenario's fixtures** (#337). A scenario
+  removed by a tag or name filter (or carrying `@ignore`/`@skip`) is now short-circuited *before*
+  its scenario-tier layer (`scenarioLayer`/`flagLayer`) is built and acquired, so no
+  `@mock(...)` source is provisioned and no per-scenario resources are set up for it. Previously
+  the `isIgnored` short-circuit fired only *inside* the already-acquired layer scope, so an
+  excluded scenario carrying a parameterized tag such as `@rift @mock(orders)` still provisioned
+  its `orders` source — and, when that source was raw/native under the wrong backend, threw and
+  failed the whole run even though the scenario was meant to be skipped.
+
 ## [1.4.3] — 2026-07-16
 
 ### Changed

--- a/core/src/main/scala/zio/bdd/core/FeatureExecutor.scala
+++ b/core/src/main/scala/zio/bdd/core/FeatureExecutor.scala
@@ -97,23 +97,34 @@ object FeatureExecutor {
   ): ZIO[R & StepRegistry[R, S], Nothing, List[ScenarioResult]] = {
     def runOne(scenario: Scenario, flags: Map[String, String]): ZIO[R & StepRegistry[R, S], Nothing, ScenarioResult] =
       ZIO.logAnnotate("scenarioId", scenario.id.toString) {
-        scenario.propertyConfig match
-          case Some(_) =>
-            // Property scenario — dispatch to PropertyExecutor. `flags` (if any @flags(...)
-            // tag is present) is forwarded so each sample uses suite.flagLayer like the
-            // literal path does; expandFlagScenarios already multiplied one full sample
-            // batch per @flags(...) combination upstream. `dryRun` is forwarded too, so
-            // --dry-run validates step matching with one sample instead of running the full
-            // configured sample count for real.
-            PropertyExecutor.run[R, S](scenario, suite, genLookup, flags, dryRun)
-          case None =>
-            val meta = ScenarioMetadata.from(scenario, flags)
-            val layer =
-              if (flags.isEmpty) suite.scenarioLayer(meta)
-              else suite.flagLayer(meta, flags)
-            ScenarioExecutor
-              .executeScenario[R, S](scenario, suite, dryRun, flags, suite.stepTimeout)
-              .provideSomeLayer[R & StepRegistry[R, S]](layer.orDie)
+        if (scenario.isIgnored)
+          // An ignored scenario (excluded by a tag/name filter, or carrying @ignore/@skip) must
+          // not have its scenario-tier layer built or acquired: scenarioLayer(meta)/flagLayer can
+          // provision per-scenario fixtures (e.g. an @mock(...) source), and that provisioning —
+          // which for a raw source under the wrong backend throws and dies the whole run — must
+          // not happen for a scenario the run asked to skip (#337). The isIgnored short-circuit in
+          // ScenarioExecutor.executeScenario is not enough on its own because it runs *inside* the
+          // provided layer scope, so the layer would already have been acquired. Return the ignored
+          // result directly, provisioning nothing.
+          ScenarioExecutor.executeScenario[R, S](scenario, suite, dryRun, flags, suite.stepTimeout)
+        else
+          scenario.propertyConfig match
+            case Some(_) =>
+              // Property scenario — dispatch to PropertyExecutor. `flags` (if any @flags(...)
+              // tag is present) is forwarded so each sample uses suite.flagLayer like the
+              // literal path does; expandFlagScenarios already multiplied one full sample
+              // batch per @flags(...) combination upstream. `dryRun` is forwarded too, so
+              // --dry-run validates step matching with one sample instead of running the full
+              // configured sample count for real.
+              PropertyExecutor.run[R, S](scenario, suite, genLookup, flags, dryRun)
+            case None =>
+              val meta = ScenarioMetadata.from(scenario, flags)
+              val layer =
+                if (flags.isEmpty) suite.scenarioLayer(meta)
+                else suite.flagLayer(meta, flags)
+              ScenarioExecutor
+                .executeScenario[R, S](scenario, suite, dryRun, flags, suite.stepTimeout)
+                .provideSomeLayer[R & StepRegistry[R, S]](layer.orDie)
       }
 
     val resolved = resolveParallelism(scenarioParallelism)

--- a/core/src/test/scala/zio/bdd/core/ExcludedScenarioFixtureSpec.scala
+++ b/core/src/test/scala/zio/bdd/core/ExcludedScenarioFixtureSpec.scala
@@ -1,0 +1,98 @@
+package zio.bdd.core
+
+import zio.*
+import zio.test.*
+import zio.bdd.ZIOBDDTask
+import zio.bdd.core.step.ZIOSteps
+import zio.bdd.gherkin.{Feature, Scenario, ScenarioMetadata, Step, StepType}
+import zio.schema.{DeriveSchema, Schema}
+
+import java.util.concurrent.ConcurrentLinkedQueue
+
+/**
+ * Regression tests for #337: `--exclude-tags <tag>` must drop a scenario from
+ * selection *before* its scenario-tier layer (`scenarioLayer`) is built or
+ * acquired — even when the scenario also carries a parameterized tag such as
+ * `@mock(...)`. An excluded scenario must provision no fixtures and run no
+ * scenario-tier layer.
+ *
+ * The bug lived in FeatureExecutor.runScenarios: `scenarioLayer(meta)` was
+ * built and `.provideSomeLayer`-acquired around every scenario, and the
+ * `isIgnored` short-circuit only fired *inside* that already-acquired scope —
+ * so an excluded `@rift @mock(orders)` scenario still provisioned its
+ * `@mock(orders)` source (and, for a raw source under the wrong backend, threw
+ * and failed the whole run). A scenario carrying only plain tags never showed
+ * the bug because its default `scenarioLayer` provisions nothing.
+ */
+object ExcludedScenarioFixtureSpec extends ZIOSpecDefault {
+
+  case class FxState(v: Int = 0)
+  given Schema[FxState] = DeriveSchema.gen[FxState]
+
+  private val F = "excluded.feature"
+
+  private def scenario(name: String, tags: String*): Scenario =
+    Scenario(name, tags.toList, List(Step(StepType.GivenStep, "a step is present")), Some(F), Some(1))
+
+  private def feature(scenarios: Scenario*): Feature =
+    Feature("Capability-partitioned", Nil, scenarios.toList, Some(F), Some(1))
+
+  // Mark scenarios exactly as `--exclude-tags rift` would (via the real filter path).
+  private def excludeRift(features: List[Feature]): List[Feature] =
+    ZIOBDDTask.filterFeatures(features, zio.bdd.BDDTestConfig(excludeTags = Set("rift")))
+
+  def spec = suite("ExcludedScenarioFixture")(
+    test("excluded scenario carrying a parameterized tag builds and acquires no scenarioLayer") {
+      val built    = new ConcurrentLinkedQueue[String]()
+      val acquired = new ConcurrentLinkedQueue[String]()
+
+      class RecordingSuite extends ZIOSteps[Any, FxState] {
+        override def scenarioLayer(meta: ScenarioMetadata): ZLayer[Any, Throwable, Any] = {
+          built.add(meta.name)
+          ZLayer.scoped(ZIO.succeed(acquired.add(meta.name)).unit)
+        }
+        Given("a step is present")(ZIO.unit)
+      }
+
+      val steps = new RecordingSuite {}
+      val features =
+        excludeRift(List(feature(scenario("rift-only", "rift", "mock(orders)"), scenario("portable"))))
+      for {
+        results  <- steps.run(features)
+        scResults = results.flatMap(_.scenarioResults)
+      } yield assertTrue(
+        scResults.find(_.scenario.name == "rift-only").exists(_.isIgnored),
+        scResults.find(_.scenario.name == "portable").exists(_.isPassed),
+        !built.contains("rift-only"),
+        !acquired.contains("rift-only"),
+        built.contains("portable"),
+        acquired.contains("portable")
+      )
+    },
+    test("a failing (raw-doc) provisioning on the excluded scenario does not fail the whole run") {
+      class FailingProvisionSuite extends ZIOSteps[Any, FxState] {
+        override def scenarioLayer(meta: ScenarioMetadata): ZLayer[Any, Throwable, Any] =
+          if (meta.tags.exists(_.startsWith("mock(")))
+            // Simulates MockFixtures provisioning a raw/native source under the wrong backend:
+            // it fails on acquire and, under the bug, dies the whole run (#337).
+            ZLayer.scoped(ZIO.fail(new RuntimeException("a raw/native source must go through provisionNative")))
+          else ZLayer.empty
+        Given("a step is present")(ZIO.unit)
+      }
+
+      val steps = new FailingProvisionSuite {}
+      val features =
+        excludeRift(List(feature(scenario("rift-only", "rift", "mock(orders)"), scenario("portable"))))
+      for {
+        exit <- steps.run(features).exit
+        scResults = exit match
+                      case Exit.Success(results) => results.flatMap(_.scenarioResults)
+                      case Exit.Failure(_)       => Nil
+      } yield assertTrue(
+        exit.isSuccess,
+        scResults.find(_.scenario.name == "rift-only").exists(_.isIgnored),
+        scResults.find(_.scenario.name == "portable").exists(_.isPassed)
+      )
+    }
+  )
+}

--- a/docs/running.md
+++ b/docs/running.md
@@ -208,6 +208,10 @@ Exclusion takes precedence over inclusion.
 sbt "testOnly com.example.MySuite -- --exclude-tags slow,flaky"
 ```
 
+A skipped scenario is skipped completely: its `scenarioLayer`/`flagLayer` is never
+built, so no per-scenario fixtures are provisioned for it — this holds even when the
+scenario also carries a parameterized fixture tag such as `@mock(orders)`.
+
 ### @ignore tag
 
 Any scenario tagged `@ignore` (case-insensitive) is always skipped, independent of


### PR DESCRIPTION
## Summary
- Moved the isIgnored short-circuit to before scenario-tier layer acquisition
- Excluded/filtered scenarios no longer provision their fixture sources
- Prevents test failures when sources are raw/unmatched to the backend

Closes #337